### PR TITLE
Add namespace warning to reporter banner - fix release workflow

### DIFF
--- a/.github/workflows/build-extension-charts.yml
+++ b/.github/workflows/build-extension-charts.yml
@@ -5,19 +5,125 @@ on:
   release:
     types: [released]
 
+env:
+  ACTIONS_RUNNER_DEBUG: false
+  CI_COMMIT_MESSAGE: CI Build Artifacts
+
 defaults:
   run:
     shell: bash
     working-directory: ./
 
 jobs:
-  build-extension-charts:
-    uses: rancher/dashboard/.github/workflows/build-extension-charts.yml@master
+  build-extension-artifact:
+    name: Build extension artifact
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.8.0
+
+      - name: Setup yq
+        uses: chrisdickinson/setup-yq@v1.0.1
+        with:
+          yq-version: v4.34.2
+
+      - name: Setup Nodejs and npm
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Setup yarn
+        run: npm install -g yarn
+
+      - name: Setup Nodejs with yarn caching
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Parse Extension Name
+        if: github.ref_type == 'tag'
+        id: parsed-name
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          chmod +x ./node_modules/@rancher/shell/scripts/extension/parse-tag-name
+          yarn parse-tag-name ${{ inputs.tagged_release }} ${{ github.run_id }} "charts"
+
+      - name: Run build script
+        shell: bash
+        id: build_script
+        run: |
+          publish="yarn publish-pkgs -s ${{ github.repository }} -b ${{ inputs.target_branch }}"
+
+          if [[ -n "${{ inputs.tagged_release }}" ]]; then
+            publish="$publish -t ${{ inputs.tagged_release }}"
+          fi
+          
+          $publish
+
+      - name: Upload charts artifact
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v3
+        with:
+          name: charts
+          path: tmp
+
+  release:
+    name: Release Build
+    if: github.ref_type == 'tag' || (github.ref == 'refs/heads/main' && github.event_name != 'pull_request')
+    needs: build-extension-artifact
+    runs-on: ubuntu-latest
     permissions:
       actions: write
       contents: write
       deployments: write
       pages: write
