### PR TITLE
Add scope to policy rule set

### DIFF
--- a/pkg/kubewarden/chart/kubewarden/admission/Rule.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/Rule.vue
@@ -39,6 +39,11 @@ export default {
   },
 
   data() {
+    const scopeOptions = [
+      '*',
+      'Cluster',
+      'Namespaced'
+    ];
     const operationOptions = [
       'CREATE',
       'UPDATE',
@@ -47,6 +52,7 @@ export default {
     ];
 
     return {
+      scopeOptions,
       operationOptions,
 
       inStore:           null,
@@ -80,6 +86,12 @@ export default {
       return out;
     },
 
+    isGroupCore() {
+      const groups = this.value.apiGroups;
+
+      return groups.includes('core') || groups.includes('') ;
+    },
+
     resourceOptions() {
       /*
         If no apiGroup or 'core' is selected we want to show all of the available resources
@@ -87,7 +99,7 @@ export default {
       */
       let schemas = this.schemas;
 
-      if ( this.value?.apiGroups?.length > 0 && !this.value.apiGroups.includes('core') ) {
+      if ( this.value?.apiGroups?.length > 0 && !this.isGroupCore ) {
         schemas = this.value.apiGroups.map(g => this.schemaForGroup(g))[0];
       }
 
@@ -135,8 +147,20 @@ export default {
   <div v-if="value" class="rules-row mt-40 mb-20">
     <div>
       <LabeledSelect
+        v-model="value.scope"
+        :label="t('kubewarden.policyConfig.scope.label')"
+        :tooltip="t('kubewarden.policyConfig.scope.tooltip')"
+        :mode="mode"
+        :multiple="false"
+        :options="scopeOptions || []"
+      />
+    </div>
+
+    <div>
+      <LabeledSelect
         v-model="value.apiGroups"
         :label="t('kubewarden.policyConfig.apiGroups.label')"
+        :tooltip="t('kubewarden.policyConfig.apiGroups.tooltip')"
         :mode="mode"
         :multiple="true"
         :options="apiGroupOptions || []"
@@ -154,11 +178,8 @@ export default {
         :required="true"
         placement="bottom"
         :label="t('kubewarden.policyConfig.apiVersions.label')"
-      >
-        <template #options="opt">
-          <span>{{ opt }}</span>
-        </template>
-      </LabeledSelect>
+        :tooltip="t('kubewarden.policyConfig.apiVersions.tooltip')"
+      />
     </div>
 
     <div>
@@ -193,7 +214,7 @@ export default {
 <style lang="scss" scoped>
 .rules-row{
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+  grid-template-columns: .5fr 1fr 1fr 1fr 1fr .5fr;
   grid-column-gap: $column-gutter;
   align-items: center;
 }

--- a/pkg/kubewarden/chart/kubewarden/admission/Rules.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/Rules.vue
@@ -65,7 +65,7 @@ export default {
         :api-groups="apiGroups"
       >
         <template v-if="!isView" #removeRule>
-          <button type="button" class="btn role-link" @click="removeRule(index)">
+          <button type="button" class="btn role-link p-0" @click="removeRule(index)">
             {{ t('kubewarden.policyConfig.rules.remove') }}
           </button>
         </template>

--- a/pkg/kubewarden/components/policies/Config.vue
+++ b/pkg/kubewarden/components/policies/Config.vue
@@ -1,5 +1,5 @@
 <script>
-import { _CREATE, _VIEW } from '@shell/config/query-params';
+import { _VIEW } from '@shell/config/query-params';
 
 import Values from './Values.vue';
 
@@ -36,21 +36,10 @@ export default {
 
   data() {
     return { chartValues: null };
-  },
-
-  computed: {
-    // if coming from the "View Yaml" page `this.mode` will display `create` - this is not legit.
-    legitMode() {
-      if ( this.mode === _CREATE ) {
-        return _VIEW;
-      }
-
-      return this.mode;
-    }
   }
 };
 </script>
 
 <template>
-  <Values :value="value" :chart-values="chartValues" :mode="legitMode" />
+  <Values :value="value" :chart-values="chartValues" :mode="mode" />
 </template>

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -107,15 +107,20 @@ kubewarden:
       add: Add Rule Set
       remove: Remove Rule Set
     apiGroups:
-      label: API Group
+      label: API Groups
+      tooltip: The API groups the resources belong to.
     apiVersions:
-      label: API Version
+      label: API Versions
+      tooltip: The API versions the resources belong to.
     operations:
       label: Operation type
-      tooltip: The type of operation to be validated.
+      tooltip: The operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT.
     resources:
       label: Resource type
       tooltip: The targeted resources for the policy. Needs to be a resource that is supported by the policy, this is determined in the `metadata.yml` of the selected policy.
+    scope:
+      label: Scope
+      tooltip: Specifies the scope of this rule. Valid values are "Cluster", "Namespaced", and "". "Cluster" means that only cluster-scoped resources will match this rule. Namespace API objects are cluster-scoped. "Namespaced" means that only namespaced resources will match this rule. "" means that there are no scope restrictions. Subresources match the scope of their parent resource. Default is "*".
   policyServerConfig:
     defaultImage:
       label: Default Image


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #127 

This adds the [scope](https://doc.crds.dev/github.com/kubewarden/kubewarden-controller/policies.kubewarden.io/ClusterAdmissionPolicy/v1@v1.1.1#spec-rules-scope) property to a policy's rule set config.