### PR TITLE
Add initial tab for Policy Reporter

### DIFF
--- a/pkg/kubewarden/chart/kubewarden/policy-server/General.vue
+++ b/pkg/kubewarden/chart/kubewarden/policy-server/General.vue
@@ -103,13 +103,17 @@ export default {
     </div>
 
     <div class="row">
-      <div class="col span-6">
+      <div v-if="showVersionBanner" class="col span-12">
         <Banner
-          v-if="showVersionBanner"
           class="mb-20 mt-0"
           color="warning"
           :label="t('kubewarden.policyServerConfig.defaultImage.versionWarning')"
         />
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col span-6">
         <RadioGroup
           v-model="defaultImage"
           data-testid="ps-config-default-image-button"

--- a/pkg/kubewarden/components/Dashboard/DashboardView.vue
+++ b/pkg/kubewarden/components/Dashboard/DashboardView.vue
@@ -24,7 +24,10 @@ export default {
     const inStore = this.currentProduct.inStore;
 
     const hash = await allHash({
-      controller:         this.$store.dispatch(`${ inStore }/findMatching`, { type: WORKLOAD_TYPES.DEPLOYMENT, selector: `${ KUBERNETES.MANAGED_NAME }=${ KUBEWARDEN_CHARTS.CONTROLLER }` }),
+      controller:         this.$store.dispatch(`${ inStore }/findMatching`, {
+        type:     WORKLOAD_TYPES.DEPLOYMENT,
+        selector: `${ KUBERNETES.MANAGED_NAME }=${ KUBEWARDEN_CHARTS.CONTROLLER }`
+      }),
       psPods:             this.$store.dispatch(`${ inStore }/findMatching`, { type: POD, selector: 'kubewarden/policy-server' }),
       globalPolicies:     this.$store.dispatch(`${ inStore }/findAll`, { type: KUBEWARDEN.CLUSTER_ADMISSION_POLICY }),
       namespacedPolicies: this.$store.dispatch(`${ inStore }/findAll`, { type: KUBEWARDEN.ADMISSION_POLICY }),

--- a/pkg/kubewarden/components/Dashboard/InstallView.vue
+++ b/pkg/kubewarden/components/Dashboard/InstallView.vue
@@ -15,7 +15,7 @@ import { KUBEWARDEN_CHARTS, KUBEWARDEN_REPO } from '../../types';
 import { getLatestStableVersion } from '../../plugins/kubewarden-class';
 import { handleGrowlError } from '../../utils/handle-growl';
 
-import InstallWizard from './InstallWizard';
+import InstallWizard from '../InstallWizard';
 
 export default {
   props: {

--- a/pkg/kubewarden/components/InstallWizard.vue
+++ b/pkg/kubewarden/components/InstallWizard.vue
@@ -1,18 +1,14 @@
 <script>
 export default {
-  name: 'InstallMenu',
-
   props: {
-    getStartedLink: {
-      type:    Object,
-      default: null,
-    },
-
     initStepIndex: {
       type:    Number,
       default: 0
     },
-
+    showTitle: {
+      type:    Boolean,
+      default: true
+    },
     steps: {
       type:    Array,
       default: null,
@@ -35,17 +31,17 @@ export default {
 
   methods: {
     goToStep(number, fromNav) {
-      if (number < 1) {
+      if ( number < 1 ) {
         return;
       }
 
-      if (number === 1 && fromNav) {
+      if ( number === 1 && fromNav ) {
         return;
       }
 
       const selected = this.steps[number - 1];
 
-      if (!selected || (!this.isAvailable(selected) && number !== 1)) {
+      if ( !selected || (!this.isAvailable(selected) && number !== 1) ) {
         return;
       }
 
@@ -55,18 +51,18 @@ export default {
     },
 
     isAvailable(step) {
-      if (!step) {
+      if ( !step ) {
         return false;
       }
 
       const idx = this.steps.findIndex(s => s.name === step.name);
 
-      if (idx === 0) {
+      if ( idx === 0 ) {
         return false;
       }
 
-      for (let i = 0; i < idx; i++) {
-        if (this.steps[i].ready === false) {
+      for ( let i = 0; i < idx; i++ ) {
+        if ( this.steps[i].ready === false ) {
           return false;
         }
       }
@@ -85,15 +81,20 @@ export default {
   <div>
     <div class="header mt-20 mb-20">
       <div class="title">
-        <div class="product-image">
-          <img src="../../assets/icon-kubewarden.svg" class="logo" />
-        </div>
-        <div class="subtitle mr-20">
-          <h2>
-            {{ t('kubewarden.title') }}
-          </h2>
-          <span class="subtext">{{ t('kubewarden.dashboard.install') }}</span>
-        </div>
+        <template v-if="showTitle">
+          <div>
+            <div class="product-image">
+              <img src="../assets/icon-kubewarden.svg" class="logo" />
+            </div>
+            <div class="subtitle mr-20">
+              <h2>
+                {{ t('kubewarden.title') }}
+              </h2>
+              <span class="subtext">{{ t('kubewarden.dashboard.install') }}</span>
+            </div>
+          </div>
+        </template>
+
         <div class="subtitle">
           <h2>{{ t('wizard.step', {number: activeStepIndex + 1}) }}</h2>
           <slot name="bannerSubtext">

--- a/pkg/kubewarden/components/MetricsBanner.vue
+++ b/pkg/kubewarden/components/MetricsBanner.vue
@@ -1,7 +1,6 @@
 <script>
 import { mapGetters } from 'vuex';
 import { monitoringStatus } from '@shell/utils/monitoring';
-import { CONFIG_MAP } from '@shell/config/types';
 
 import { Banner } from '@components/Banner';
 import AsyncButton from '@shell/components/AsyncButton';
@@ -31,7 +30,11 @@ export default {
       await this.$store.dispatch('catalog/load');
     }
 
-    await this.$store.dispatch('cluster/findAll', { type: CONFIG_MAP });
+    this.grafanaDashboard = await this.value.grafanaDashboard();
+  },
+
+  data() {
+    return { grafanaDashboard: null };
   },
 
   computed: {
@@ -40,16 +43,7 @@ export default {
 
     monitoringChart() {
       return this.$store.getters['catalog/chart']({ chartName: 'rancher-monitoring' });
-    },
-
-    metricsDashboard() {
-      const out = this.$store.getters['cluster/matching']({
-        type:     CONFIG_MAP,
-        selector: `kubewarden/part-of=cattle-kubewarden-system`
-      });
-
-      return Array.isArray(out) && !out.length ? null : out;
-    },
+    }
   },
 
   methods: {
@@ -79,7 +73,7 @@ export default {
     </Banner>
   </div>
 
-  <div v-else-if="!metricsDashboard">
+  <div v-else-if="!grafanaDashboard">
     <Banner color="warning">
       <template v-if="!reloadRequired">
         <p class="mb-20">

--- a/pkg/kubewarden/components/Policies/PolicyDetail.vue
+++ b/pkg/kubewarden/components/Policies/PolicyDetail.vue
@@ -59,7 +59,7 @@ export default {
       }
     }
 
-    this.jaegerService = await this.value.jaegerService();
+    this.jaegerService = await this.value.jaegerQueryService();
 
     if ( this.jaegerService ) {
       this.filteredValidations = await this.value.jaegerSpecificValidations({ service: this.jaegerService });

--- a/pkg/kubewarden/components/PolicyReporter/InstallView.vue
+++ b/pkg/kubewarden/components/PolicyReporter/InstallView.vue
@@ -1,0 +1,245 @@
+<script>
+import { mapGetters } from 'vuex';
+import { CATALOG } from '@shell/config/types';
+import { REPO_TYPE, REPO, CHART, VERSION } from '@shell/config/query-params';
+
+import ResourceFetch from '@shell/mixins/resource-fetch';
+
+import Loading from '@shell/components/Loading';
+import AsyncButton from '@shell/components/AsyncButton';
+
+import { POLICY_REPORTER_CHART, POLICY_REPORTER_REPO } from '../../types';
+import { getLatestStableVersion } from '../../plugins/kubewarden-class';
+import { handleGrowlError } from '../../utils/handle-growl';
+
+import InstallWizard from '../InstallWizard';
+
+export default {
+  components: {
+    InstallWizard, Loading, AsyncButton
+  },
+
+  mixins: [ResourceFetch],
+
+  async fetch() {
+    await this.$fetchType(CATALOG.CLUSTER_REPO);
+    await this.refreshCharts(1, true);
+  },
+
+  data() {
+    const installSteps = [
+      {
+        name:  'repo',
+        label: 'Policy Reporter Repository',
+        ready: false,
+      },
+      {
+        name:  'chart',
+        label: 'Chart Install',
+        ready: false,
+      },
+    ];
+
+    return {
+      installSteps,
+      initStepIndex: 0,
+      reloadReady:   false
+    };
+  },
+
+  beforeUpdate() {
+    if ( this.reporterChart ) {
+      this.installSteps[0].ready = true;
+
+      this.$nextTick(() => {
+        this.$refs.wizard?.goToStep(2);
+      });
+    }
+  },
+
+  watch: {
+    reporterChart() {
+      this.installSteps[0].ready = true;
+      this.$refs.wizard?.goToStep(2);
+    }
+  },
+
+  computed: {
+    ...mapGetters({ allRepos: 'catalog/repos', rawCharts: 'catalog/rawCharts' }),
+
+    isAirgap() {
+      // return this.$store.getters['kubewarden/airGapped'];
+      return false; // Returning false until we have a method of installing this while air-gapped
+    },
+
+    reporterChart() {
+      const chartValues = Object.values(this.rawCharts);
+
+      return chartValues.find(c => c.chartName === POLICY_REPORTER_CHART);
+    },
+
+    reporterRepo() {
+      if ( !this.isAirgap ) {
+        return this.allRepos?.find(r => r.spec.url === POLICY_REPORTER_REPO);
+      }
+
+      return this.reporterChart;
+    }
+  },
+
+  methods: {
+    async addRepository(btnCb) {
+      try {
+        const repoObj = await this.$store.dispatch('cluster/create', {
+          type:     CATALOG.CLUSTER_REPO,
+          metadata: { name: 'policy-reporter-charts' },
+          spec:     { url: POLICY_REPORTER_REPO },
+        });
+
+        try {
+          await repoObj.save();
+        } catch (e) {
+          handleGrowlError({ error: e, store: this.$store });
+          btnCb(false);
+
+          return;
+        }
+
+        await this.refreshCharts();
+        btnCb(true);
+      } catch (e) {
+        handleGrowlError({ error: e, store: this.$store });
+        btnCb(false);
+      }
+    },
+
+    async installChart() {
+      if ( !this.controllerChart ) {
+        try {
+          await this.refreshCharts();
+        } catch (e) {
+          handleGrowlError({ error: e, store: this.$store });
+
+          return;
+        }
+      }
+
+      const {
+        repoType, repoName, chartName, versions
+      } = this.reporterChart;
+      const latestStableVersion = getLatestStableVersion(versions);
+
+      if ( latestStableVersion ) {
+        const query = {
+          [REPO_TYPE]: repoType,
+          [REPO]:      repoName,
+          [CHART]:     chartName,
+          [VERSION]:   latestStableVersion.version
+        };
+
+        this.$router.push({
+          name:   'c-cluster-apps-charts-install',
+          params: { cluster: this.currentCluster?.id || '_' },
+          query,
+        });
+      } else {
+        const error = {
+          _statusText: this.t('kubewarden.dashboard.appInstall.versionError.title'),
+          message:     this.t('kubewarden.dashboard.appInstall.versionError.message')
+        };
+
+        handleGrowlError({ error, store: this.$store });
+      }
+    },
+
+    async refreshCharts(retry = 0, init) {
+      try {
+        await this.$store.dispatch('catalog/load', { force: true, reset: true });
+      } catch (e) {
+        handleGrowlError({ error: e, store: this.$store });
+      }
+
+      if ( !this.reporterChart && retry === 0 ) {
+        await this.$fetchType(CATALOG.CLUSTER_REPO);
+        await this.refreshCharts(retry + 1);
+      }
+
+      if ( !this.reporterChart && retry === 1 && !init ) {
+        this.reloadReady = true;
+      }
+    },
+
+    reload() {
+      this.$router.go();
+    }
+  }
+};
+</script>
+
+<template>
+  <Loading v-if="$fetchState.pending" />
+
+  <div v-else>
+    <!-- Air-Gapped -->
+    <template v-if="isAirgap">
+      <InstallWizard ref="wizard" :init-step-index="initStepIndex" :steps="installSteps" :show-title="false">
+        <Banner
+          class="mb-20 mt-20"
+          color="warning"
+        >
+          <span data-testid="kw-pr-install-ag-warning">{{ t('kubewarden.policyReporter.install.airGapped.warning') }}</span>
+        </Banner>
+      </InstallWizard>
+    </template>
+
+    <!-- Non Air-Gapped -->
+    <template v-else>
+      <InstallWizard ref="wizard" :init-step-index="initStepIndex" :steps="installSteps" :show-title="false">
+        <template #repo>
+          <div class="step-container">
+            <h3 class="mt-20 mb-10" data-testid="kw-pr-install-repo-title">
+              {{ t("kubewarden.policyReporter.install.repo.title") }}
+            </h3>
+            <p class="mb-20">
+              {{ t("kubewarden.policyReporter.install.repo.description") }}
+            </p>
+
+            <AsyncButton mode="policyReporterRepo" data-testid="kw-pr-install-repo-add-button" @click="addRepository" />
+          </div>
+        </template>
+
+        <template #chart>
+          <Loading v-if="!reporterChart && !reloadReady" mode="relative" class="mt-20" />
+
+          <template v-else-if="!reporterChart && reloadReady">
+            <Banner color="warning">
+              <span class="mb-20">
+                {{ t('kubewarden.dashboard.appInstall.reload' ) }}
+              </span>
+              <button data-testid="kw-pr-install-repo-reload" class="ml-10 btn btn-sm role-primary" @click="reload()">
+                {{ t('generic.reload') }}
+              </button>
+            </Banner>
+          </template>
+
+          <template v-else>
+            <div>
+              <h3 class="mt-20 mb-10" data-testid="kw-pr-install-repo-title">
+                {{ t("kubewarden.policyReporter.install.chart.title") }}
+              </h3>
+              <AsyncButton mode="policyReporterChart" data-testid="kw-pr-install-chart-button" @click="installChart" />
+            </div>
+          </template>
+        </template>
+      </InstallWizard>
+    </template>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.step-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+</style>

--- a/pkg/kubewarden/components/PolicyReporter/index.vue
+++ b/pkg/kubewarden/components/PolicyReporter/index.vue
@@ -1,0 +1,88 @@
+<script>
+import isEmpty from 'lodash/isEmpty';
+
+import { Banner } from '@components/Banner';
+
+import InstallView from './InstallView';
+
+export default {
+  props: {
+    value: {
+      type:     Object,
+      required: true
+    }
+  },
+
+  components: { Banner, InstallView },
+
+  async fetch() {
+    this.reporterService = await this.value.policyReporterService();
+
+    if ( !isEmpty(this.reporterService) ) {
+      this.reporterUrl = await this.value.policyReporterProxy();
+    }
+  },
+
+  data() {
+    return {
+      reporterService: null,
+      reporterUrl:     null
+    };
+  }
+};
+</script>
+
+<template>
+  <div>
+    <template v-if="!reporterService">
+      <div>
+        <Banner
+          :label="t('kubewarden.policyReporter.service.banner.unavailable')"
+          color="warning"
+        />
+      </div>
+      <InstallView />
+    </template>
+    <template v-if="reporterUrl">
+      <div>
+        <div class="reporter__header mb-20">
+          <div
+            class="reporter__external-link"
+          >
+            <a
+              :href="reporterUrl"
+              target="_blank"
+              rel="noopener nofollow"
+            >
+              {{ t('kubewarden.policyReporter.link') }} <i class="icon icon-external-link" />
+            </a>
+          </div>
+        </div>
+        <div class="reporter__container">
+          <iframe
+            ref="frame"
+            :src="reporterUrl"
+            frameborder="0"
+          />
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<style lang='scss' scoped>
+.reporter {
+  &__header {
+    display: flex;
+    justify-content: right;
+    align-items: center;
+  }
+
+  &__container {
+    iframe {
+      width: 100%;
+      height: 80vh;
+    }
+  }
+}
+</style>

--- a/pkg/kubewarden/components/TraceBanner.vue
+++ b/pkg/kubewarden/components/TraceBanner.vue
@@ -4,8 +4,8 @@ import { Banner } from '@components/Banner';
 export default {
   props: {
     openTelemetryService: {
-      type:    Object,
-      default: null
+      type:    Array,
+      default: () => []
     },
     jaegerService: {
       type:    Object,
@@ -20,7 +20,7 @@ export default {
 <template>
   <div>
     <Banner color="warning">
-      <span v-if="!openTelemetryService" v-clean-html="t('kubewarden.tracing.noOpenTelemetry', {}, true)" data-testid="kw-trace-banner-no-telemetry" />
+      <span v-if="!openTelemetryService.length " v-clean-html="t('kubewarden.tracing.noOpenTelemetry', {}, true)" data-testid="kw-trace-banner-no-telemetry" />
       <span v-else-if="!jaegerService" v-clean-html="t('kubewarden.tracing.noJaeger', {}, true)" data-testid="kw-trace-banner-no-jaeger" />
       <span v-else data-testid="kw-trace-banner-no-traces">{{ t('kubewarden.tracing.noRelatedTraces') }}</span>
     </Banner>

--- a/pkg/kubewarden/components/TraceBanner.vue
+++ b/pkg/kubewarden/components/TraceBanner.vue
@@ -1,4 +1,5 @@
 <script>
+import isEmpty from 'lodash/isEmpty';
 import { Banner } from '@components/Banner';
 
 export default {
@@ -13,15 +14,21 @@ export default {
     }
   },
 
-  components: { Banner }
+  components: { Banner },
+
+  methods: {
+    hasService(service) {
+      return !!isEmpty(service);
+    }
+  }
 };
 </script>
 
 <template>
   <div>
     <Banner color="warning">
-      <span v-if="!openTelemetryService.length " v-clean-html="t('kubewarden.tracing.noOpenTelemetry', {}, true)" data-testid="kw-trace-banner-no-telemetry" />
-      <span v-else-if="!jaegerService" v-clean-html="t('kubewarden.tracing.noJaeger', {}, true)" data-testid="kw-trace-banner-no-jaeger" />
+      <span v-if="!hasService(openTelemetryService) " v-clean-html="t('kubewarden.tracing.noOpenTelemetry', {}, true)" data-testid="kw-trace-banner-no-telemetry" />
+      <span v-else-if="!hasService(jaegerService)" v-clean-html="t('kubewarden.tracing.noJaeger', {}, true)" data-testid="kw-trace-banner-no-jaeger" />
       <span v-else data-testid="kw-trace-banner-no-traces">{{ t('kubewarden.tracing.noRelatedTraces') }}</span>
     </Banner>
   </div>

--- a/pkg/kubewarden/config/kubewarden.ts
+++ b/pkg/kubewarden/config/kubewarden.ts
@@ -1,5 +1,5 @@
 import { rootKubewardenRoute } from '../utils/custom-routing';
-import { KUBEWARDEN, KUBEWARDEN_DASHBOARD } from '../types';
+import { KUBEWARDEN, KUBEWARDEN_DASHBOARD, POLICY_REPORTER_PRODUCT, KUBEWARDEN_PRODUCT_NAME } from '../types';
 import { POLICY_SERVER_HEADERS, POLICY_HEADERS } from './table-headers';
 
 export function init($plugin: any, store: any) {
@@ -35,8 +35,21 @@ export function init($plugin: any, store: any) {
     overview:    true
   });
 
+  virtualType({
+    label:      store.getters['i18n/t']('kubewarden.policyReporter.title'),
+    icon:       'notifier',
+    name:       POLICY_REPORTER_PRODUCT,
+    namespaced: false,
+    weight:     95,
+    route:      {
+      name:   `c-cluster-${ KUBEWARDEN_PRODUCT_NAME }-${ POLICY_REPORTER_PRODUCT }`,
+      params: { product: KUBEWARDEN_PRODUCT_NAME }
+    }
+  });
+
   basicType([
     KUBEWARDEN_DASHBOARD,
+    POLICY_REPORTER_PRODUCT,
     POLICY_SERVER,
     ADMISSION_POLICY,
     CLUSTER_ADMISSION_POLICY

--- a/pkg/kubewarden/detail/policies.kubewarden.io.policyserver.vue
+++ b/pkg/kubewarden/detail/policies.kubewarden.io.policyserver.vue
@@ -24,13 +24,12 @@ import { handleGrowlError } from '../utils/handle-growl';
 import MetricsBanner from '../components/MetricsBanner';
 import TraceBanner from '../components/TraceBanner';
 import TraceTable from '../components/TraceTable';
-import PolicyReporter from '../components/PolicyReporter';
 
 export default {
   name: 'PolicyServer',
 
   components: {
-    CountGauge, DashboardMetrics, Loading, MetricsBanner, PolicyReporter, ResourceTabs, ResourceTable, Tab, TraceBanner, TraceTable
+    CountGauge, DashboardMetrics, Loading, MetricsBanner, ResourceTabs, ResourceTable, Tab, TraceBanner, TraceTable
   },
 
   mixins: [CreateEditView],
@@ -249,11 +248,7 @@ export default {
         </template>
       </Tab>
 
-      <Tab name="policy-reporter" label="Policy Reporter" :weight="98">
-        <PolicyReporter :value="value" />
-      </Tab>
-
-      <Tab name="policy-metrics" label="Metrics" :weight="97">
+      <Tab name="policy-metrics" label="Metrics" :weight="98">
         <MetricsBanner
           v-if="!monitoringStatus.installed || !metricsService"
           :metrics-service="metricsService"
@@ -274,7 +269,7 @@ export default {
         </template>
       </Tab>
 
-      <Tab name="policy-tracing" label="Tracing" :weight="96">
+      <Tab name="policy-tracing" label="Tracing" :weight="97">
         <template>
           <TraceTable :rows="filteredValidations">
             <template #traceBanner>

--- a/pkg/kubewarden/detail/policies.kubewarden.io.policyserver.vue
+++ b/pkg/kubewarden/detail/policies.kubewarden.io.policyserver.vue
@@ -24,12 +24,13 @@ import { handleGrowlError } from '../utils/handle-growl';
 import MetricsBanner from '../components/MetricsBanner';
 import TraceBanner from '../components/TraceBanner';
 import TraceTable from '../components/TraceTable';
+import PolicyReporter from '../components/PolicyReporter';
 
 export default {
   name: 'PolicyServer',
 
   components: {
-    CountGauge, DashboardMetrics, Loading, MetricsBanner, ResourceTabs, ResourceTable, Tab, TraceBanner, TraceTable
+    CountGauge, DashboardMetrics, Loading, MetricsBanner, PolicyReporter, ResourceTabs, ResourceTable, Tab, TraceBanner, TraceTable
   },
 
   mixins: [CreateEditView],
@@ -50,7 +51,7 @@ export default {
     const hash = await allHash({
       relatedPolicies:      this.value.allRelatedPolicies(),
       policyGauges:         this.value.policyGauges(),
-      jaegerService:        this.value.jaegerService(),
+      jaegerService:        this.value.jaegerQueryService(),
       openTelemetryService: this.value.openTelemetryService()
     });
 
@@ -248,7 +249,11 @@ export default {
         </template>
       </Tab>
 
-      <Tab name="policy-metrics" label="Metrics" :weight="98">
+      <Tab name="policy-reporter" label="Policy Reporter" :weight="98">
+        <PolicyReporter :value="value" />
+      </Tab>
+
+      <Tab name="policy-metrics" label="Metrics" :weight="97">
         <MetricsBanner
           v-if="!monitoringStatus.installed || !metricsService"
           :metrics-service="metricsService"
@@ -269,7 +274,7 @@ export default {
         </template>
       </Tab>
 
-      <Tab name="policy-tracing" label="Tracing" :weight="97">
+      <Tab name="policy-tracing" label="Tracing" :weight="96">
         <template>
           <TraceTable :rows="filteredValidations">
             <template #traceBanner>

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -258,6 +258,7 @@ kubewarden:
       label: Context Aware
       tooltip: Can determine whether an AdmissionRequest has to be accepted or rejected based on other resources already deployed in the cluster.
   policyReporter:
+    title: Policy Reporter
     link: Policy Reporter UI
     service:
       banner:

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -52,7 +52,7 @@ kubewarden:
         stepProgress: The active step will progress once Cert-Manager is installed.
       repository:
         title: Repository
-        description: You will need the Kubewarden helm repository (https://charts.kubewarden.io) to install the `kubewarden` chart.
+        description: You will need the Kubewarden Helm repository (https://charts.kubewarden.io) to install the `kubewarden` chart.
       airGapped:
         warning: "An air-gapped installation has been detected, this will require intervention to enable access to Kubewarden images and policies. It is necessary to make them available from an OCI registry that is accessible to the cluster."
         docs: |
@@ -257,6 +257,22 @@ kubewarden:
     contextAware: 
       label: Context Aware
       tooltip: Can determine whether an AdmissionRequest has to be accepted or rejected based on other resources already deployed in the cluster.
+  policyReporter:
+    link: Policy Reporter UI
+    service:
+      banner:
+        unavailable: The Policy Reporter service is unavailable, follow the instructions to install the Policy Reporter chart.
+    url:
+      banner:
+        unavailable: The Policy Reporter UI proxy URL is unavailble, please ensure that the UI is properly configured.
+    install:
+      airGapped:
+        warning: "An air-gapped installation has been detected, this will require intervention to install the Policy Reporter UI. It is necessary to make the charts available from an OCI registry that is accessible to the cluster."
+      repo:
+        title: Policy Reporter Repository
+        description: You will need to add the Policy Reporter Helm (https://kyverno.github.io/policy-reporter) to install the `policy-reporter` chart.
+      chart:
+        title: Install Policy Reporter Chart
 
 asyncButton:
   artifactHub:
@@ -275,3 +291,11 @@ asyncButton:
     action: Add Grafana Dashboard
     success: Added
     wating: Adding&hellip;
+  policyReporterRepo:
+    action: Add Policy Reporter Repository
+    success: Added
+    waiting: Adding&hellip;
+  policyReporterChart:
+    action: Install Policy Reporter Chart
+    success: Installed
+    waiting: Installing&hellip;

--- a/pkg/kubewarden/pages/c/_cluster/kubewarden/_resource/policy-reporter.vue
+++ b/pkg/kubewarden/pages/c/_cluster/kubewarden/_resource/policy-reporter.vue
@@ -1,0 +1,12 @@
+<script lang="ts">
+import PolicyReporter from '../../../../../components/PolicyReporter/index.vue';
+
+export default {
+  name:       'KubewardenResourcedList',
+  components: { PolicyReporter },
+};
+</script>
+
+<template>
+  <PolicyReporter />
+</template>

--- a/pkg/kubewarden/plugins/kubewarden-class.js
+++ b/pkg/kubewarden/plugins/kubewarden-class.js
@@ -261,52 +261,6 @@ export default class KubewardenModel extends SteveModel {
     return out;
   }
 
-  get policyReporterService() {
-    return async() => {
-      try {
-        const services = await this.$dispatch('cluster/findMatching', {
-          type:     SERVICE,
-          selector: 'app.kubernetes.io/part-of=policy-reporter'
-        }, { root: true });
-
-        if ( !isEmpty(services) ) {
-          return services.find(s => s.metadata?.labels?.['app.kubernetes.io/name'] === 'ui');
-        }
-      } catch (e) {
-        const error = e.data || e;
-
-        this.$dispatch('growl/error', {
-          title:   error._statusText,
-          message: error.message,
-          timeout: 3000,
-        }, { root: true });
-      }
-    };
-  }
-
-  get policyReporterProxy() {
-    return async() => {
-      try {
-        const service = await this.policyReporterService();
-
-        if ( service ) {
-          const base = `/api/v1/namespaces/${ service.metadata?.namespace }/services/`;
-          const proxy = `http:${ service.metadata?.name }:${ service.spec?.ports?.[0].port }/proxy`;
-
-          return base + proxy;
-        }
-      } catch (e) {
-        const error = e.data || e;
-
-        this.$dispatch('growl/error', {
-          title:   error._statusText,
-          message: error.message,
-          timeout: 3000,
-        }, { root: true });
-      }
-    };
-  }
-
   get openTelemetryService() {
     return async() => {
       try {

--- a/pkg/kubewarden/plugins/kubewarden-class.js
+++ b/pkg/kubewarden/plugins/kubewarden-class.js
@@ -1,5 +1,6 @@
 import filter from 'lodash/filter';
 import matches from 'lodash/matches';
+import isEmpty from 'lodash/isEmpty';
 
 import SteveModel from '@shell/plugins/steve/steve-class';
 import {
@@ -7,7 +8,7 @@ import {
   STATES_ENUM,
 } from '@shell/plugins/dashboard-store/resource-class';
 import { CONFIG_MAP, MANAGEMENT, SERVICE } from '@shell/config/types';
-import { findBy, isArray } from '@shell/utils/array';
+import { isArray } from '@shell/utils/array';
 import { addParams } from '@shell/utils/url';
 
 import {
@@ -26,6 +27,11 @@ import policyDashboard from '../assets/kubewarden-metrics-policy.json';
 export default class KubewardenModel extends SteveModel {
   async allServices() {
     const inStore = this.$rootGetters['currentProduct'].inStore;
+    const services = this.$rootGetters[`${ inStore }/all`](SERVICE);
+
+    if ( !isEmpty(services) ) {
+      return services;
+    }
 
     return await this.$dispatch(
       `${ inStore }/findAll`,
@@ -103,9 +109,10 @@ export default class KubewardenModel extends SteveModel {
   get certManagerService() {
     return async() => {
       try {
-        const all = await this.allServices();
-
-        return all.find(s => s.metadata?.labels?.['app'] === 'cert-manager');
+        return await this.$dispatch('cluster/findMatch', {
+          type:     SERVICE,
+          selector: 'app.kubernetes.io/instance=cert-manager'
+        }, { root: true });
       } catch (e) {
         console.warn(`Error fetching cert-manager service: ${ e }`); // eslint-disable-line no-console
       }
@@ -117,17 +124,10 @@ export default class KubewardenModel extends SteveModel {
   get grafanaService() {
     return async() => {
       try {
-        const services = await this.allServices();
-
-        if (services) {
-          const grafana = findBy(
-            services,
-            'id',
-            'cattle-monitoring-system/rancher-monitoring-grafana'
-          );
-
-          return grafana;
-        }
+        return await this.$dispatch('cluster/find', {
+          type: SERVICE,
+          id:   'cattle-monitoring-system/rancher-monitoring-grafana'
+        }, { root: true });
       } catch (e) {
         console.warn(`Error getting Grafana service: ${ e }`); // eslint-disable-line no-console
       }
@@ -136,19 +136,16 @@ export default class KubewardenModel extends SteveModel {
 
   get grafanaProxy() {
     return async(type) => {
-      const dashboardName =
-        type === METRICS_DASHBOARD.POLICY_SERVER ? 'kubewarden-policy-server' : 'kubewarden-policy';
+      const dashboardName = type === METRICS_DASHBOARD.POLICY_SERVER ? 'kubewarden-policy-server' : 'kubewarden-policy';
 
       try {
         const grafana = await this.grafanaService();
 
-        if (grafana) {
+        if ( !isEmpty(grafana) ) {
           const base = `/api/v1/namespaces/${ grafana.metadata.namespace }/services/http:${ grafana.metadata.name }:80/proxy`;
           const path = `/d/${ type }/${ dashboardName }?orgId=1&kiosk`;
 
-          const out = base + path;
-
-          return out;
+          return base + path;
         }
       } catch (e) {
         console.warn(`Error fetching Grafana proxy: ${ e }`); // eslint-disable-line no-console
@@ -158,23 +155,32 @@ export default class KubewardenModel extends SteveModel {
     };
   }
 
-  get jaegerService() {
+  get grafanaDashboard() {
     return async() => {
       try {
-        const services = await this.allServices();
+        return await this.$dispatch('cluster/findMatching', {
+          type:     CONFIG_MAP,
+          selector: `kubewarden/part-of=cattle-kubewarden-system`
+        }, { root: true });
+      } catch (e) {
+        console.warn(`Error fetching grafana dashboard configMap: ${ e }`); // eslint-disable-line no-console
+      }
+    };
+  }
 
-        if (services) {
-          return services.find((s) => {
-            const found =
-              s.metadata?.labels?.['app'] === 'jaeger' &&
-              s.metadata?.labels?.['app.kubernetes.io/component'] ===
-                'service-query';
+  get jaegerQueryService() {
+    return async() => {
+      try {
+        const services = await this.$dispatch('cluster/findMatching', {
+          type:     SERVICE,
+          selector: 'app.kubernetes.io/part-of=jaeger'
+        }, { root: true });
 
-            if (found) {
-              return s;
-            }
-          });
+        if ( !isEmpty(services) ) {
+          return services.find(s => s.metadata?.labels?.['app.kubernetes.io/component'] === 'service-query');
         }
+
+        return null;
       } catch (e) {
         console.warn(`Error fetching services: ${ e }`); // eslint-disable-line no-console
       }
@@ -255,20 +261,59 @@ export default class KubewardenModel extends SteveModel {
     return out;
   }
 
+  get policyReporterService() {
+    return async() => {
+      try {
+        const services = await this.$dispatch('cluster/findMatching', {
+          type:     SERVICE,
+          selector: 'app.kubernetes.io/part-of=policy-reporter'
+        }, { root: true });
+
+        if ( !isEmpty(services) ) {
+          return services.find(s => s.metadata?.labels?.['app.kubernetes.io/name'] === 'ui');
+        }
+      } catch (e) {
+        const error = e.data || e;
+
+        this.$dispatch('growl/error', {
+          title:   error._statusText,
+          message: error.message,
+          timeout: 3000,
+        }, { root: true });
+      }
+    };
+  }
+
+  get policyReporterProxy() {
+    return async() => {
+      try {
+        const service = await this.policyReporterService();
+
+        if ( service ) {
+          const base = `/api/v1/namespaces/${ service.metadata?.namespace }/services/`;
+          const proxy = `http:${ service.metadata?.name }:${ service.spec?.ports?.[0].port }/proxy`;
+
+          return base + proxy;
+        }
+      } catch (e) {
+        const error = e.data || e;
+
+        this.$dispatch('growl/error', {
+          title:   error._statusText,
+          message: error.message,
+          timeout: 3000,
+        }, { root: true });
+      }
+    };
+  }
+
   get openTelemetryService() {
     return async() => {
       try {
-        const services = await this.allServices();
-
-        if (services) {
-          return services.find((s) => {
-            const found = s.metadata?.labels?.['app.kubernetes.io/name'] === 'opentelemetry-operator';
-
-            if ( found ) {
-              return s;
-            }
-          });
-        }
+        return await this.$dispatch('cluster/findMatching', {
+          type:     SERVICE,
+          selector: 'app.kubernetes.io/name=opentelemetry-operator'
+        }, { root: true });
       } catch (e) {
         console.warn(`Error fetching opentelemetry service: ${ e }`); // eslint-disable-line no-console
       }
@@ -332,7 +377,13 @@ export default class KubewardenModel extends SteveModel {
     try {
       await configMapTemplate.save();
     } catch (e) {
-      console.warn(`Error creating dashboard configmap: ${ e }`); // eslint-disable-line no-console
+      const error = e.data || e;
+
+      this.$dispatch('growl/error', {
+        title:   error._statusText,
+        message: error.message,
+        timeout: 3000,
+      }, { root: true });
     }
   }
 

--- a/pkg/kubewarden/routes/kubewarden-routes.ts
+++ b/pkg/kubewarden/routes/kubewarden-routes.ts
@@ -1,6 +1,7 @@
-import { KUBEWARDEN_PRODUCT_NAME } from '../types';
+import { KUBEWARDEN_PRODUCT_NAME, POLICY_REPORTER_PRODUCT } from '../types';
 
 import Dashboard from '../pages/c/_cluster/kubewarden/index.vue';
+import PolicyReport from '../pages/c/_cluster/kubewarden/_resource/policy-reporter.vue';
 import KubewardenResourcedList from '../pages/c/_cluster/kubewarden/_resource/index.vue';
 import CreateKubewardenResource from '../pages/c/_cluster/kubewarden/_resource/create.vue';
 import ViewKubewardenResource from '../pages/c/_cluster/kubewarden/_resource/_id.vue';
@@ -11,6 +12,12 @@ const routes = [
     name:       `c-cluster-${ KUBEWARDEN_PRODUCT_NAME }`,
     path:       `/c/:cluster/${ KUBEWARDEN_PRODUCT_NAME }`,
     component:  Dashboard,
+    meta:       { product: KUBEWARDEN_PRODUCT_NAME, pkg: KUBEWARDEN_PRODUCT_NAME }
+  },
+  {
+    name:       `c-cluster-${ KUBEWARDEN_PRODUCT_NAME }-${ POLICY_REPORTER_PRODUCT }`,
+    path:       `/c/:cluster/${ KUBEWARDEN_PRODUCT_NAME }/${ POLICY_REPORTER_PRODUCT }`,
+    component:  PolicyReport,
     meta:       { product: KUBEWARDEN_PRODUCT_NAME, pkg: KUBEWARDEN_PRODUCT_NAME }
   },
   {

--- a/pkg/kubewarden/types.ts
+++ b/pkg/kubewarden/types.ts
@@ -1,3 +1,4 @@
 export * from './types/kubewarden';
 export * from './types/policy';
 export * from './types/grafana';
+export * from './types/policy-reporter';

--- a/pkg/kubewarden/types/kubewarden.ts
+++ b/pkg/kubewarden/types/kubewarden.ts
@@ -19,5 +19,7 @@ export const KUBEWARDEN_APPS = {
 export const KUBEWARDEN = {
   ADMISSION_POLICY:         'policies.kubewarden.io.admissionpolicy',
   CLUSTER_ADMISSION_POLICY: 'policies.kubewarden.io.clusteradmissionpolicy',
-  POLICY_SERVER:            'policies.kubewarden.io.policyserver'
+  POLICY_SERVER:            'policies.kubewarden.io.policyserver',
+  POLICY_REPORT:            'wgpolicyk8s.io.policyreport',
+  CLUSTER_POLICY_REPORT:    'wgpolicyk8s.io.clusterpolicyreport'
 };

--- a/pkg/kubewarden/types/policy-reporter.ts
+++ b/pkg/kubewarden/types/policy-reporter.ts
@@ -1,0 +1,3 @@
+export const POLICY_REPORTER_REPO = 'https://kyverno.github.io/policy-reporter';
+
+export const POLICY_REPORTER_CHART = 'policy-reporter';

--- a/pkg/kubewarden/types/policy-reporter.ts
+++ b/pkg/kubewarden/types/policy-reporter.ts
@@ -1,3 +1,6 @@
+export const POLICY_REPORTER_PRODUCT = 'policy-reporter';
+export const POLICY_REPORTER_RESOURCE = 'PolicyReporter';
+
 export const POLICY_REPORTER_REPO = 'https://kyverno.github.io/policy-reporter';
 
 export const POLICY_REPORTER_CHART = 'policy-reporter';

--- a/tests/unit/components/MetricsBanner.spec.ts
+++ b/tests/unit/components/MetricsBanner.spec.ts
@@ -24,7 +24,6 @@ describe('component: MetricsBanner', () => {
           getters: {
             currentProduct:         () => 'current_product',
             monitoringChart:        () => null,
-            metricsDashboard:       () => null,
             'current_product/all':  jest.fn(),
             'i18n/t':               jest.fn()
           },
@@ -53,7 +52,6 @@ describe('component: MetricsBanner', () => {
           getters: {
             currentProduct:         () => 'current_product',
             monitoringChart:        () => null,
-            metricsDashboard:       () => null,
             'current_product/all':  jest.fn(),
             'cluster/matching':     jest.fn(),
             'i18n/t':               jest.fn()
@@ -82,7 +80,6 @@ describe('component: MetricsBanner', () => {
           getters: {
             currentProduct:         () => 'current_product',
             monitoringChart:        () => null,
-            metricsDashboard:       () => null,
             'current_product/all':  jest.fn(),
             'cluster/matching':     jest.fn(),
             'i18n/t':               jest.fn()
@@ -105,8 +102,7 @@ describe('component: MetricsBanner', () => {
       computed:  {
         monitoringStatus: () => {
           return { installed: true };
-        },
-        metricsDashboard: () => true
+        }
       },
       mocks:     {
         $fetchState: { pending: false },
@@ -114,9 +110,7 @@ describe('component: MetricsBanner', () => {
           getters: {
             currentProduct:         () => 'current_product',
             monitoringChart:        () => null,
-            metricsDashboard:       () => null,
             'current_product/all':  jest.fn(),
-            'cluster/matching':     jest.fn(),
             'i18n/t':               jest.fn()
           },
         }
@@ -126,36 +120,6 @@ describe('component: MetricsBanner', () => {
     const banner = wrapper.findComponent(Banner);
 
     expect(banner.exists()).toBe(true);
-    expect(banner.html().includes('%kubewarden.metrics.noService%')).toBe(true);
-  });
-
-  it('warning banner displays when metrics is installed and service is falsy', () => {
-    const wrapper = shallowMount(MetricsBanner as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
-      propsData: { metricsType: METRICS_DASHBOARD.POLICY_SERVER },
-      computed:  {
-        monitoringStatus: () => {
-          return { installed: true };
-        },
-        metricsDashboard: () => true
-      },
-      mocks:     {
-        $fetchState: { pending: false },
-        $store:      {
-          getters: {
-            currentProduct:         () => 'current_product',
-            monitoringChart:        () => null,
-            metricsDashboard:       () => null,
-            'current_product/all':  jest.fn(),
-            'cluster/matching':     jest.fn(),
-            'i18n/t':               jest.fn()
-          },
-        }
-      },
-    });
-
-    const banner = wrapper.findComponent(Banner);
-
-    expect(banner.exists()).toBe(true);
-    expect(banner.html().includes('%kubewarden.metrics.noService%')).toBe(true);
+    expect(banner.html().includes('%kubewarden.metrics.notInstalled%')).toBe(true);
   });
 });


### PR DESCRIPTION
fix #447 

This is the initial iteration of adding the Policy Reporter as a tab within the Policy Server page. For the sake of simplicity, the flow of installing the reporter is:
- Add the policy reporter repository: `https://kyverno.github.io/policy-reporter`
- Install the reporter chart

This could be improved but will leave up to further discussion.


https://github.com/rancher/kubewarden-ui/assets/40806497/6dabcc6f-9682-48c6-90b5-2d6b41aea35c

