### PR TITLE
Add unit-tests to policy server detail view - metrics banner

### DIFF
--- a/tests/unit/charts/admission/General.spec.ts
+++ b/tests/unit/charts/admission/General.spec.ts
@@ -41,7 +41,7 @@ describe('component: General', () => {
     const input = wrapper.findComponent(LabeledSelect);
 
     expect(input.props().value).toStrictEqual('default' as String);
-    expect(input.props().options).toStrictEqual(['default', 'custom-ps'] as Array<String>);
+    expect(input.props().options).toStrictEqual(['default', 'custom-ps'] as String[]);
   });
 
   it('monitor mode should be protect by default', async() => {

--- a/tests/unit/charts/policy-server/General.spec.ts
+++ b/tests/unit/charts/policy-server/General.spec.ts
@@ -22,7 +22,7 @@ describe('component: General', () => {
 
     const selector = wrapper.findComponent(ServiceNameSelect);
 
-    expect(selector.props().options).toStrictEqual(serviceAccounts as Array<String>);
+    expect(selector.props().options).toStrictEqual(serviceAccounts as String[]);
   });
 
   it('displays correct service account when existing', () => {

--- a/tests/unit/charts/policy-server/Verification.spec.ts
+++ b/tests/unit/charts/policy-server/Verification.spec.ts
@@ -19,7 +19,7 @@ describe('component: Verification', () => {
 
     const selector = wrapper.findComponent(LabeledSelect);
 
-    expect(selector.props().options).toStrictEqual(configMaps as Array<String>);
+    expect(selector.props().options).toStrictEqual(configMaps as String[]);
   });
 
   it('displays correct configmap when existing', () => {

--- a/tests/unit/components/MetricsBanner.spec.ts
+++ b/tests/unit/components/MetricsBanner.spec.ts
@@ -1,0 +1,161 @@
+import { ExtendedVue, Vue } from 'vue/types/vue';
+import { DefaultProps } from 'vue/types/options';
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it } from '@jest/globals';
+
+import MetricsBanner from '@kubewarden/components/MetricsBanner';
+import AsyncButton from '@shell/components/AsyncButton';
+import { Banner } from '@components/Banner';
+
+import { METRICS_DASHBOARD } from '@kubewarden/types';
+
+describe('component: MetricsBanner', () => {
+  it('metrics banner displays correctly when uninstalled', () => {
+    const wrapper = shallowMount(MetricsBanner as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      propsData: { metricsType: METRICS_DASHBOARD.POLICY_SERVER },
+      computed:  {
+        monitoringStatus: () => {
+          return { installed: false };
+        },
+      },
+      mocks:     {
+        $fetchState: { pending: false },
+        $store:      {
+          getters: {
+            currentProduct:         () => 'current_product',
+            monitoringChart:        () => null,
+            metricsDashboard:       () => null,
+            'current_product/all':  jest.fn(),
+            'i18n/t':               jest.fn()
+          },
+        }
+      },
+      stubs: { AsyncButton: { template: '<span />' } }
+    });
+
+    const banner = wrapper.findComponent(Banner);
+
+    expect(banner.exists()).toBe(true);
+    expect(banner.html().includes('<span>%kubewarden.monitoring.notInstalled%</span>')).toBe(true);
+  });
+
+  it('button to add dashboard displays when installed with no dashboard found', () => {
+    const wrapper = shallowMount(MetricsBanner as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      propsData: { metricsType: METRICS_DASHBOARD.POLICY_SERVER },
+      computed:  {
+        monitoringStatus: () => {
+          return { installed: true };
+        },
+      },
+      mocks:     {
+        $fetchState: { pending: false },
+        $store:      {
+          getters: {
+            currentProduct:         () => 'current_product',
+            monitoringChart:        () => null,
+            metricsDashboard:       () => null,
+            'current_product/all':  jest.fn(),
+            'cluster/matching':     jest.fn(),
+            'i18n/t':               jest.fn()
+          },
+        }
+      },
+    });
+
+    const button = wrapper.findComponent(AsyncButton);
+
+    expect(button.exists()).toBe(true);
+    expect(button.html().includes('mode="grafanaDashboard"')).toBe(true);
+  });
+
+  it('button to add dashboard not displayed when reload is required', () => {
+    const wrapper = shallowMount(MetricsBanner as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      propsData: { metricsType: METRICS_DASHBOARD.POLICY_SERVER, reloadRequired: true },
+      computed:  {
+        monitoringStatus: () => {
+          return { installed: true };
+        },
+      },
+      mocks:     {
+        $fetchState: { pending: false },
+        $store:      {
+          getters: {
+            currentProduct:         () => 'current_product',
+            monitoringChart:        () => null,
+            metricsDashboard:       () => null,
+            'current_product/all':  jest.fn(),
+            'cluster/matching':     jest.fn(),
+            'i18n/t':               jest.fn()
+          },
+        }
+      },
+    });
+
+    const button = wrapper.findComponent(AsyncButton);
+    const banner = wrapper.findComponent(Banner);
+
+    expect(banner.exists()).toBe(true);
+    expect(button.exists()).toBe(false);
+    expect(banner.html().includes('%kubewarden.metrics.reload%')).toBe(true);
+  });
+
+  it('warning banner displays when metrics is installed and service is falsy', () => {
+    const wrapper = shallowMount(MetricsBanner as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      propsData: { metricsType: METRICS_DASHBOARD.POLICY_SERVER },
+      computed:  {
+        monitoringStatus: () => {
+          return { installed: true };
+        },
+        metricsDashboard: () => true
+      },
+      mocks:     {
+        $fetchState: { pending: false },
+        $store:      {
+          getters: {
+            currentProduct:         () => 'current_product',
+            monitoringChart:        () => null,
+            metricsDashboard:       () => null,
+            'current_product/all':  jest.fn(),
+            'cluster/matching':     jest.fn(),
+            'i18n/t':               jest.fn()
+          },
+        }
+      },
+    });
+
+    const banner = wrapper.findComponent(Banner);
+
+    expect(banner.exists()).toBe(true);
+    expect(banner.html().includes('%kubewarden.metrics.noService%')).toBe(true);
+  });
+
+  it('warning banner displays when metrics is installed and service is falsy', () => {
+    const wrapper = shallowMount(MetricsBanner as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      propsData: { metricsType: METRICS_DASHBOARD.POLICY_SERVER },
+      computed:  {
+        monitoringStatus: () => {
+          return { installed: true };
+        },
+        metricsDashboard: () => true
+      },
+      mocks:     {
+        $fetchState: { pending: false },
+        $store:      {
+          getters: {
+            currentProduct:         () => 'current_product',
+            monitoringChart:        () => null,
+            metricsDashboard:       () => null,
+            'current_product/all':  jest.fn(),
+            'cluster/matching':     jest.fn(),
+            'i18n/t':               jest.fn()
+          },
+        }
+      },
+    });
+
+    const banner = wrapper.findComponent(Banner);
+
+    expect(banner.exists()).toBe(true);
+    expect(banner.html().includes('%kubewarden.metrics.noService%')).toBe(true);
+  });
+});

