### PR TITLE
Initial Policy Reports integration - add to projects/namespaces, pods

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,6 +22,11 @@
     "yarn-error.log": true,
     "CODEOWNERS": true
   },
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/bower_components": true,
+    "**/*.code-search": true
+  },
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "1.2.1-rc3",
+  "version": "1.2.1",
   "private": false,
   "scripts": {
     "build-pkg": "./node_modules/@rancher/shell/scripts/build-pkg.sh",
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@rancher/components": "0.1.3",
-    "@rancher/shell": "0.3.23",
+    "@rancher/shell": "0.3.25",
     "@types/lodash": "4.14.196",
     "core-js": "3.21.1",
     "css-loader": "4.3.0",

--- a/pkg/kubewarden/chart/kubewarden/admission/General.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/General.vue
@@ -191,6 +191,18 @@ export default {
             :label="t('kubewarden.policyConfig.mode.warning')"
           />
         </div>
+        <div class="col span-6">
+          <RadioGroup
+            v-model="policy.spec.backgroundAudit"
+            data-testid="kw-policy-general-background-audit-input"
+            name="mode"
+            :options="[true, false]"
+            :mode="mode"
+            :label="t('kubewarden.policyConfig.backgroundAudit.label')"
+            :labels="['On', 'Off']"
+            :tooltip="t('kubewarden.policyConfig.backgroundAudit.tooltip')"
+          />
+        </div>
       </div>
     </template>
   </div>

--- a/pkg/kubewarden/components/MetricsBanner.vue
+++ b/pkg/kubewarden/components/MetricsBanner.vue
@@ -30,7 +30,7 @@ export default {
       await this.$store.dispatch('catalog/load');
     }
 
-    this.grafanaDashboard = await this.value.grafanaDashboard();
+    this.grafanaDashboard = await this.value?.grafanaDashboard();
   },
 
   data() {

--- a/pkg/kubewarden/components/PolicyReporter/ReporterPanel.vue
+++ b/pkg/kubewarden/components/PolicyReporter/ReporterPanel.vue
@@ -1,0 +1,26 @@
+<script>
+import { getPolicyReports } from '../../modules/policyReporter';
+
+/**
+ * Invisible panel to fetch PolicyReports for ResourceList
+ * views. Instead of running a fetch on each resource within
+ * the list we can fetch once at the top of the page and
+ * store the reports.
+ */
+export default {
+  async fetch() {
+    await getPolicyReports(this.$store);
+  },
+};
+</script>
+
+<template>
+  <div class="reporter-panel">
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.reporter-panel {
+  display: none;
+}
+</style>

--- a/pkg/kubewarden/components/PolicyReporter/ResourceTab.vue
+++ b/pkg/kubewarden/components/PolicyReporter/ResourceTab.vue
@@ -1,0 +1,270 @@
+<script>
+import isEmpty from 'lodash/isEmpty';
+import { NAMESPACE } from '@shell/config/query-params';
+import { allHash } from '@shell/utils/promise';
+import ResourceFetch from '@shell/mixins/resource-fetch';
+
+import { BadgeState } from '@components/BadgeState';
+import { Banner } from '@components/Banner';
+import Loading from '@shell/components/Loading';
+import SortableTable from '@shell/components/SortableTable';
+
+import { KUBEWARDEN } from '../../types';
+import { POLICY_REPORTER_HEADERS } from '../../config/table-headers';
+import { getFilteredReports, getLinkForPolicy, colorForResult, colorForSeverity } from '../../modules/policyReporter';
+
+export default {
+  props: {
+    resource: {
+      type:     Object,
+      required: true
+    }
+  },
+
+  components: {
+    BadgeState, Banner, Loading, SortableTable
+  },
+
+  mixins: [ResourceFetch],
+
+  async fetch() {
+    const fetchedReports = await getFilteredReports(this.$store, this.resource);
+
+    if ( this.isNamespaceResource ) {
+      this.reports = fetchedReports.results || [];
+    } else {
+      this.reports = fetchedReports || [];
+    }
+
+    if ( !isEmpty(this.reports) ) {
+      const hash = [
+        this.$fetchType(KUBEWARDEN.ADMISSION_POLICY),
+        this.$fetchType(KUBEWARDEN.CLUSTER_ADMISSION_POLICY)
+      ];
+
+      await allHash(hash);
+    }
+  },
+
+  data() {
+    return {
+      colorForResult,
+      headers:      POLICY_REPORTER_HEADERS,
+      reports:      null
+    };
+  },
+
+  created() {
+    if ( !this.isNamespaceResource ) {
+      this.headers = this.headers.slice(2);
+    }
+  },
+
+  computed: {
+    canGetKubewardenLinks() {
+      const capSchema = this.$store.getters['cluster/schemaFor'](KUBEWARDEN.CLUSTER_ADMISSION_POLICY);
+      const apSchema = this.$store.getters['cluster/schemaFor'](KUBEWARDEN.ADMISSION_POLICY);
+
+      if ( capSchema || apSchema ) {
+        return true;
+      }
+
+      return false;
+    },
+
+    hasNamespace() {
+      return this.resource?.metadata?.namespace;
+    },
+
+    isNamespaceResource() {
+      return this.resource?.type === NAMESPACE;
+    }
+  },
+
+  methods: {
+    getResourceValue(row, val, needsResource = false) {
+      if ( this.isNamespaceResource && needsResource && !isEmpty(row.resources) ) {
+        return row.resources[0][val] || '-';
+      }
+
+      if ( !isEmpty(row) ) {
+        return row[val] || '-';
+      }
+
+      return '-';
+    },
+
+    getPolicyLink(row) {
+      return getLinkForPolicy(this.$store, row);
+    },
+
+    severityColor(row) {
+      if ( row.result ) {
+        return colorForSeverity(row.severity);
+      }
+
+      return 'bg-muted';
+    },
+
+    statusColor(row) {
+      if ( row.result ) {
+        const color = colorForResult(row.result);
+        const bgColor = color.includes('sizzle') ? color.concat('-bg') : color.replace(/text-/, 'bg-');
+
+        return bgColor;
+      }
+
+      return 'bg-muted';
+    }
+  }
+};
+</script>
+
+<template>
+  <Loading v-if="$fetchState.pending" mode="relative" />
+  <div v-else class="pr-tab__container">
+    <SortableTable
+      v-if="reports"
+      :rows="reports"
+      :headers="headers"
+      :table-actions="false"
+      :row-actions="false"
+      key-field="uid"
+      :sub-expandable="true"
+      :sub-expand-column="true"
+      :sub-rows="true"
+      :paging="true"
+      :rows-per-page="40"
+    >
+      <!-- Namespace Resource columns -->
+      <template v-if="isNamespaceResource" #col:kind="{row}">
+        <td>{{ getResourceValue(row, 'kind', true) }}</td>
+      </template>
+      <template v-if="isNamespaceResource" #col:name="{row}">
+        <td>
+          <span>{{ getResourceValue(row, 'name', true) }}</span>
+        </td>
+      </template>
+
+      <template #col:policy="{row}">
+        <td v-if="row.policy" :class="{ 'text-bold': isNamespaceResource}">
+          <template v-if="canGetKubewardenLinks">
+            <n-link :to="getPolicyLink(row)">
+              <span>{{ row.policy }}</span>
+            </n-link>
+          </template>
+          <template v-else>
+            <span>{{ row.policy }}</span>
+          </template>
+        </td>
+      </template>
+      <template #col:rule="{row}">
+        <td class="text-bold">
+          {{ row.rule }}
+        </td>
+      </template>
+      <template #col:severity="{row}">
+        <td>
+          <BadgeState
+            :label="getResourceValue(row, 'severity')"
+            :color="severityColor(row)"
+          />
+        </td>
+      </template>
+      <template #col:status="{row}">
+        <td>
+          <BadgeState
+            :label="getResourceValue(row, 'result')"
+            :color="statusColor(row)"
+          />
+        </td>
+      </template>
+
+      <!-- Sub-rows -->
+      <template #sub-row="{row, fullColspan}">
+        <td :colspan="fullColspan" class="pr-tab__sub-row">
+          <Banner v-if="row.message" color="info" class="message">
+            <span class="text-muted">{{ t('kubewarden.policyReporter.headers.policyReportsTab.message.title') }}:</span>
+            <span>{{ row.message }}</span>
+          </Banner>
+          <div class="details">
+            <section class="col">
+              <div class="title">
+                {{ t('kubewarden.policyReporter.headers.policyReportsTab.properties.mutating') }}
+              </div>
+              <span>
+                {{ row.properties['mutating'] || '-' }}
+              </span>
+            </section>
+            <section class="col">
+              <div class="title">
+                {{ t('kubewarden.policyReporter.headers.policyReportsTab.properties.validating') }}
+              </div>
+              <span>
+                {{ row.properties['validating'] || '-' }}
+              </span>
+            </section>
+          </div>
+        </td>
+      </template>
+    </SortableTable>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+$error: #614EA2;
+
+// Need to override the default colors for these classes
+.pr-tab {
+  &__container {
+    .sizzle-warning-bg {
+      background-color: $error;
+      color: #fff;
+    }
+
+    .text-warning {
+      color: var(--warning) !important;
+    }
+
+    .text-darker {
+      color: var(--dark) !important;
+    }
+
+    .sizzle-warning {
+      color: $error;
+    }
+  }
+
+  &__sub-row {
+    background-color: var(--body-bg);
+    border-bottom: 1px solid var(--sortable-table-top-divider);
+    padding-left: 1rem;
+    padding-right: 1rem;
+
+    .message {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .details {
+      display: flex;
+      flex-direction: row;
+
+      .col {
+        display: flex;
+        flex-direction: column;
+
+        section {
+          margin-bottom: 1.5rem;
+        }
+
+        .title {
+          color: var(--muted);
+          margin-bottom: 0.5rem;
+        }
+      }
+    }
+  }
+}
+
+</style>

--- a/pkg/kubewarden/config/table-headers.ts
+++ b/pkg/kubewarden/config/table-headers.ts
@@ -253,31 +253,31 @@ export const POLICY_REPORTER_HEADERS = [
   {
     name:     'kind',
     labelKey: 'tableHeaders.subType',
-    value:    'kind'
+    value:    'kind',
+    sort:     'kind'
   },
   {
     name:     'name',
     labelKey: 'tableHeaders.name',
-    value:    'name'
+    value:    'name',
+    sort:     'name'
   },
   {
     name:     'policy',
     labelKey: 'kubewarden.policyReporter.headers.policyReportsTab.policy.label',
-    value:    'policy'
-  },
-  {
-    name:     'rule',
-    labelKey: 'kubewarden.policyReporter.headers.policyReportsTab.rule.label',
-    value:    'rule'
+    value:    'policy',
+    sort:     'policy'
   },
   {
     name:     'severity',
     labelKey: 'kubewarden.policyReporter.headers.policyReportsTab.severity.label',
-    value:    'severity'
+    value:    'severity',
+    sort:     'severity'
   },
   {
     name:     'status',
     labelKey: 'kubewarden.policyReporter.headers.policyReportsTab.status.label',
-    value:    'status'
+    value:    'status',
+    sort:     'result'
   },
 ];

--- a/pkg/kubewarden/config/table-headers.ts
+++ b/pkg/kubewarden/config/table-headers.ts
@@ -248,3 +248,36 @@ export const RULE_HEADERS = [
     sort:  'resources'
   },
 ];
+
+export const POLICY_REPORTER_HEADERS = [
+  {
+    name:     'kind',
+    labelKey: 'tableHeaders.subType',
+    value:    'kind'
+  },
+  {
+    name:     'name',
+    labelKey: 'tableHeaders.name',
+    value:    'name'
+  },
+  {
+    name:     'policy',
+    labelKey: 'kubewarden.policyReporter.headers.policyReportsTab.policy.label',
+    value:    'policy'
+  },
+  {
+    name:     'rule',
+    labelKey: 'kubewarden.policyReporter.headers.policyReportsTab.rule.label',
+    value:    'rule'
+  },
+  {
+    name:     'severity',
+    labelKey: 'kubewarden.policyReporter.headers.policyReportsTab.severity.label',
+    value:    'severity'
+  },
+  {
+    name:     'status',
+    labelKey: 'kubewarden.policyReporter.headers.policyReportsTab.status.label',
+    value:    'status'
+  },
+];

--- a/pkg/kubewarden/formatters/PolicyReportSummary.vue
+++ b/pkg/kubewarden/formatters/PolicyReportSummary.vue
@@ -1,0 +1,202 @@
+<script>
+import { mapGetters } from 'vuex';
+import isEmpty from 'lodash/isEmpty';
+import { sortBy } from '@shell/utils/sort';
+
+import { colorForResult } from '../modules/policyReporter';
+
+export default {
+  props: {
+    value: {
+      type:     Object,
+      default:  () => {}
+    }
+  },
+
+  data() {
+    return { expanded: false };
+  },
+
+  computed: {
+    ...mapGetters({ reports: 'kubewarden/policyReports' }),
+
+    canShow() {
+      if ( !isEmpty(this.summary) ) {
+        const counts = [];
+
+        for ( const obj of Object.keys(this.summary) ) {
+          if ( this.summary[obj] ) {
+            counts.push(this.summary[obj]);
+          }
+        }
+
+        return !!counts.length;
+      }
+
+      return false;
+    },
+
+    summaryParts() {
+      const out = {};
+
+      for ( const [result, value] of Object.entries(this.summary) ) {
+        const textColor = colorForResult(result);
+        const replacedTextColor = textColor.includes('sizzle') ? textColor : textColor.replace(/text-/, 'bg-');
+        const bgColor = textColor.includes('sizzle') ? textColor.concat('-bg') : textColor.replace(/text-/, 'bg-');
+        const key = `${ textColor }/${ result }`;
+
+        out[key] = {
+          key,
+          label:           result.charAt(0).toUpperCase() + result.slice(1),
+          color:           replacedTextColor,
+          bgColor,
+          textColor,
+          value,
+          sort:            this.policySummarySort(textColor, result),
+        };
+      }
+
+      return sortBy(Object.values(out), 'sort:desc').reverse();
+    },
+
+    colorParts() {
+      const out = {};
+
+      for ( const p of this.summaryParts ) {
+        out[p.color] = {
+          color: p.color,
+          label: p.label,
+          value: p.value
+        };
+      }
+
+      return sortBy(Object.values(out), 'sort:desc').reverse();
+    },
+
+    summary() {
+      const connectedReport = this.reports?.find(r => r.namespace === this.value?.id);
+
+      if ( connectedReport ) {
+        return connectedReport.summary;
+      }
+
+      return null;
+    }
+  },
+
+  methods: {
+    policySummarySort(color, display) {
+      const SORT_ORDER = {
+        pass:    1,
+        fail:    2,
+        error:   3,
+        warning: 4,
+        skip:    5,
+        other:   6
+      };
+
+      color = color.replace(/^(text|bg|sizzle)-/, '');
+
+      return `${ SORT_ORDER[display] || SORT_ORDER['other'] } ${ display }`;
+    }
+  }
+};
+</script>
+
+<template>
+  <!-- <Loading v-if="$fetchState.pending" mode="relative" /> -->
+  <div v-if="canShow" class="pr-summary">
+    <v-popover
+      class="text-center hand"
+      placement="top"
+      :open-group="value.id"
+      trigger="click"
+      offset="1"
+    >
+      <template>
+        <div class="pr-summary__container">
+          <div v-for="obj in summaryParts" :key="`${obj.key}-badge`">
+            <div v-if="obj.value" class="badge" :class="{[obj.bgColor]: true}">
+              <span v-clean-tooltip="obj.label">{{ obj.value }}</span>
+            </div>
+          </div>
+        </div>
+      </template>
+
+      <template #popover>
+        <div class="pr-summary__content">
+          <div>
+            <div v-for="obj in summaryParts" :key="obj.key" class="counts">
+              <span class="text-left pr-20" :class="{[obj.textColor]: true}">
+                {{ obj.label }}
+              </span>
+              <span class="text-right">
+                {{ obj.value }}
+              </span>
+            </div>
+          </div>
+        </div>
+      </template>
+    </v-popover>
+  </div>
+  <div v-else></div>
+</template>
+
+<style lang="scss" scoped>
+$height: 30px;
+$width: 143px;
+$error: #614EA2;
+
+.pr-summary {
+  position: relative;
+
+  &__container {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+
+    width: $width;
+    height: $height;
+
+    border: solid thin var(--sortable-table-top-divider);
+
+    .badge {
+      padding: 4px;
+      margin: 2px;
+      border-radius: 8px;
+    }
+
+    .sizzle-warning-bg {
+      background-color: $error;
+      color: #fff;
+    }
+  }
+
+  &__content {
+    z-index: 14;
+    width: $width;
+
+    & > div {
+      padding: 10px;
+    }
+
+    .counts {
+      display: flex;
+      justify-content: space-between;
+    }
+
+    // Need to override the default colors for these classes
+    .text-warning {
+      color: var(--warning) !important;
+    }
+
+    .text-darker {
+      color: var(--dark) !important;
+    }
+
+    .sizzle-warning {
+      color: $error;
+    }
+  }
+}
+</style>

--- a/pkg/kubewarden/index.ts
+++ b/pkg/kubewarden/index.ts
@@ -2,7 +2,9 @@ import { importTypes } from '@rancher/auto-import';
 import {
   IPlugin, TableColumnLocation, TabLocation, PanelLocation, OnNavToPackage
 } from '@shell/core/types';
-import { NAMESPACE } from '@shell/config/types';
+import {
+  NAMESPACE, POD, WORKLOAD_TYPES, INGRESS, SERVICE
+} from '@shell/config/types';
 
 import kubewardenRoutes from './routes/kubewarden-routes';
 import kubewardenStore from './store/kubewarden';
@@ -59,26 +61,24 @@ export default function($plugin: IPlugin, args: any) {
   /** Tabs */
   $plugin.addTab(
     TabLocation.RESOURCE_DETAIL,
-    { resource: [NAMESPACE] },
+    {
+      resource: [
+        NAMESPACE,
+        POD,
+        WORKLOAD_TYPES.CRON_JOB,
+        WORKLOAD_TYPES.DAEMON_SET,
+        WORKLOAD_TYPES.DEPLOYMENT,
+        WORKLOAD_TYPES.JOB,
+        WORKLOAD_TYPES.STATEFUL_SET,
+        INGRESS,
+        SERVICE
+      ]
+    },
     {
       name:       'policy-report-tab',
       labelKey:   'kubewarden.policyReporter.headers.label',
       weight:     -5,
       showHeader: true,
-      tooltip:    'this is a tooltip message',
-      component:  () => import('./components/PolicyReporter/ResourceTab.vue')
-    }
-  );
-
-  $plugin.addTab(
-    TabLocation.RESOURCE_DETAIL,
-    { resource: ['pod'] },
-    {
-      name:       'policy-report-tab',
-      labelKey:   'kubewarden.policyReporter.headers.label',
-      weight:     -5,
-      showHeader: true,
-      tooltip:    'this is a tooltip message',
       component:  () => import('./components/PolicyReporter/ResourceTab.vue')
     }
   );

--- a/pkg/kubewarden/index.ts
+++ b/pkg/kubewarden/index.ts
@@ -1,15 +1,23 @@
 import { importTypes } from '@rancher/auto-import';
-import { IPlugin } from '@shell/core/types';
+import {
+  IPlugin, TableColumnLocation, TabLocation, PanelLocation, OnNavToPackage
+} from '@shell/core/types';
+import { NAMESPACE } from '@shell/config/types';
 
 import kubewardenRoutes from './routes/kubewarden-routes';
 import kubewardenStore from './store/kubewarden';
+import { getPolicyReports } from './modules/policyReporter';
 
 // fix missing directives on dashboard v2.7.2
 import '@shell/plugins/clean-tooltip-directive';
 import '@shell/plugins/clean-html-directive';
 
+const onEnter: OnNavToPackage = async(store) => {
+  await getPolicyReports(store);
+};
+
 // Init the package
-export default function($plugin: IPlugin) {
+export default function($plugin: IPlugin, args: any) {
   // Auto-import model, detail, edit from the folders
   importTypes($plugin);
 
@@ -24,4 +32,54 @@ export default function($plugin: IPlugin) {
 
   // Routes
   $plugin.addRoutes(kubewardenRoutes);
+
+  // Add hooks to Vue navigation world
+  $plugin.addNavHooks(onEnter);
+
+  /** Panels */
+  $plugin.addPanel(
+    PanelLocation.RESOURCE_LIST,
+    { path: [{ urlPath: 'explorer/projectsnamespaces', endsWith: true }] },
+    { component: () => import('./components/PolicyReporter/ReporterPanel.vue') }
+  );
+
+  /** Columns */
+  $plugin.addTableColumn(
+    TableColumnLocation.RESOURCE,
+    { path: [{ urlPath: 'explorer/projectsnamespaces', endsWith: true }] },
+    {
+      name:      'policy-reports',
+      labelKey:  'kubewarden.policyReporter.headers.label',
+      getValue:  (row: any) => row,
+      weight:    3,
+      formatter: 'PolicyReportSummary'
+    }
+  );
+
+  /** Tabs */
+  $plugin.addTab(
+    TabLocation.RESOURCE_DETAIL,
+    { resource: [NAMESPACE] },
+    {
+      name:       'policy-report-tab',
+      labelKey:   'kubewarden.policyReporter.headers.label',
+      weight:     -5,
+      showHeader: true,
+      tooltip:    'this is a tooltip message',
+      component:  () => import('./components/PolicyReporter/ResourceTab.vue')
+    }
+  );
+
+  $plugin.addTab(
+    TabLocation.RESOURCE_DETAIL,
+    { resource: ['pod'] },
+    {
+      name:       'policy-report-tab',
+      labelKey:   'kubewarden.policyReporter.headers.label',
+      weight:     -5,
+      showHeader: true,
+      tooltip:    'this is a tooltip message',
+      component:  () => import('./components/PolicyReporter/ResourceTab.vue')
+    }
+  );
 }

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -170,6 +170,9 @@ kubewarden:
         checkbox: Update to Protect Mode
         title: Update Policy Mode
         body: The monitor mode is a way to view the behavior of a policy without letting it make the final decision on requests that are validated by the policy.
+    backgroundAudit:
+      label: Background Audit
+      tooltip: 'Indicates whether a policy should be used or skipped when performing audit checks. If false, the policy cannot produce meaningful evaluation results during audit checks and will be skipped. The default is "true".'
     ignoreRancherNamespaces:
       label: Ignore Rancher Namespaces
       tooltip: Certain policies will break core services of Rancher, this will add a default list of namespaces to ignore.

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -274,6 +274,25 @@ kubewarden:
     url:
       banner:
         unavailable: The Policy Reporter UI proxy URL is unavailble, please ensure that the UI is properly configured.
+    headers:
+      label: Policy Reports
+      description: When using the Kubewarden Audit Scanner, the results of the policy scans are stored using the PolicyReport Custom Resource.
+      policyReportsTab:
+        policy:
+          label: Policy
+        rule:
+          label: Rule
+        severity:
+          label: Severity
+        status:
+          label: Status
+        message:
+          title: Message
+        properties:
+          policy-uid: policy-uid
+          version: policy-resource-version
+          mutating: mutating
+          validating: validating
 
 asyncButton:
   artifactHub:

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -275,7 +275,7 @@ kubewarden:
       banner:
         unavailable: The Policy Reporter UI proxy URL is unavailble, please ensure that the UI is properly configured.
     headers:
-      label: Policy Reports
+      label: Compliance
       description: When using the Kubewarden Audit Scanner, the results of the policy scans are stored using the PolicyReport Custom Resource.
       policyReportsTab:
         policy:

--- a/pkg/kubewarden/modules/core.ts
+++ b/pkg/kubewarden/modules/core.ts
@@ -1,0 +1,14 @@
+/**
+ * To find the `type` of a resource that does not have the `group` listed, this
+ * will split the `apiVersion` and concatenate it with the `kind`.
+ * @param resource | Any resource with the `apiVersion` and `kind` properties
+ * @returns `string | void` | Group type (e.g. `apps.deployment`)
+ */
+export function splitGroupKind(resource: any): string | void {
+  const loweredKind = resource.kind?.toLowerCase();
+  const group = resource.apiVersion?.split('/')[0];
+
+  if ( loweredKind && group ) {
+    return `${ group }.${ loweredKind }`;
+  }
+}

--- a/pkg/kubewarden/modules/policyReporter.ts
+++ b/pkg/kubewarden/modules/policyReporter.ts
@@ -1,0 +1,209 @@
+import isEmpty from 'lodash/isEmpty';
+import { randomStr } from '@shell/utils/string';
+import {
+  KUBEWARDEN, Resource, Severity, Result, PolicyReport, PolicyReportResult
+} from '../types';
+import { createKubewardenRoute } from '../utils/custom-routing';
+
+/**
+ * Attempts to fetch PolicyReports by dispatching a findAll against `wgpolicyk8s.io.policyreport`
+ * @param store
+ * @returns `PolicyReport[] | void` - Scaffolded value of a PolicyReport accomplished by scaffoldPolicyReport()
+ */
+export async function getPolicyReports(store: any): Promise<PolicyReport[] | void> {
+  const schema = store.getters['cluster/schemaFor'](KUBEWARDEN.POLICY_REPORT);
+
+  if ( schema ) {
+    try {
+      const reports = await fetchPolicyReports(store);
+
+      if ( !isEmpty(reports) ) {
+        reports?.forEach((report: PolicyReport) => store.dispatch('kubewarden/updatePolicyReports', report));
+
+        return reports;
+      }
+    } catch (e) {
+      console.warn(`Error fetching PolicyReports: ${ e }`); // eslint-disable-line no-console
+    }
+  }
+}
+
+/**
+ * Dispatches findAll for PolicyReports (`wgpolicyk8s.io.policyreport`)
+ * @param store
+ * @returns `wgpolicyk8s.io.policyreport[] | void`
+ */
+export async function fetchPolicyReports(store: any): Promise<Array<PolicyReport>> {
+  return await store.dispatch('cluster/findAll', { type: KUBEWARDEN.POLICY_REPORT }, { root: true });
+}
+
+/**
+ * Filters PolicyReports for namespaced resources or the Namespace resource type
+ * @param store
+ * @param resource
+ * @returns `PolicyReport | PolicyReportResult[] | null | void`
+ */
+export async function getFilteredReports(store: any, resource: any): Promise<PolicyReport | PolicyReportResult[] | null | void> {
+  const schema = store.getters['cluster/schemaFor'](resource.type);
+
+  if ( schema ) {
+    try {
+      const reports = await getPolicyReports(store);
+
+      if ( !isEmpty(reports) ) {
+        const hasNamespace = resource?.metadata?.namespace;
+
+        // If the resource is a namespace, return the all reports for the ns
+        if ( resource?.type === 'namespace' ) {
+          let out: PolicyReport | undefined | null = null;
+
+          if ( Array.isArray(reports) ) {
+            out = reports.find((report: PolicyReport) => report.scope?.name === resource?.name);
+          }
+
+          if ( !isEmpty(out) ) {
+            // Assign uid for SortableTable sub-row
+            out.results?.forEach((result: any) => {
+              Object.assign(result, { uid: randomStr() });
+            });
+
+            return out;
+          }
+        }
+
+        if ( hasNamespace ) {
+          let out: PolicyReportResult[] | null = null;
+
+          // Find the report that is scoped to the resource namespace
+          if ( Array.isArray(reports) ) {
+            reports.forEach((report: any) => {
+              if ( report.scope?.name === resource.metadata.namespace ) {
+                const filteredResult = report.results?.filter((result: PolicyReportResult) => {
+                  const filteredResource = result?.resources?.find((r: Resource) => {
+                    const { kind, name, namespace } = r;
+
+                    if ( kind === resource.kind && name === resource.metadata.name && namespace === resource.metadata.namespace ) {
+                      return r;
+                    }
+                  });
+
+                  if ( !isEmpty(filteredResource) ) {
+                    // Assign uid for SortableTable sub-row
+                    Object.assign(result, { uid: randomStr() });
+
+                    return result;
+                  }
+                });
+
+                if ( !isEmpty(filteredResult) ) {
+                  out = filteredResult;
+                }
+              }
+            });
+          }
+
+          return out;
+        }
+      }
+    } catch (e) {
+      console.warn(`Error fetching PolicyReports: ${ e }`); // eslint-disable-line no-console
+    }
+  }
+}
+
+/**
+ * Finds the resource (policy) that is connected to the PolicyReportResult and returns the route.
+ * @param store
+ * @param report: `PolicyReportResult`
+ * @returns `createKubewardenRoute` | Will return a route to either a ClusterAdmissionPolicy or AdmissionPolicy
+ */
+export function getLinkForPolicy(store: any, report: PolicyReportResult): Object | void {
+  if ( report?.policy ) {
+    const apSchema = store.getters['cluster/schemaFor'](KUBEWARDEN.ADMISSION_POLICY);
+    const capSchema = store.getters['cluster/schemaFor'](KUBEWARDEN.CLUSTER_ADMISSION_POLICY);
+
+    /**
+     * Split policy name as it is formatted like: 'cap-do-not-run-as-root'
+     * To determine which type of policy we need the first part of the string,
+     * 'cap' or 'ap' for ClusterAdmissionPolicy and AdmissionPolicy respectively.
+     */
+    let policyType: string = '';
+    let policyParts: string[] = report.policy.split('-');
+    let policyNs: string | null = null;
+
+    if ( policyParts.length >= 2 ) {
+      policyParts = [policyParts[0], policyParts.slice(1).join('-')];
+      policyType = policyParts[0] === 'cap' ? KUBEWARDEN.CLUSTER_ADMISSION_POLICY : KUBEWARDEN.ADMISSION_POLICY;
+
+      // Find the namespace of the AdmissionPolicy
+      if ( policyType === KUBEWARDEN.ADMISSION_POLICY && apSchema ) {
+        const admissionPolicies = store.getters['cluster/all'](KUBEWARDEN.ADMISSION_POLICY);
+        const resource = admissionPolicies?.find((ap: any) => ap.metadata?.name === policyParts[1]);
+
+        if ( resource ) {
+          policyNs = resource.metadata?.namespace;
+        }
+      }
+    }
+
+    if ( policyType === KUBEWARDEN.ADMISSION_POLICY && apSchema ) {
+      return createKubewardenRoute({
+        name:   'c-cluster-product-resource-namespace-id',
+        params: {
+          resource: policyType, id: policyParts[1], namespace: policyNs
+        }
+      });
+    }
+
+    if ( policyType === KUBEWARDEN.CLUSTER_ADMISSION_POLICY && capSchema ) {
+      return createKubewardenRoute({
+        name:   'c-cluster-product-resource-id',
+        params: { resource: policyType, id: policyParts[1] }
+      });
+    }
+  }
+}
+
+/**
+ * Determines color for PolicyReport status
+ * @param result | PolicyReport summary result || report resource.result
+ * @returns string
+ */
+export function colorForResult(result: Result): string {
+  switch (result) {
+  case Result.FAIL:
+    return 'text-error';
+  case Result.ERROR:
+    return 'sizzle-warning';
+  case Result.PASS:
+    return 'text-success';
+  case Result.WARN:
+    return 'text-warning';
+  case Result.SKIP:
+    return 'text-darker';
+  default:
+    return 'text-muted';
+  }
+}
+
+/**
+ * Determines color for PolicyReport severity
+ * @param severity | PolicyReport severity
+ * @returns string
+ */
+export function colorForSeverity(severity: Severity): string {
+  switch (severity) {
+  case Severity.INFO:
+    return 'bg-info';
+  case Severity.LOW:
+    return 'bg-warning';
+  case Severity.MEDIUM:
+    return 'bg-warning';
+  case Severity.HIGH:
+    return 'bg-warning';
+  case Severity.CRITICAL:
+    return 'bg-critical';
+  default:
+    return 'bg-muted';
+  }
+}

--- a/pkg/kubewarden/store/kubewarden/actions.ts
+++ b/pkg/kubewarden/store/kubewarden/actions.ts
@@ -1,3 +1,5 @@
+import { PolicyReport } from '../../types';
+
 export default {
   updateAirGapped({ commit }: any, val: Boolean) {
     commit('updateAirGapped', val);
@@ -10,5 +12,11 @@ export default {
   },
   updateHideBannerAirgapPolicy({ commit }: any, val: Boolean) {
     commit('updateHideBannerAirgapPolicy', val);
+  },
+  updatePolicyReports({ commit }: any, val: PolicyReport[]) {
+    commit('updatePolicyReports', val);
+  },
+  removePolicyReportById({ commit }: any, val: PolicyReport) {
+    commit('removePolicyReportById', val.id);
   }
 };

--- a/pkg/kubewarden/store/kubewarden/getters.ts
+++ b/pkg/kubewarden/store/kubewarden/getters.ts
@@ -1,8 +1,10 @@
+import { PolicyReport } from '../../types';
 import { StateConfig } from './index';
 
 export default {
   airGapped:              (state: StateConfig): Boolean => state.airGapped,
   hideBannerDefaults:     (state: StateConfig): Boolean => state.hideBannerDefaults,
   hideBannerArtifactHub:  (state: StateConfig): Boolean => state.hideBannerArtifactHub,
-  hideBannerAirgapPolicy: (state: StateConfig): Boolean => state.hideBannerAirgapPolicy
+  hideBannerAirgapPolicy: (state: StateConfig): Boolean => state.hideBannerAirgapPolicy,
+  policyReports:          (state: StateConfig): PolicyReport[] => state.policyReports
 };

--- a/pkg/kubewarden/store/kubewarden/index.ts
+++ b/pkg/kubewarden/store/kubewarden/index.ts
@@ -1,6 +1,6 @@
 import { CoreStoreSpecifics, CoreStoreConfig } from '@shell/core/types';
 
-import { KUBEWARDEN_PRODUCT_NAME } from '../../types';
+import { KUBEWARDEN_PRODUCT_NAME, PolicyReport } from '../../types';
 
 import getters from './getters';
 import mutations from './mutations';
@@ -10,7 +10,8 @@ export interface StateConfig {
   airGapped: Boolean,
   hideBannerDefaults: Boolean,
   hideBannerArtifactHub: Boolean,
-  hideBannerAirgapPolicy: Boolean
+  hideBannerAirgapPolicy: Boolean,
+  policyReports: PolicyReport[]
 }
 
 const kubewardenFactory = (config: StateConfig): CoreStoreSpecifics => {
@@ -20,7 +21,8 @@ const kubewardenFactory = (config: StateConfig): CoreStoreSpecifics => {
         airGapped:              config.airGapped,
         hideBannerDefaults:     config.hideBannerDefaults,
         hideBannerArtifactHub:  config.hideBannerArtifactHub,
-        hideBannerAirgapPolicy: config.hideBannerAirgapPolicy
+        hideBannerAirgapPolicy: config.hideBannerAirgapPolicy,
+        policyReports:          config.policyReports
       };
     },
 
@@ -37,7 +39,8 @@ export default {
     airGapped:              false,
     hideBannerDefaults:     false,
     hideBannerArtifactHub:  false,
-    hideBannerAirgapPolicy: false
+    hideBannerAirgapPolicy: false,
+    policyReports:          []
   }),
   config
 };

--- a/pkg/kubewarden/store/kubewarden/mutations.ts
+++ b/pkg/kubewarden/store/kubewarden/mutations.ts
@@ -1,3 +1,4 @@
+import { PolicyReport } from '../../types';
 import { StateConfig } from './index';
 
 export default {
@@ -12,5 +13,36 @@ export default {
   },
   updateHideBannerAirgapPolicy(state: StateConfig, val: Boolean) {
     state.hideBannerAirgapPolicy = val;
+  },
+
+  /**
+   * Updates/Adds policy reports to the state
+   * @param state
+   * @param updatedReport - PolicyReport interface
+   */
+  updatePolicyReports(state: StateConfig, updatedReport: PolicyReport) {
+    const existingReport = state.policyReports.find(report => report.id === updatedReport.id);
+
+    if ( existingReport ) {
+      // We only need to update the results and summary of the report
+      existingReport.results = updatedReport.results;
+      existingReport.summary = updatedReport.summary;
+    } else {
+      // If the report doesn't exist, add it to the store
+      state.policyReports.push(updatedReport);
+    }
+  },
+
+  /**
+   * Searches and then removes a report by id from the store
+   * @param state
+   * @param reportId
+   */
+  removePolicyReportById(state: StateConfig, reportId: String) {
+    const idx = state.policyReports.findIndex(report => report.id === reportId);
+
+    if ( idx !== -1 ) {
+      state.policyReports.splice(idx, 1);
+    }
   }
 };

--- a/pkg/kubewarden/types.ts
+++ b/pkg/kubewarden/types.ts
@@ -1,3 +1,4 @@
+export * from './types/core';
 export * from './types/kubewarden';
 export * from './types/policy';
 export * from './types/grafana';

--- a/pkg/kubewarden/types/core.ts
+++ b/pkg/kubewarden/types/core.ts
@@ -1,0 +1,34 @@
+export type Metadata = {
+  creationTimestamp: string;
+  fields?: Array<string>;
+  generation?: number;
+  labels?: {[key: string]: string}
+  name: string;
+  namespace?: string;
+  relationships?: any;
+  resourceVersion?: string;
+  state?: {
+    error?: boolean;
+    message?: string;
+    name?: string;
+    transitioning?: boolean;
+  };
+  uid: string;
+}
+
+export type Links = {
+  remove?: string;
+  self?: string;
+  update?: string;
+  view?: string;
+}
+
+export type Route = {
+  name: string;
+  params: {
+    resource?: string;
+    product?: string;
+    cluster?: string;
+    hash?: string;
+  }
+}

--- a/pkg/kubewarden/types/policy-reporter.ts
+++ b/pkg/kubewarden/types/policy-reporter.ts
@@ -33,45 +33,42 @@ export enum Result {
 }
 /* eslint-enable no-unused-vars */
 
+export type PolicyReportSummary = {
+  pass?: number;
+  fail?: number;
+  warn?: number;
+  error?: number;
+  skip?: number;
+}
+
+export type PolicyReportResult = {
+  message: string;
+  policy: string;
+  rule: string;
+  priority?: string;
+  status?: string;
+  source?: string;
+  severity?: string;
+  category?: string;
+  properties?: {[key: string]: string};
+  scored: boolean;
+  result?: string;
+  resources?: Resource[];
+  uid?: string;
+}
+
 export type PolicyReport = {
   apiVersion: string;
   id: string;
   kind: string;
   links?: Links;
   metadata: Metadata;
-  results?: Array<{
-    category?: string;
-    message?: string;
-    policy?: string;
-    result?: string;
-    resources?: Resource[];
-  }>
+  results?: Array<PolicyReportResult>
   scope?: {
     name?: string;
     uid?: string;
   }
-  summary?: {
-    pass?: number;
-    fail?: number;
-    warn?: number;
-    error?: number;
-    skip?: number;
-  }
+  summary?: PolicyReportSummary
   type: string;
   uid: string;
-}
-
-export type PolicyReportResult = {
-    message: string;
-    policy: string;
-    rule: string;
-    priority?: string;
-    status?: string;
-    source?: string;
-    severity?: string;
-    category?: string;
-    properties?: {[key: string]: string};
-    scored: boolean;
-    resources?: Resource[];
-    uid?: string;
 }

--- a/pkg/kubewarden/types/policy-reporter.ts
+++ b/pkg/kubewarden/types/policy-reporter.ts
@@ -1,6 +1,77 @@
+import { Links, Metadata } from './core';
+
 export const POLICY_REPORTER_PRODUCT = 'policy-reporter';
 export const POLICY_REPORTER_RESOURCE = 'PolicyReporter';
 
 export const POLICY_REPORTER_REPO = 'https://kyverno.github.io/policy-reporter';
 
 export const POLICY_REPORTER_CHART = 'policy-reporter';
+
+export type Resource = {
+  apiVersion: string;
+  kind: string;
+  name: string;
+  namespace?: string;
+  uid: string;
+}
+
+/* eslint-disable no-unused-vars */
+export enum Severity {
+  INFO = 'info',
+  LOW = 'low',
+  MEDIUM = 'medium',
+  HIGH = 'high',
+  CRITICAL = 'critical',
+}
+
+export enum Result {
+  SKIP = 'skip',
+  PASS = 'pass',
+  WARN = 'warn',
+  FAIL = 'fail',
+  ERROR = 'error'
+}
+/* eslint-enable no-unused-vars */
+
+export type PolicyReport = {
+  apiVersion: string;
+  id: string;
+  kind: string;
+  links?: Links;
+  metadata: Metadata;
+  results?: Array<{
+    category?: string;
+    message?: string;
+    policy?: string;
+    result?: string;
+    resources?: Resource[];
+  }>
+  scope?: {
+    name?: string;
+    uid?: string;
+  }
+  summary?: {
+    pass?: number;
+    fail?: number;
+    warn?: number;
+    error?: number;
+    skip?: number;
+  }
+  type: string;
+  uid: string;
+}
+
+export type PolicyReportResult = {
+    message: string;
+    policy: string;
+    rule: string;
+    priority?: string;
+    status?: string;
+    source?: string;
+    severity?: string;
+    category?: string;
+    properties?: {[key: string]: string};
+    scored: boolean;
+    resources?: Resource[];
+    uid?: string;
+}

--- a/pkg/kubewarden/types/policy.ts
+++ b/pkg/kubewarden/types/policy.ts
@@ -6,9 +6,10 @@ export const DEFAULT_POLICY = {
     namespace: ''
   },
   spec:       {
-    policyServer: '',
-    module:       '',
-    rules:        [{
+    backgroundAudit: true,
+    policyServer:    '',
+    module:          '',
+    rules:           [{
       apiGroups:   [],
       apiVersions: [],
       resources:   [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1017,7 +1017,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.21.9.tgz#10a2e7fda4e51742c907938ac3b7229426515514"
   integrity sha512-FUGed8kfhyWvbYug/Un/VPJD41rDIgoVVcR+FuzhzOYyRz5uED+Gd3SLZml0Uw2l2aHFb7ZgdW5mGA3G2cCCnQ==
 
-"@babel/core@^7.1.0", "@babel/core@^7.11.0", "@babel/core@^7.11.6", "@babel/core@^7.12.16", "@babel/core@^7.12.3", "@babel/core@^7.14.0", "@babel/core@^7.4.4", "@babel/core@^7.7.2", "@babel/core@^7.7.5", "@babel/core@^7.8.0":
+"@babel/core@^7.1.0", "@babel/core@^7.11.0", "@babel/core@^7.11.6", "@babel/core@^7.12.16", "@babel/core@^7.12.3", "@babel/core@^7.14.0", "@babel/core@^7.7.2", "@babel/core@^7.7.5", "@babel/core@^7.8.0":
   version "7.21.8"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.21.8.tgz#2a8c7f0f53d60100ba4c32470ba0281c92aa9aa4"
   integrity sha512-YeM22Sondbo523Sz0+CirSPnbj9bG3P0CdHcBZdqUuaeOaYEFbOLoGU7lebvGP6P5J/WE9wOn7u7C4J9HvS1xQ==
@@ -1857,7 +1857,7 @@
     "@babel/helper-create-regexp-features-plugin" "^7.18.6"
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/preset-env@^7.11.0", "@babel/preset-env@^7.14.1", "@babel/preset-env@^7.20.2", "@babel/preset-env@^7.4.4":
+"@babel/preset-env@^7.11.0", "@babel/preset-env@^7.14.1", "@babel/preset-env@^7.20.2":
   version "7.21.5"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.21.5.tgz#db2089d99efd2297716f018aeead815ac3decffb"
   integrity sha512-wH00QnTTldTbf/IefEVyChtRdw5RJvODT/Vb4Vcxq1AZvtXj6T0YeX0cAcXhI6/BdGuiP3GcNIL4OQbI2DVNxg==
@@ -3109,16 +3109,16 @@
     webpack-node-externals "^3.0.0"
     webpackbar "^4.0.0"
 
-"@nuxtjs/axios@5.12.0":
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/@nuxtjs/axios/-/axios-5.12.0.tgz#50692340e64ec838f167d292d59b1cc2a0e2dbef"
-  integrity sha512-VQI9Nnf12jWknldrgCNGzCQxnWO3/CvMwrkWKNUr3WtGYuOKryUOd1XXxDbaJmopfX4SGjKvDL1G6qTkWLiPew==
+"@nuxtjs/axios@5.13.6":
+  version "5.13.6"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/axios/-/axios-5.13.6.tgz#6f4bbd98a3a7799a5d2c0726c6ad2a98aa111881"
+  integrity sha512-XS+pOE0xsDODs1zAIbo95A0LKlilvJi8YW0NoXYuq3/jjxGgWDxizZ6Yx0AIIjZOoGsXJOPc0/BcnSEUQ2mFBA==
   dependencies:
-    "@nuxtjs/proxy" "^2.0.0"
-    axios "^0.19.2"
-    axios-retry "^3.1.8"
-    consola "^2.14.0"
-    defu "^2.0.4"
+    "@nuxtjs/proxy" "^2.1.0"
+    axios "^0.21.1"
+    axios-retry "^3.1.9"
+    consola "^2.15.3"
+    defu "^5.0.0"
 
 "@nuxtjs/eslint-config-typescript@6.0.1":
   version "6.0.1"
@@ -3143,7 +3143,7 @@
     eslint-plugin-unicorn "^28.0.2"
     eslint-plugin-vue "^7.9.0"
 
-"@nuxtjs/proxy@^2.0.0":
+"@nuxtjs/proxy@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@nuxtjs/proxy/-/proxy-2.1.0.tgz#fa7715a11d237fa1273503c4e9e137dd1bf5575b"
   integrity sha512-/qtoeqXgZ4Mg6LRg/gDUZQrFpOlOdHrol/vQYMnKu3aN3bP90UfOUB3QSDghUUK7OISAJ0xp8Ld78aHyCTcKCQ==
@@ -3181,10 +3181,10 @@
   dependencies:
     lodash.debounce "4.0.8"
 
-"@rancher/shell@0.3.23":
-  version "0.3.23"
-  resolved "https://registry.yarnpkg.com/@rancher/shell/-/shell-0.3.23.tgz#9f334f2e9034e27d7edf6f8a12af597790e31d14"
-  integrity sha512-nnfrpEBR/JMCS2MGRhgAygr9hIOsO1cVB+1jvbo/q8VVLZQTlNmVNcl2YyOuCvo+tE6J/svD4rQmPwyIeJ6EQA==
+"@rancher/shell@0.3.25":
+  version "0.3.25"
+  resolved "https://registry.yarnpkg.com/@rancher/shell/-/shell-0.3.25.tgz#ed0ed34622d7bbba333187f050ac04fa53043f07"
+  integrity sha512-qqz1V5BYnQSqZ1xWs2gtMK84d4lb26iReRsWjK4nME78sHXxyoaX3u9WVYTpR4WhMB5C0hCdDhsLDESvXZSwgA==
   dependencies:
     "@aws-sdk/client-ec2" "3.1.0"
     "@aws-sdk/client-eks" "3.1.0"
@@ -3196,7 +3196,7 @@
     "@novnc/novnc" "1.2.0"
     "@nuxt/types" "2.14.6"
     "@nuxt/typescript-build" "2.1.0"
-    "@nuxtjs/axios" "5.12.0"
+    "@nuxtjs/axios" "5.13.6"
     "@nuxtjs/eslint-config-typescript" "6.0.1"
     "@nuxtjs/webpack-profile" "0.1.0"
     "@popperjs/core" "2.4.4"
@@ -3265,9 +3265,6 @@
     papaparse "5.3.0"
     portal-vue "2.1.7"
     rancher-icons rancher/icons#v2.0.16
-    require-extension-hooks "0.3.3"
-    require-extension-hooks-babel "1.0.0"
-    require-extension-hooks-vue "3.0.0"
     sass "1.51.0"
     sass-loader "10.2.1"
     serve-static "1.14.1"
@@ -4291,21 +4288,6 @@
     postcss "^8.4.14"
     source-map "^0.6.1"
 
-"@vue/component-compiler-utils@^2.3.1":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@vue/component-compiler-utils/-/component-compiler-utils-2.6.0.tgz#aa46d2a6f7647440b0b8932434d22f12371e543b"
-  integrity sha512-IHjxt7LsOFYc0DkTncB7OXJL7UzwOLPPQCfEUNyxL2qt+tF12THV+EO33O1G2Uk4feMSWua3iD39Itszx0f0bw==
-  dependencies:
-    consolidate "^0.15.1"
-    hash-sum "^1.0.2"
-    lru-cache "^4.1.2"
-    merge-source-map "^1.1.0"
-    postcss "^7.0.14"
-    postcss-selector-parser "^5.0.0"
-    prettier "1.16.3"
-    source-map "~0.6.1"
-    vue-template-es2015-compiler "^1.9.0"
-
 "@vue/component-compiler-utils@^3.1.0", "@vue/component-compiler-utils@^3.1.2":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@vue/component-compiler-utils/-/component-compiler-utils-3.3.0.tgz#f9f5fb53464b0c37b2c8d2f3fbfe44df60f61dc9"
@@ -5023,20 +5005,13 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.12.0.tgz#ce1c9d143389679e253b314241ea9aa5cec980d3"
   integrity sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==
 
-axios-retry@^3.1.8:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/axios-retry/-/axios-retry-3.5.0.tgz#32206b3e6555169488eded232527e36c8ce6e545"
-  integrity sha512-g48qNrLX30VU6ECWltpFCPegKK6dWzMDYv2o83W2zUL/Zh/SLXbT6ksGoKqYZHtghzqeeXhZBcSXJkO1fPbCcw==
+axios-retry@^3.1.9:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/axios-retry/-/axios-retry-3.8.0.tgz#a174af633ef143a9f5642b9e4afe65c2017936b5"
+  integrity sha512-CfIsQyWNc5/AE7x/UEReRUadiBmQeoBpSEC+4QyGLJMswTsP1tz0GW2YYPnE7w9+ESMef5zOgLDFpHynNyEZ1w==
   dependencies:
     "@babel/runtime" "^7.15.4"
     is-retry-allowed "^2.2.0"
-
-axios@^0.19.2:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
-  dependencies:
-    follow-redirects "1.5.10"
 
 axios@^0.21.1:
   version "0.21.4"
@@ -6337,7 +6312,7 @@ connect@^3.7.0:
     parseurl "~1.3.3"
     utils-merge "1.0.1"
 
-consola@^2.10.0, consola@^2.14.0, consola@^2.15.0, consola@^2.15.3, consola@^2.6.0, consola@^2.9.0:
+consola@^2.10.0, consola@^2.15.0, consola@^2.15.3, consola@^2.6.0, consola@^2.9.0:
   version "2.15.3"
   resolved "https://registry.yarnpkg.com/consola/-/consola-2.15.3.tgz#2e11f98d6a4be71ff72e0bdf07bd23e12cb61550"
   integrity sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==
@@ -6378,7 +6353,7 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
   integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
 
-convert-source-map@^1.3.0, convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
+convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
   integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
@@ -6745,14 +6720,6 @@ css-select@^5.1.0:
     domhandler "^5.0.2"
     domutils "^3.0.1"
     nth-check "^2.0.1"
-
-css-selector-tokenizer@^0.7.0:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/css-selector-tokenizer/-/css-selector-tokenizer-0.7.3.tgz#735f26186e67c749aaf275783405cf0661fae8f1"
-  integrity sha512-jWQv3oCEL5kMErj4wRnK/OPoBi0D+P1FR2cDCKYPaMeD2eW3/mttav8HT4hT1CKopiJI/psEULjkClhvJo4Lvg==
-  dependencies:
-    cssesc "^3.0.0"
-    fastparse "^1.1.2"
 
 css-tree@1.0.0-alpha.37:
   version "1.0.0-alpha.37"
@@ -7568,13 +7535,6 @@ debug@4.3.2:
   dependencies:
     ms "2.1.2"
 
-debug@=3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
-
 debug@^3.1.0, debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
@@ -7692,11 +7652,6 @@ define-property@^2.0.2:
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
-
-defu@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/defu/-/defu-2.0.4.tgz#09659a6e87a8fd7178be13bd43e9357ebf6d1c46"
-  integrity sha512-G9pEH1UUMxShy6syWk01VQSRVs3CDWtlxtZu7A+NyqjxaCA4gSlWAKDBx6QiUEKezqS8+DUlXLI14Fp05Hmpwg==
 
 defu@^4.0.1:
   version "4.0.1"
@@ -9088,11 +9043,6 @@ fast-xml-parser@^3.16.0:
   dependencies:
     strnum "^1.0.4"
 
-fastparse@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"
-  integrity sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==
-
 fastq@^1.6.0:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.15.0.tgz#d04d07c6a2a68fe4599fea8d2e103a937fae6b3a"
@@ -9292,13 +9242,6 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
-
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
 
 follow-redirects@^1.0.0, follow-redirects@^1.14.0:
   version "1.15.2"
@@ -9555,13 +9498,6 @@ functions-have-names@^1.2.2, functions-have-names@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
-
-generic-names@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/generic-names/-/generic-names-1.0.3.tgz#2d786a121aee508876796939e8e3bff836c20917"
-  integrity sha512-b6OHfQuKasIKM9b6YPkX+KUj/TLBTx3B/1aT1T5F12FEuEqyFMdr59OMS53aoaSw8eVtapdqieX6lbg5opaOhA==
-  dependencies:
-    loader-utils "^0.2.16"
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -9878,11 +9814,6 @@ has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
   integrity sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==
-
-has-flag@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
-  integrity sha512-DyYHfIYwAJmjAjSSPKANxI8bFY9YtFrgkAfinBojQ8YJTOuOuav64tMUJv584SES4xl74PmuaevIyaLESHdTAA==
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -10346,11 +10277,6 @@ iconv-lite@0.6, iconv-lite@0.6.3:
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
-
-icss-replace-symbols@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz#06ea6f83679a7749e386cfe1fe812ae5db223ded"
-  integrity sha512-chIaY3Vh2mh2Q3RGXttaDIzeiPvaVXJ+C4DAh/w3c37SKZ/U6PGMmuicR2EQQp9bKG8zLMCl7I+PtIoOOPp8Gg==
 
 icss-utils@^4.0.0, icss-utils@^4.1.1:
   version "4.1.1"
@@ -12092,11 +12018,6 @@ jquery@3.5.1:
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
   integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
 
-js-base64@^2.1.9:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"
-  integrity sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==
-
 js-beautify@^1.6.12:
   version "1.14.7"
   resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.14.7.tgz#9206296de33f86dc106d3e50a35b7cf8729703b2"
@@ -12885,7 +12806,7 @@ merge-descriptors@1.0.1:
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==
 
-merge-source-map@^1.0.3, merge-source-map@^1.1.0:
+merge-source-map@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.1.0.tgz#2fdde7e6020939f70906a68f2d7ae685e4c8c646"
   integrity sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==
@@ -14540,14 +14461,6 @@ postcss-modules-extract-imports@^3.0.0:
   resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz#cda1f047c0ae80c97dbe28c3e76a43b88025741d"
   integrity sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==
 
-postcss-modules-local-by-default@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz#f7d80c398c5a393fa7964466bd19500a7d61c069"
-  integrity sha512-X4cquUPIaAd86raVrBwO8fwRfkIdbwFu7CTfEOjiZQHVQwlHRSkTgH5NLDmMm5+1hQO8u6dZ+TOOJDbay1hYpA==
-  dependencies:
-    css-selector-tokenizer "^0.7.0"
-    postcss "^6.0.1"
-
 postcss-modules-local-by-default@^3.0.2, postcss-modules-local-by-default@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.3.tgz#bb14e0cc78279d504dbdcbfd7e0ca28993ffbbb0"
@@ -14567,14 +14480,6 @@ postcss-modules-local-by-default@^4.0.0:
     postcss-selector-parser "^6.0.2"
     postcss-value-parser "^4.1.0"
 
-postcss-modules-scope@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz#d6ea64994c79f97b62a72b426fbe6056a194bb90"
-  integrity sha512-LTYwnA4C1He1BKZXIx1CYiHixdSe9LWYVKadq9lK5aCCMkoOkFyZ7aigt+srfjlRplJY3gIol6KUNefdMQJdlw==
-  dependencies:
-    css-selector-tokenizer "^0.7.0"
-    postcss "^6.0.1"
-
 postcss-modules-scope@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-2.2.0.tgz#385cae013cc7743f5a7d7602d1073a89eaae62ee"
@@ -14589,18 +14494,6 @@ postcss-modules-scope@^3.0.0:
   integrity sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==
   dependencies:
     postcss-selector-parser "^6.0.4"
-
-postcss-modules-sync@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-modules-sync/-/postcss-modules-sync-1.0.0.tgz#619a719cf78dd16a4834135140b324cf77334be1"
-  integrity sha512-kIDk2NYmxHshqUbjtFf1WdBij08IsvRdgDT0nOGWhvwkr8/z1piLSzxVrPt56J4DU6ON986h2H+5xcBnFhT8UQ==
-  dependencies:
-    generic-names "^1.0.2"
-    icss-replace-symbols "^1.0.2"
-    postcss "^5.2.5"
-    postcss-modules-local-by-default "^1.1.1"
-    postcss-modules-scope "^1.0.2"
-    string-hash "^1.1.0"
 
 postcss-modules-values@^3.0.0:
   version "3.0.0"
@@ -14839,7 +14732,7 @@ postcss-selector-parser@^3.0.0:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss-selector-parser@^5.0.0, postcss-selector-parser@^5.0.0-rc.3, postcss-selector-parser@^5.0.0-rc.4:
+postcss-selector-parser@^5.0.0-rc.3, postcss-selector-parser@^5.0.0-rc.4:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz#249044356697b33b64f1a8f7c80922dddee7195c"
   integrity sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==
@@ -14912,25 +14805,6 @@ postcss@7.x.x, postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17,
     picocolors "^0.2.1"
     source-map "^0.6.1"
 
-postcss@^5.2.5:
-  version "5.2.18"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5"
-  integrity sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==
-  dependencies:
-    chalk "^1.1.3"
-    js-base64 "^2.1.9"
-    source-map "^0.5.6"
-    supports-color "^3.2.3"
-
-postcss@^6.0.1:
-  version "6.0.23"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
-  integrity sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==
-  dependencies:
-    chalk "^2.4.1"
-    source-map "^0.6.1"
-    supports-color "^5.4.0"
-
 postcss@^8.4.14, postcss@^8.4.19:
   version "8.4.23"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.23.tgz#df0aee9ac7c5e53e1075c24a3613496f9e6552ab"
@@ -14954,11 +14828,6 @@ prepend-http@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha512-PhmXi5XmoyKw1Un4E+opM2KcsJInDvKyuOumcjjw3waw86ZNjHwVUOOWLc4bCzLdcKNaWBH9e99sbWzDQsVaYg==
-
-prettier@1.16.3:
-  version "1.16.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.3.tgz#8c62168453badef702f34b45b6ee899574a6a65d"
-  integrity sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw==
 
 "prettier@^1.18.2 || ^2.0.0":
   version "2.8.8"
@@ -15544,36 +15413,6 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
-
-require-extension-hooks-babel@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/require-extension-hooks-babel/-/require-extension-hooks-babel-1.0.0.tgz#78755c505ab884077d51fc393bfc3b2884249777"
-  integrity sha512-n8+KxBVMjUgNz3ipFOrGoflWgiabcoGul8PE+5JZk1oA3/Bb5jtCvne/sRZ4TjkFuqDDOiWxPfAVK/UsL0iMOw==
-  dependencies:
-    "@babel/core" "^7.4.4"
-    "@babel/preset-env" "^7.4.4"
-
-require-extension-hooks-vue@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/require-extension-hooks-vue/-/require-extension-hooks-vue-3.0.0.tgz#09126a5ef7db5cd25c21346b848ed95e6e5cb615"
-  integrity sha512-vxjepJ6JOvpplt1wjLZH7hcyW6I7hKGdCI5Btr5kr/7hr/8WP9Qqojy/kgtlIN6KUMkPKpjAmx1VRmcuaH+abQ==
-  dependencies:
-    "@vue/component-compiler-utils" "^2.3.1"
-    consolidate "^0.15.1"
-    postcss "^7.0.14"
-    postcss-modules-sync "^1.0.0"
-    source-map-support "^0.5.10"
-
-require-extension-hooks@0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/require-extension-hooks/-/require-extension-hooks-0.3.3.tgz#e5a4eb1c821bf70b84a7e8374e3c4166dc42a820"
-  integrity sha512-UrOSBIFHu2D1pVyeCl3+5/FBE4aTgoxyYu5iDR0BhtwRsdSzNzrKAvQGUlbELj1LgjI0HNWLUaOpns+iZpw3eQ==
-  dependencies:
-    convert-source-map "^1.3.0"
-    merge-source-map "^1.0.3"
-    minimatch "^3.0.4"
-    mkdirp "^0.5.1"
-    source-map "^0.5.6"
 
 require-from-string@^2.0.2:
   version "2.0.2"
@@ -16331,7 +16170,7 @@ source-map-support@0.5.13:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map-support@^0.5.10, source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12, source-map-support@~0.5.20:
+source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12, source-map-support@~0.5.20:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
@@ -16587,11 +16426,6 @@ strict-uri-encode@^1.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==
 
-string-hash@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"
-  integrity sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==
-
 string-length@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-4.0.2.tgz#a8a8dc7bd5c1a82b9b3c8b87e125f66871b6e57a"
@@ -16767,14 +16601,7 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==
 
-supports-color@^3.2.3:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
-  integrity sha512-Jds2VIYDrlp5ui7t8abHN2bjAu4LV/q4N2KivFPpGH0lrka0BMq/33AmECUXlKPcHigkNaqfXRENFju+rlcy+A==
-  dependencies:
-    has-flag "^1.0.0"
-
-supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
+supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==


### PR DESCRIPTION
Fix #479 Fix #480 

This is the initial work for integration with PolicyReporter across the Dashboard.

- Adds Policy Reports Summary column to `Projects/Namespaces` list view
- Adds Policy Reports tab to Namespace and Pod detail views
- Bumped `@rancher/shell` to `0.3.25`


https://github.com/rancher/kubewarden-ui/assets/40806497/460f4e18-d0cc-48a7-8f0d-49d740f5afe7

