### PR TITLE
Add banner for schema condition in policy reporter

### DIFF
--- a/pkg/kubewarden/components/Dashboard/InstallView.vue
+++ b/pkg/kubewarden/components/Dashboard/InstallView.vue
@@ -13,7 +13,7 @@ import Loading from '@shell/components/Loading';
 
 import { KUBEWARDEN_CHARTS, KUBEWARDEN_REPO } from '../../types';
 import { getLatestStableVersion } from '../../plugins/kubewarden-class';
-import { handleGrowlError } from '../../utils/handle-growl';
+import { handleGrowl } from '../../utils/handle-growl';
 
 import InstallWizard from '../InstallWizard';
 
@@ -137,7 +137,7 @@ export default {
         this.installSteps[0].ready = true;
         this.$refs.wizard.next();
       } catch (e) {
-        handleGrowlError({ error: e, store: this.$store });
+        handleGrowl({ error: e, store: this.$store });
         btnCb(false);
       }
     },
@@ -153,7 +153,7 @@ export default {
         try {
           await repoObj.save();
         } catch (e) {
-          handleGrowlError({ error: e, store: this.$store });
+          handleGrowl({ error: e, store: this.$store });
           btnCb(false);
 
           return;
@@ -162,7 +162,7 @@ export default {
         await this.refreshCharts();
         btnCb(true);
       } catch (e) {
-        handleGrowlError({ error: e, store: this.$store });
+        handleGrowl({ error: e, store: this.$store });
         btnCb(false);
       }
     },
@@ -171,7 +171,7 @@ export default {
       try {
         await this.$store.dispatch('catalog/load', { force: true, reset: true });
       } catch (e) {
-        handleGrowlError({ error: e, store: this.$store });
+        handleGrowl({ error: e, store: this.$store });
       }
 
       if ( !this.controllerChart && retry === 0 ) {
@@ -189,7 +189,7 @@ export default {
         try {
           await this.refreshCharts();
         } catch (e) {
-          handleGrowlError({ error: e, store: this.$store });
+          handleGrowl({ error: e, store: this.$store });
 
           return;
         }
@@ -219,7 +219,7 @@ export default {
           message:     this.t('kubewarden.dashboard.appInstall.versionError.message')
         };
 
-        handleGrowlError({ error, store: this.$store });
+        handleGrowl({ error, store: this.$store });
       }
     },
 

--- a/pkg/kubewarden/components/DefaultsBanner.vue
+++ b/pkg/kubewarden/components/DefaultsBanner.vue
@@ -9,7 +9,7 @@ import { Banner } from '@components/Banner';
 
 import { KUBEWARDEN_CHARTS } from '../types';
 import { getLatestStableVersion } from '../plugins/kubewarden-class';
-import { handleGrowlError } from '../utils/handle-growl';
+import { handleGrowl } from '../utils/handle-growl';
 
 export default {
   components: { Banner },
@@ -37,7 +37,7 @@ export default {
       try {
         await this.$store.dispatch('catalog/load', { force: true, reset: true });
       } catch (e) {
-        handleGrowlError({ error: e, store: this.$store });
+        handleGrowl({ error: e, store: this.$store });
       }
 
       if ( !this.defaultsChart && retry === 0 ) {
@@ -51,7 +51,7 @@ export default {
         try {
           await this.refreshCharts();
         } catch (e) {
-          handleGrowlError({ error: e, store: this.$store });
+          handleGrowl({ error: e, store: this.$store });
 
           return;
         }
@@ -81,7 +81,7 @@ export default {
           message:     this.t('kubewarden.dashboard.appInstall.versionError.message')
         };
 
-        handleGrowlError({ error, store: this.$store });
+        handleGrowl({ error, store: this.$store });
       }
     }
   }

--- a/pkg/kubewarden/components/Policies/Create.vue
+++ b/pkg/kubewarden/components/Policies/Create.vue
@@ -23,7 +23,7 @@ import {
   DEFAULT_POLICY
 } from '../../types';
 import { removeEmptyAttrs } from '../../utils/object';
-import { handleGrowlError } from '../../utils/handle-growl';
+import { handleGrowl } from '../../utils/handle-growl';
 
 import PolicyGrid from './PolicyGrid';
 import Values from './Values';
@@ -246,7 +246,7 @@ export default ({
         btnCb(true);
         this.loadingPackages = false;
       } catch (e) {
-        handleGrowlError({ error: e, store: this.$store });
+        handleGrowl({ error: e, store: this.$store });
 
         btnCb(false);
         this.loadingPackages = false;
@@ -279,7 +279,7 @@ export default ({
 
         await this.save(event);
       } catch (e) {
-        handleGrowlError({ error: e, store: this.$store });
+        handleGrowl({ error: e, store: this.$store });
 
         console.error('Error creating policy', e); // eslint-disable-line no-console
       }
@@ -297,7 +297,7 @@ export default ({
 
           this.packages = packages.filter(pkg => pkg?.data?.['kubewarden/hidden-ui'] !== 'true');
         } catch (e) {
-          handleGrowlError({ error: e, store: this.$store });
+          handleGrowl({ error: e, store: this.$store });
 
           console.warn(`Error fetching packages`, e); // eslint-disable-line no-console
         }

--- a/pkg/kubewarden/components/PolicyReporter/InstallView.vue
+++ b/pkg/kubewarden/components/PolicyReporter/InstallView.vue
@@ -10,7 +10,7 @@ import AsyncButton from '@shell/components/AsyncButton';
 
 import { POLICY_REPORTER_CHART, POLICY_REPORTER_REPO } from '../../types';
 import { getLatestStableVersion } from '../../plugins/kubewarden-class';
-import { handleGrowlError } from '../../utils/handle-growl';
+import { handleGrowl } from '../../utils/handle-growl';
 
 import InstallWizard from '../InstallWizard';
 
@@ -99,7 +99,7 @@ export default {
         try {
           await repoObj.save();
         } catch (e) {
-          handleGrowlError({ error: e, store: this.$store });
+          handleGrowl({ error: e, store: this.$store });
           btnCb(false);
 
           return;
@@ -108,7 +108,7 @@ export default {
         await this.refreshCharts();
         btnCb(true);
       } catch (e) {
-        handleGrowlError({ error: e, store: this.$store });
+        handleGrowl({ error: e, store: this.$store });
         btnCb(false);
       }
     },
@@ -118,7 +118,7 @@ export default {
         try {
           await this.refreshCharts();
         } catch (e) {
-          handleGrowlError({ error: e, store: this.$store });
+          handleGrowl({ error: e, store: this.$store });
 
           return;
         }
@@ -148,7 +148,7 @@ export default {
           message:     this.t('kubewarden.dashboard.appInstall.versionError.message')
         };
 
-        handleGrowlError({ error, store: this.$store });
+        handleGrowl({ error, store: this.$store });
       }
     },
 
@@ -156,7 +156,7 @@ export default {
       try {
         await this.$store.dispatch('catalog/load', { force: true, reset: true });
       } catch (e) {
-        handleGrowlError({ error: e, store: this.$store });
+        handleGrowl({ error: e, store: this.$store });
       }
 
       if ( !this.reporterChart && retry === 0 ) {

--- a/pkg/kubewarden/detail/policies.kubewarden.io.policyserver.vue
+++ b/pkg/kubewarden/detail/policies.kubewarden.io.policyserver.vue
@@ -19,7 +19,7 @@ import Tab from '@shell/components/Tabbed/Tab';
 import { isEmpty } from 'lodash';
 import { METRICS_DASHBOARD } from '../types';
 import { RELATED_HEADERS } from '../config/table-headers';
-import { handleGrowlError } from '../utils/handle-growl';
+import { handleGrowl } from '../utils/handle-growl';
 
 import MetricsBanner from '../components/MetricsBanner';
 import TraceBanner from '../components/TraceBanner';
@@ -167,7 +167,7 @@ export default {
 
         this.reloadRequired = true;
       } catch (e) {
-        handleGrowlError({ error: e, store: this.$store });
+        handleGrowl({ error: e, store: this.$store });
 
         btnCb(false);
       }

--- a/pkg/kubewarden/edit/policies.kubewarden.io.admissionpolicy.vue
+++ b/pkg/kubewarden/edit/policies.kubewarden.io.admissionpolicy.vue
@@ -4,7 +4,7 @@ import CreateEditView from '@shell/mixins/create-edit-view';
 
 import CruResource from '@shell/components/CruResource';
 import { removeEmptyAttrs } from '../utils/object';
-import { handleGrowlError } from '../utils/handle-growl';
+import { handleGrowl } from '../utils/handle-growl';
 
 import Config from '../components/Policies/Config';
 import Create from '../components/Policies/Create';
@@ -52,7 +52,7 @@ export default {
 
         await this.save(event);
       } catch (e) {
-        handleGrowlError({ error: e, store: this.$store });
+        handleGrowl({ error: e, store: this.$store });
       }
     },
   }

--- a/pkg/kubewarden/edit/policies.kubewarden.io.clusteradmissionpolicy.vue
+++ b/pkg/kubewarden/edit/policies.kubewarden.io.clusteradmissionpolicy.vue
@@ -4,7 +4,7 @@ import CreateEditView from '@shell/mixins/create-edit-view';
 
 import CruResource from '@shell/components/CruResource';
 import { removeEmptyAttrs } from '../utils/object';
-import { handleGrowlError } from '../utils/handle-growl';
+import { handleGrowl } from '../utils/handle-growl';
 
 import Config from '../components/Policies/Config';
 import Create from '../components/Policies/Create';
@@ -52,7 +52,7 @@ export default {
 
         await this.save(event);
       } catch (e) {
-        handleGrowlError({ error: e, store: this.$store });
+        handleGrowl({ error: e, store: this.$store });
       }
     },
   }

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -260,6 +260,9 @@ kubewarden:
   policyReporter:
     title: Policy Reporter
     link: Policy Reporter UI
+    noSchema:
+      banner: Kubewarden has not been installed, this will need to be accomplished before installing the Policy Reporter
+      link: Install Kubewarden
     service:
       banner:
         unavailable: The Policy Reporter service is unavailable, follow the instructions to install the Policy Reporter chart.

--- a/pkg/kubewarden/package.json
+++ b/pkg/kubewarden/package.json
@@ -4,7 +4,12 @@
   "icon": "https://raw.githubusercontent.com/kubewarden/ui/main/pkg/kubewarden/assets/icon-kubewarden.svg",
   "version": "1.2.0-rc1",
   "private": false,
-  "rancher": true,
+  "rancher": {
+    "annotations": {
+      "catalog.cattle.io/kube-version": ">= v1.16.0-0 < v1.29.0-0",
+      "catalog.cattle.io/rancher-version": ">= 2.7.5-0"
+    }
+  },
   "scripts": {
     "dev": "./node_modules/.bin/nuxt dev",
     "nuxt": "./node_modules/.bin/nuxt"

--- a/pkg/kubewarden/utils/determine-airgap.ts
+++ b/pkg/kubewarden/utils/determine-airgap.ts
@@ -1,7 +1,7 @@
 import isEmpty from 'lodash/isEmpty';
 import { MANAGEMENT } from '@shell/config/types';
 
-import { handleGrowlError } from './handle-growl';
+import { handleGrowl } from './handle-growl';
 
 interface AirgapConfig {
   store: any
@@ -42,11 +42,13 @@ export async function isAirgap(context: AirgapConfig): Promise<Boolean> {
   } catch (e) {
     if ( !store.getters['kubewarden/airGapped'] ) {
       const error = {
-        _statusText: 'Error',
+        _statusText: 'Warning',
         message:     'Unable to determine management.cattle.io.settings/whitelist-domain value. Some Kubewarden UI features may be unavailable.'
       };
 
-      handleGrowlError({ error, store });
+      handleGrowl({
+        error, store, type: 'warning'
+      });
       store.dispatch('kubewarden/updateAirGapped', true);
     }
 

--- a/pkg/kubewarden/utils/handle-growl.ts
+++ b/pkg/kubewarden/utils/handle-growl.ts
@@ -7,13 +7,14 @@ interface GrowlConfig {
     _statusText: String,
     message: String
   },
-  store?: any
+  store?: any,
+  type?: String
 }
 
-export function handleGrowlError(config: GrowlConfig): void {
+export function handleGrowl(config: GrowlConfig): void {
   const error = config.error?.data || config.error;
 
-  config.store.dispatch('growl/error', {
+  config.store.dispatch(`growl/${ config.type || 'error' }`, {
     title:   error._statusText,
     message: error.message,
     timeout: 5000,


### PR DESCRIPTION
#457 

This adds a new banner within the Policy Reporter link that will warn the user if Kubewarden is not installed, and will provide a link to the installation wizard.

***Before Kubewarden Installation***
![pr2](https://github.com/rancher/kubewarden-ui/assets/40806497/a7e2662e-83eb-4505-88fc-2860f7a2170c)

***After Kubewarden Installation***
![pr3](https://github.com/rancher/kubewarden-ui/assets/40806497/98fa3b3e-c141-4c5d-b9d1-f69d50928274)


## Additional changes
- Updated the `handleGrowl` utility to allow for different types of growls to be called (i.e. error, warning, success). 
- Added annotations for the kube version and rancher version
  - `"catalog.cattle.io/kube-version": ">= v1.16.0-0 < v1.29.0-0"`
  - `"catalog.cattle.io/rancher-version": ">= 2.7.5-0"`