--- a/tests/unit/detail/PolicyServer.spec.ts
+++ b/tests/unit/detail/PolicyServer.spec.ts
@@ -1,0 +1,178 @@
+import { ExtendedVue, Vue } from 'vue/types/vue';
+import { DefaultProps } from 'vue/types/options';
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it } from '@jest/globals';
+
+import PolicyServer from '@kubewarden/detail/policies.kubewarden.io.policyserver.vue';
+import MetricsBanner from '@kubewarden/components/MetricsBanner';
+import CountGauge from '@shell/components/CountGauge';
+
+const policyGauges = {
+  Active: {
+    count: 42,
+    color: 'success'
+  },
+  Pending: {
+    count: 13,
+    color: 'info'
+  }
+};
+
+const relatedPolicies = () => {
+  let out = 0;
+
+  for ( const key of Object.keys(policyGauges) ) {
+    out += policyGauges[key].count;
+  }
+
+  return out;
+};
+
+describe('component: PolicyServer', () => {
+  it('policy gauges display correct info', () => {
+    const wrapper = shallowMount(PolicyServer as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      propsData: { value: {} },
+      data() {
+        return { policyGauges };
+      },
+      computed:  {
+        monitoringStatus: () => {
+          return { installed: false };
+        },
+        relatedPoliciesTotal: () => relatedPolicies()
+      },
+      mocks:     {
+        $fetchState: { pending: false },
+        $store:      {
+          getters: {
+            currentCluster:                  () => 'current_cluster',
+            currentProduct:                  () => 'current_product',
+            'current_product/all':           jest.fn(),
+            'i18n/t':                        jest.fn()
+          },
+        }
+      },
+      stubs: {
+        ResourceTabs:  { template: '<span />' },
+        Tab:           { template: '<span />' },
+        MetricsBanner: { template: '<span />' },
+        TraceTable:    { template: '<span />' },
+        Banner:        { template: '<span />' }
+      }
+    });
+
+    const gauges = wrapper.findAllComponents(CountGauge);
+    const activeGauge = gauges.at(0).props();
+    const pendingGauge = gauges.at(1).props();
+
+    expect(activeGauge.name).toStrictEqual('Active' as String);
+    expect(activeGauge.total).toStrictEqual(relatedPolicies() as Number);
+    expect(activeGauge.useful).toStrictEqual(policyGauges['Active'].count as Number);
+    expect(activeGauge.primaryColorVar.replace('--sizzle-', '')).toStrictEqual(policyGauges['Active'].color as String);
+
+    expect(pendingGauge.name).toStrictEqual('Pending' as String);
+    expect(pendingGauge.total).toStrictEqual(relatedPolicies() as Number);
+    expect(pendingGauge.useful).toStrictEqual(policyGauges['Pending'].count as Number);
+    expect(pendingGauge.primaryColorVar.replace('--sizzle-', '')).toStrictEqual(policyGauges['Pending'].color as String);
+  });
+
+  it('tracing gauges display correct info', () => {
+    const traceCounts = {
+      Denied: {
+        count: 42,
+        color: 'error'
+      },
+      Mutated: {
+        count: 13,
+        color: 'warning'
+      }
+    };
+
+    const wrapper = shallowMount(PolicyServer as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      propsData: { value: {} },
+      data() {
+        const filteredValidations:Number[] = [];
+
+        for ( const key of Object.keys(traceCounts) ) {
+          for ( let i = 0; i < traceCounts[key].count; i++ ) {
+            filteredValidations.push(i);
+          }
+        }
+
+        return { policyGauges, filteredValidations };
+      },
+      computed:  {
+        monitoringStatus: () => {
+          return { installed: false };
+        },
+        relatedPoliciesTotal: () => relatedPolicies(),
+        tracesGauges:         () => traceCounts,
+        emptyTraces:          () => false
+      },
+      mocks:     {
+        $fetchState: { pending: false },
+        $store:      {
+          getters: {
+            currentCluster:                  () => 'current_cluster',
+            currentProduct:                  () => 'current_product',
+            'current_product/all':           jest.fn(),
+            'i18n/t':                        jest.fn()
+          },
+        }
+      },
+      stubs: {
+        ResourceTabs:  { template: '<span />' },
+        Tab:           { template: '<span />' },
+        MetricsBanner: { template: '<span />' },
+        TraceTable:    { template: '<span />' },
+        Banner:        { template: '<span />' }
+      }
+    });
+
+    const gauges = wrapper.findAllComponents(CountGauge);
+    const deniedGauge = gauges.at(2).props();
+    const mutatedGauge = gauges.at(3).props();
+
+    expect(deniedGauge.name).toStrictEqual('Denied' as String);
+    expect(deniedGauge.total).toStrictEqual(wrapper.vm.$data.filteredValidations.length as Number);
+    expect(deniedGauge.useful).toStrictEqual(traceCounts['Denied'].count as Number);
+    expect(deniedGauge.primaryColorVar.replace('--sizzle-', '')).toStrictEqual(traceCounts['Denied'].color as String);
+
+    expect(mutatedGauge.name).toStrictEqual('Mutated' as String);
+    expect(mutatedGauge.total).toStrictEqual(wrapper.vm.$data.filteredValidations.length as Number);
+    expect(mutatedGauge.useful).toStrictEqual(traceCounts['Mutated'].count as Number);
+    expect(mutatedGauge.primaryColorVar.replace('--sizzle-', '')).toStrictEqual(traceCounts['Mutated'].color as String);
+  });
+
+  it('metrics banner displays when uninstalled', () => {
+    const wrapper = shallowMount(PolicyServer as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      propsData: { value: {} },
+      computed:  {
+        monitoringStatus: () => {
+          return { installed: true };
+        },
+      },
+      mocks:     {
+        $fetchState: { pending: false },
+        $store:      {
+          getters: {
+            currentCluster:                  () => 'current_cluster',
+            currentProduct:                  () => 'current_product',
+            'current_product/all':           jest.fn(),
+            'i18n/t':                        jest.fn()
+          },
+        }
+      },
+      stubs: {
+        CountGauge:  { template: '<span />' },
+        TraceTable:  { template: '<span />' },
+        Banner:      { template: '<span />' }
+      }
+    });
+
+    const banner = wrapper.findComponent(MetricsBanner);
+
+    expect(banner.exists()).toBe(true);
+    expect(banner.props().metricsService).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix #270 

Added unit-tests for detail view of Policy server which includes the metrics banner.

Tests:
- policy gauges
- tracing gauages
- metrics banner displays
