### PR TITLE
Bump 1.2.0-rc2

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -63,4 +63,4 @@ jobs:
 
       - name: Build and push UI image
         run: |
-          yarn publish-pkgs -cp -r ${{ env.REGISTRY }} -o ${{ github.repository_owner }} -i "kubewarden-"
+          yarn publish-pkgs -cp -r ${{ env.REGISTRY }} -o ${{ github.repository_owner }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "1.2.0-rc1",
+  "version": "1.2.0-rc2",
   "private": false,
   "scripts": {
     "build-pkg": "./node_modules/@rancher/shell/scripts/build-pkg.sh",

--- a/pkg/kubewarden/package.json
+++ b/pkg/kubewarden/package.json
@@ -2,7 +2,7 @@
   "name": "kubewarden",
   "description": "Kubewarden extension for Rancher Manager",
   "icon": "https://raw.githubusercontent.com/kubewarden/ui/main/pkg/kubewarden/assets/icon-kubewarden.svg",
-  "version": "1.2.0-rc1",
+  "version": "1.2.0-rc2",
   "private": false,
   "rancher": true,
   "scripts": {


### PR DESCRIPTION
This will release `1.2.0-rc2`.
Also fixes the Catalog image name to `kubewarden-ui` rather than `kubewarden-kubewarden-ui`