### PR TITLE
Fix rc repository url after transfer to rancher org

### DIFF
--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -43,7 +43,7 @@ test('02 Install extension', async({ page }) => {
   // Add UI charts repository
   if (ORIGIN == 'rc') {
     const rancher = new RancherCommonPage(page);
-    await rancher.addRepository('kubewarden-extension-rc', 'https://kubewarden.github.io/ui');
+    await rancher.addRepository('kubewarden-extension-rc', 'https://rancher.github.io/kubewarden-ui/');
   }
 
   // Install or developer load extension


### PR DESCRIPTION
Original repository is not available anymore.