-    with:
-      target_branch: gh-pages
-      tagged_release: ${{ github.ref_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: "${{ inputs.target_branch }}"
+
+      - name: Configure Git
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: charts
+
+      - name: Commit build
+        run: |
+          git add ./{assets,charts,extensions,index.yaml}
+          git commit -a -m "${{ env.CI_COMMIT_MESSAGE }}"
+          git push
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.4.1
+        with:
+          charts_dir: ./charts/*
+        env:
+          CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          CR_SKIP_EXISTING: true
+

--- a/pkg/kubewarden/components/Policies/PolicyGrid.vue
+++ b/pkg/kubewarden/components/Policies/PolicyGrid.vue
@@ -38,10 +38,10 @@ export default {
     return {
       KUBEWARDEN_PRODUCT_NAME,
 
-      category:     null,
-      keywords:     [],
-      organization: [],
-      searchQuery:  null
+      category:      null,
+      keywords:      [],
+      organizations: [],
+      searchQuery:   null
     };
   },
 
@@ -51,7 +51,7 @@ export default {
 
       this.$nextTick(() => {
         if ( officialExists && officialExists.repository?.organization_display_name ) {
-          this.organization.push(officialExists.repository.organization_display_name);
+          this.organizations.push(officialExists.repository.organization_display_name);
         }
       });
     }
@@ -86,8 +86,8 @@ export default {
           }
         }
 
-        if ( this.organization ) {
-          for ( const org of this.organization ) {
+        if ( this.organizations ) {
+          for ( const org of this.organizations ) {
             const name = subtype.repository?.organization_display_name || subtype.repository?.user_alias;
 
             if ( !name || name !== org ) {
@@ -171,7 +171,7 @@ export default {
     refresh() {
       this.category = null;
       this.keywords = [];
-      this.organization = null;
+      this.organizations = [];
       this.searchQuery = null;
     },
 
@@ -207,7 +207,7 @@ export default {
     <div class="filter">
       <LabeledSelect
         v-if="organizationOptions.length"
-        v-model="organization"
+        v-model="organizations"
         data-testid="kw-grid-filter-organization"
         :clearable="true"
         :taggable="true"

--- a/pkg/kubewarden/components/PolicyReporter/InstallView.vue
+++ b/pkg/kubewarden/components/PolicyReporter/InstallView.vue
@@ -16,6 +16,13 @@ import { handleGrowl } from '../../utils/handle-growl';
 import InstallWizard from '../InstallWizard';
 
 export default {
+  props: {
+    controllerNs: {
+      type:    String,
+      default: ''
+    }
+  },
+
   components: {
     InstallWizard, Loading, AsyncButton, Banner
   },
@@ -224,11 +231,11 @@ export default {
           <template v-else>
             <div class="step-container">
               <h3 class="mt-20 mb-10" data-testid="kw-pr-install-repo-title">
-                {{ t("kubewarden.policyReporter.install.chart.title") }}
+                {{ t('kubewarden.policyReporter.install.chart.title') }}
               </h3>
               <Banner color="warning">
                 <span class="mb-20">
-                  {{ t("kubewarden.policyReporter.install.chart.warning") }}
+                  {{ t('kubewarden.policyReporter.install.chart.warning', { ns: controllerNs }) }}
                 </span>
               </Banner>
               <AsyncButton mode="policyReporterChart" data-testid="kw-pr-install-chart-button" @click="installChart" />

--- a/pkg/kubewarden/components/PolicyReporter/index.vue
+++ b/pkg/kubewarden/components/PolicyReporter/index.vue
@@ -61,6 +61,14 @@ export default {
       return this.hasClusterPolicyReportSchema && this.hasPolicyReportSchema;
     },
 
+    controllerNamespace() {
+      if ( !isEmpty(this.controller) ) {
+        return this.controller[0].metadata?.namespace;
+      }
+
+      return null;
+    },
+
     controllerVersion() {
       if ( !isEmpty(this.controller) ) {
         return this.controller[0].metadata?.labels?.['app.kubernetes.io/version'];
@@ -162,7 +170,7 @@ export default {
             data-testid="kw-pr-main-service-unavailable-banner"
             color="warning"
           />
-          <InstallView />
+          <InstallView :controller-ns="controllerNamespace" />
         </template>
         <template v-else-if="!reporterUIService">
           <Banner

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -282,7 +282,7 @@ kubewarden:
         description: You will need to add the Policy Reporter Helm (https://kyverno.github.io/policy-reporter) to install the `policy-reporter` chart.
       chart:
         title: Install Policy Reporter Chart
-        warning: "When installing the chart ensure the property `ui.enabled` is set to `true`."
+        warning: "When installing the chart ensure the selected namespace is `{ ns }` and the property `ui.enabled` is set to `true`."
 
 asyncButton:
   artifactHub:

--- a/tests/unit/components/Policies/PolicyGrid.spec.ts
+++ b/tests/unit/components/Policies/PolicyGrid.spec.ts
@@ -59,7 +59,7 @@ describe('component: General', () => {
     expect(wrapper.html()).toContain('Signed Test Policy');
     expect(wrapper.html()).toContain('Test Policy 2');
 
-    await wrapper.setData({ organization: ['evil'] });
+    await wrapper.setData({ organizations: ['evil'] });
 
     expect(wrapper.html()).not.toContain('Allow Privilege Escalation PSP');
     expect(wrapper.html()).toContain('Test Policy 2');


### PR DESCRIPTION
- Added info to the warning banner about choosing the correct namespace during the policy reporter installation
  - Namespace is determined by the kubewarden-controller namespace
- Fixed the release workflow by modifying the reusable workflow
  - Bumping the `@rancher/shell` package to `0.3.24` will cause issues with Rancher lower than `v2.8.0` due to the side-nav restyling