### PR TITLE
Add workaround for failing nightly test

### DIFF
--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -104,5 +104,7 @@ test('05 Whitelist artifacthub', async({ page }) => {
 
   await kwPage.whitelistArtifacthub();
   await expect(page.getByRole('heading', { name: 'Pod Privileged Policy' })).toBeVisible();
+
+  test.fail(ORIGIN === 'released', 'Expect failure until 1.2.0 is released - https://github.com/rancher/kubewarden-ui/issues/451')
   await expect(page.locator('.subtype')).toHaveCount(policyTitles.length, { timeout: 5_000 });
 });

--- a/tests/e2e/components/table-row.ts
+++ b/tests/e2e/components/table-row.ts
@@ -38,7 +38,7 @@ export class TableRow {
   }
 
   column(...names: string[]) {
-    // Generate selector from column names
+    // Transform: names > normalize-space(.)="names[0]" [or ...]
     const selector = names.map(str => `normalize-space(.)="${str}"`).join(" or ")
     // https://stackoverflow.com/questions/14745478/how-to-select-table-column-by-column-header-name-with-xpath
     return this.row.locator(`xpath=/td[count(ancestor::table[1]/thead/tr/th[${selector}]/preceding-sibling::th)+1]`)

--- a/tests/e2e/pages/rancher-extensions.page.ts
+++ b/tests/e2e/pages/rancher-extensions.page.ts
@@ -19,11 +19,17 @@ export class RancherExtensionsPage extends BasePage {
 
     // Enable extensions
     await this.page.getByRole('button', { name: 'Enable' }).click();
-    await this.ui.checkbox('Rancher Extensions Repository').setChecked(rancherRepo)
-    await this.ui.checkbox('Partners Extensions Repository').setChecked(partnersRepo)
-    await this.page.getByRole('button', { name: 'OK' }).click();
+    await expect(this.page.getByRole('heading', { name: 'Enable Extension Support?' })).toBeVisible()
 
-    // Wait for extensions to be enabled
+    // Add repositories
+    await this.ui.checkbox('Rancher Extension').setChecked(rancherRepo)
+    // New option in rancher 2.7.7
+    if (await this.ui.checkbox('Partners Extension').isVisible()) {
+      await this.ui.checkbox('Partners Extension').setChecked(partnersRepo)
+    }
+
+    // Confirm and wait for extensions to be enabled
+    await this.page.getByRole('button', { name: 'OK' }).click();
     await expect(this.tabs).toBeVisible({timeout: 60_000})
   }
 

--- a/tests/package.json
+++ b/tests/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {
-    "@playwright/test": "^1.34.3",
+    "@playwright/test": "^1.37.1",
     "@types/js-yaml": "^4.0.5",
     "@types/lodash.merge": "^4.6.7",
     "js-yaml": "^4.1.0",

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -2,13 +2,13 @@
 # yarn lockfile v1
 
 
-"@playwright/test@^1.34.3":
-  version "1.34.3"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.34.3.tgz#d9f1ac3f1a09633b5ca5351c50c308bf802bde53"
-  integrity sha512-zPLef6w9P6T/iT6XDYG3mvGOqOyb6eHaV9XtkunYs0+OzxBtrPAAaHotc0X+PJ00WPPnLfFBTl7mf45Mn8DBmw==
+"@playwright/test@^1.37.1":
+  version "1.37.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.37.1.tgz#e7f44ae0faf1be52d6360c6bbf689fd0057d9b6f"
+  integrity sha512-bq9zTli3vWJo8S3LwB91U0qDNQDpEXnw7knhxLM0nwDvexQAwx9tO8iKDZSqqneVq+URd/WIoz+BALMqUTgdSg==
   dependencies:
     "@types/node" "*"
-    playwright-core "1.34.3"
+    playwright-core "1.37.1"
   optionalDependencies:
     fsevents "2.3.2"
 
@@ -56,7 +56,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-playwright-core@1.34.3:
-  version "1.34.3"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.34.3.tgz#bc906ea1b26bb66116ce329436ee59ba2e78fe9f"
-  integrity sha512-2pWd6G7OHKemc5x1r1rp8aQcpvDh7goMBZlJv6Co5vCNLVcQJdhxRL09SGaY6HcyHH9aT4tiynZabMofVasBYw==
+playwright-core@1.37.1:
+  version "1.37.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.37.1.tgz#cb517d52e2e8cb4fa71957639f1cd105d1683126"
+  integrity sha512-17EuQxlSIYCmEMwzMqusJ2ztDgJePjrbttaefgdsiqeLWidjYz9BxXaTaZWxH1J95SHGk6tjE+dwgWILJoUZfA==


### PR DESCRIPTION
- expect failure on policy count until 1.2.0 release - [broken test](https://github.com/rancher/kubewarden-ui/actions/runs/6079438623/job/16491928187)
- rancher 2.7.6 and 2.7.7 have different extensions menu, add support for both
- upgrade playwright