### PR TITLE
Fix provider options to filter for organization and user_alias

### DIFF
--- a/pkg/kubewarden/components/Policies/PolicyGrid.vue
+++ b/pkg/kubewarden/components/Policies/PolicyGrid.vue
@@ -36,10 +36,10 @@ export default {
     return {
       KUBEWARDEN_PRODUCT_NAME,
 
-      category:    null,
-      keywords:    [],
-      provider:    null,
-      searchQuery: null
+      category:     null,
+      keywords:     [],
+      organization:    null,
+      searchQuery:  null
     };
   },
 
@@ -72,9 +72,11 @@ export default {
           }
         }
 
-        if ( this.provider ) {
-          for ( const p of this.provider ) {
-            if ( !subtype.provider || !subtype.provider?.includes(p) ) {
+        if ( this.organization ) {
+          for ( const org of this.organization ) {
+            const name = subtype.repository?.organization_display_name || subtype.repository?.user_alias;
+
+            if ( !name || name !== org ) {
               return false;
             }
           }
@@ -100,9 +102,11 @@ export default {
       return [...new Set(flattened.filter(Boolean))];
     },
 
-    providerOptions() {
+    organizationOptions() {
       const out = this.value?.flatMap((subtype) => {
-        return subtype.provider ? subtype.provider : [];
+        const name = subtype.repository?.organization_display_name || subtype.repository?.user_alias;
+
+        return name || [];
       });
 
       if ( !out || out?.length === 0 ) {
@@ -142,7 +146,7 @@ export default {
       }
 
       return [...new Set(out.filter(Boolean))];
-    },
+    }
   },
 
   methods: {
@@ -153,7 +157,7 @@ export default {
     refresh() {
       this.category = null;
       this.keywords = [];
-      this.provider = null;
+      this.organization = null;
       this.searchQuery = null;
     },
 
@@ -171,6 +175,10 @@ export default {
       return type === '*' ? 'Global' : type;
     },
 
+    showOfficialBadge(subtype) {
+      return subtype?.repository?.organization_name?.toLowerCase() === KUBEWARDEN_PRODUCT_NAME;
+    },
+
     subtypeSignature(subtype) {
       return subtype.signatures?.[0] || 'unknown';
     }
@@ -184,16 +192,16 @@ export default {
   >
     <div class="filter">
       <LabeledSelect
-        v-if="providerOptions.length"
-        v-model="provider"
-        data-testid="kw-grid-filter-provider"
+        v-if="organizationOptions.length"
+        v-model="organization"
+        data-testid="kw-grid-filter-organization"
         :clearable="true"
         :taggable="true"
         :mode="mode"
         :multiple="true"
-        class="filter__provider"
-        :label="t('kubewarden.utils.provider')"
-        :options="providerOptions"
+        class="filter__organization"
+        :label="t('kubewarden.utils.organization')"
+        :options="organizationOptions"
       />
 
       <LabeledSelect
@@ -262,7 +270,7 @@ export default {
               </span>
             </div>
 
-            <div v-if="subtype.provider === KUBEWARDEN_PRODUCT_NAME" class="subtype__icon">
+            <div v-if="showOfficialBadge(subtype)" class="subtype__icon">
               <img
                 v-clean-tooltip="t('kubewarden.policies.official')"
                 src="../../assets/icon-kubewarden.svg"

--- a/pkg/kubewarden/components/Policies/PolicyGrid.vue
+++ b/pkg/kubewarden/components/Policies/PolicyGrid.vue
@@ -1,4 +1,6 @@
 <script>
+import isEmpty from 'lodash/isEmpty';
+
 import { _CREATE, CATEGORY, SEARCH_QUERY } from '@shell/config/query-params';
 import { ensureRegex } from '@shell/utils/string';
 import { sortBy } from '@shell/utils/sort';
@@ -38,9 +40,21 @@ export default {
 
       category:     null,
       keywords:     [],
-      organization:    null,
+      organization: [],
       searchQuery:  null
     };
+  },
+
+  beforeMount() {
+    if ( !isEmpty(this.value) ) {
+      const officialExists = this.value.find(subtype => this.isOfficial(subtype));
+
+      this.$nextTick(() => {
+        if ( officialExists && officialExists.repository?.organization_display_name ) {
+          this.organization.push(officialExists.repository.organization_display_name);
+        }
+      });
+    }
   },
 
   computed: {
@@ -175,7 +189,7 @@ export default {
       return type === '*' ? 'Global' : type;
     },
 
-    showOfficialBadge(subtype) {
+    isOfficial(subtype) {
       return subtype?.repository?.organization_name?.toLowerCase() === KUBEWARDEN_PRODUCT_NAME;
     },
 
@@ -270,7 +284,7 @@ export default {
               </span>
             </div>
 
-            <div v-if="showOfficialBadge(subtype)" class="subtype__icon">
+            <div v-if="isOfficial(subtype)" class="subtype__icon">
               <img
                 v-clean-tooltip="t('kubewarden.policies.official')"
                 src="../../assets/icon-kubewarden.svg"

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -129,7 +129,7 @@ kubewarden:
       banner: "An air-gapped installation is detected, you will be unable to use the policies listed within the ArtifactHub catalog. You are still able to deploy a custom policy by referencing a WebAssembly module that is accessible to this cluster."
   utils:
     keyword: Filter by Keyword
-    provider: Filter by Provider
+    organization: Filter by Organization
     resource: Filter by Resource Type
     resetFilter: Reset Filter
   tracing:

--- a/tests/unit/components/Policies/PolicyGrid.spec.ts
+++ b/tests/unit/components/Policies/PolicyGrid.spec.ts
@@ -36,7 +36,7 @@ describe('component: General', () => {
     expect(wrapper.html()).toContain('Allow Privilege Escalation PSP');
   });
 
-  it('should render correct provider options in LabeledSelect', () => {
+  it('should render correct organization options in LabeledSelect', () => {
     const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
       propsData:  { targetNamespace: 'default', value: policyPackages },
       directives: { tooltip: jest.fn() },
@@ -45,10 +45,10 @@ describe('component: General', () => {
 
     const selects = wrapper.findAllComponents(LabeledSelect);
 
-    expect(selects.at(0).props().options).toStrictEqual(['kubewarden', 'evil'] as String[]);
+    expect(selects.at(0).props().options).toStrictEqual(['Kubewarden Developers', 'evil'] as String[]);
   });
 
-  it('filters shown cards by provider when selected', async() => {
+  it('filters shown cards by organization when selected', async() => {
     const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
       propsData:  { targetNamespace: 'default', value: policyPackages },
       directives: { tooltip: jest.fn() },
@@ -59,7 +59,7 @@ describe('component: General', () => {
     expect(wrapper.html()).toContain('Signed Test Policy');
     expect(wrapper.html()).toContain('Test Policy 2');
 
-    await wrapper.setData({ provider: ['evil'] });
+    await wrapper.setData({ organization: ['evil'] });
 
     expect(wrapper.html()).not.toContain('Allow Privilege Escalation PSP');
     expect(wrapper.html()).toContain('Test Policy 2');

--- a/tests/unit/templates/policyPackages.js
+++ b/tests/unit/templates/policyPackages.js
@@ -7,14 +7,14 @@ export default [
     data:         { 'kubewarden/resources': 'Deployment,Replicaset,Statefulset,Daemonset,Replicationcontroller,Job,Cronjob,Pod' },
     signed:       true,
     signatures:   ['cosign'],
-    provider:     'kubewarden'
+    repository:   { organization_display_name: 'Kubewarden Developers' }
   },
   {
     name:         'signed-test-policy',
     display_name: 'Signed Test Policy',
     description:  'A signed test policy with no signatures',
     signed:       true,
-    provider:     'evil'
+    repository:   { user_alias: 'evil' }
   },
   {
     name:         'test-policy',
@@ -27,6 +27,6 @@ export default [
     description:  'A test policy with less info',
     data:         { 'kubewarden/resources': 'Daemonset' },
     keywords:     ['PSP'],
-    provider:     'evil'
+    repository:   { user_alias: 'evil' }
   }
 ];


### PR DESCRIPTION
Fix #451 

This fixes the `provider` filter to instead filter by `organization`, as a user can copy a Kubewarden policy and re-upload the package to ArtifactHub with the same `provider` information.
Now the filter will first search for an `organization_name` - if it matches `kubewarden` the policy card will display the official badge. If the `organization_display_name` does not exist, it will default to the `user_alias` - in this case the two extra packages for `Environment Variable Policy` are displayed without the badge and can filtered correctly.

https://github.com/rancher/kubewarden-ui/assets/40806497/3a78998d-d797-4ee5-ae07-972376526121

