### PR TITLE
Remove workaround for kubewarden-ui/issues/451

### DIFF
--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -104,7 +104,5 @@ test('05 Whitelist artifacthub', async({ page }) => {
 
   await kwPage.whitelistArtifacthub();
   await expect(page.getByRole('heading', { name: 'Pod Privileged Policy' })).toBeVisible();
-
-  test.fail(ORIGIN === 'released', 'Expect failure until 1.2.0 is released - https://github.com/rancher/kubewarden-ui/issues/451')
   await expect(page.locator('.subtype')).toHaveCount(policyTitles.length, { timeout: 5_000 });
 });

--- a/tests/e2e/pages/rancher-ui.ts
+++ b/tests/e2e/pages/rancher-ui.ts
@@ -57,7 +57,6 @@ export class RancherUI {
         await this.page.locator('#btn-kubectl').click()
         await expect(win.locator('.status').getByText('Connected', {exact: true})).toBeVisible({timeout: 30_000})
         // Run command
-        // await win.locator('.xterm-cursor').click()
         for (const cmd of commands) {
             await this.page.keyboard.type(cmd + ' || echo ERREXIT-$?')
             await this.page.keyboard.press('Enter')


### PR DESCRIPTION
1.2.0 was released, test started passing again
Fix for: https://github.com/rancher/kubewarden-ui/actions/runs/6307251121/job/17123594966