### PR TITLE
Publish 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "1.2.0-rc2",
+  "version": "1.2.0",
   "private": false,
   "scripts": {
     "build-pkg": "./node_modules/@rancher/shell/scripts/build-pkg.sh",

--- a/pkg/kubewarden/package.json
+++ b/pkg/kubewarden/package.json
@@ -2,7 +2,7 @@
   "name": "kubewarden",
   "description": "Kubewarden extension for Rancher Manager",
   "icon": "https://raw.githubusercontent.com/kubewarden/ui/main/pkg/kubewarden/assets/icon-kubewarden.svg",
-  "version": "1.2.0-rc2",
+  "version": "1.2.0",
   "private": false,
   "rancher": true,
   "scripts": {


### PR DESCRIPTION
# Release `1.2.0`

## Summary

The repository has been migrated from `kubewarden/ui` to `rancher/kubewarden-ui`. With this, endpoints for the charts and e2e tests needed to be updated to target the new repository.

## Enhancements
-#435
- #449

## Bug Fixes
- #452

## E2E
- #429
- #438
- #437

## Docs
- #431

## Dependency Updates

- #443