### PR TITLE
Fix bugs in UI tests

### DIFF
--- a/tests/e2e/pages/rancher-extensions.page.ts
+++ b/tests/e2e/pages/rancher-extensions.page.ts
@@ -30,7 +30,9 @@ export class RancherExtensionsPage extends BasePage {
 
     // Confirm and wait for extensions to be enabled
     await this.page.getByRole('button', { name: 'OK' }).click();
-    await expect(this.tabs).toBeVisible({timeout: 60_000})
+    await this.ui.withReload(async() => {
+      await expect(this.tabs).toBeVisible({timeout: 60_000})
+    }, 'Extensions enabled but not visible');
   }
 
   /**

--- a/tests/e2e/pages/rancher-ui.ts
+++ b/tests/e2e/pages/rancher-ui.ts
@@ -45,30 +45,6 @@ export class RancherUI {
             .getByRole('radio', {name: name})
     }
 
-    /**
-     * Execute commands in kubectl shell
-     * @param commands execute, have to finish with 0 exit code
-     */
-    async shell(...commands: string[]) {
-        const win = this.page.locator('#windowmanager')
-        const prompt = win.locator('.xterm-rows>div:has(span)').filter({hasText: ">"}).last()
-
-        // Open terminal
-        await this.page.locator('#btn-kubectl').click()
-        await expect(win.locator('.status').getByText('Connected', {exact: true})).toBeVisible({timeout: 30_000})
-        // Run command
-        for (const cmd of commands) {
-            await this.page.keyboard.type(cmd + ' || echo ERREXIT-$?')
-            await this.page.keyboard.press('Enter')
-            // Wait - command finished when prompt (>) has blinking cursor
-            await expect(prompt.locator('span.xterm-cursor')).toBeVisible({timeout: 60_000})
-            // Verify that it passed
-            await expect(win.getByText(/ERREXIT-[0-9]+/), {message: 'Shell command finished with an error'}).not.toBeVisible({timeout: 1})
-        }
-        // Close terminal
-        await win.locator('.tab').filter({hasText: 'Kubectl: local'}).locator('i.closer').click()
-    }
-
     // Labeled Select
     async select(label: string, option: string) {
         await this.page.locator('div.labeled-select')
@@ -101,8 +77,11 @@ export class RancherUI {
      * await editYaml(page, '{"policyServer": {"telemetry": { "enabled": false }}}')
      */
     async editYaml(page: Page, source: Function|string) {
+        const cmEditor = page.locator('div.CodeMirror-lines[role="presentation"]')
+
         // Load yaml from code editor
-        const lines = await page.locator('.CodeMirror-code > div > pre.CodeMirror-line').allTextContents();
+        await expect(cmEditor).toBeVisible()
+        const lines = await cmEditor.locator('pre.CodeMirror-line').allTextContents()
         let cmYaml = jsyaml.load(lines.join('\n')
             .replace(/\u00a0/g, " ")  // replace &nbsp; with space
             .replace(/\u200b/g, "")   // remove ZERO WIDTH SPACE last line
@@ -120,6 +99,31 @@ export class RancherUI {
         await page.keyboard.insertText(jsyaml.dump(cmYaml))
     }
 
+    /**
+     * Execute commands in kubectl shell, can process single-line commands
+     * @param commands execute, have to finish with 0 exit code
+     */
+    async shell(...commands: string[]) {
+        const win = this.page.locator('#windowmanager')
+        const prompt = win.locator('.xterm-rows>div:has(span)').filter({hasText: ">"}).last()
+        const input = win.getByLabel('Terminal input', {exact: true})
+
+        // Open terminal
+        await this.page.locator('#btn-kubectl').click()
+        await expect(win.locator('.status').getByText('Connected', {exact: true})).toBeVisible({timeout: 30_000})
+        // Run command
+        for (const cmd of commands) {
+            // Fill removes newlines, multiline commands require input.pressSequentially
+            await input.fill(cmd + ' || echo ERREXIT-$?')
+            await input.press('Enter')
+            // Wait - command finished when prompt is empty
+            await expect(prompt.getByText(/^>\s+$/)).toBeVisible({timeout: 60_000})
+            // Verify command exit status
+            await expect(win.getByText(/ERREXIT-[0-9]+/), {message: 'Shell command finished with an error'}).not.toBeVisible({timeout: 1})
+        }
+        // Close terminal
+        await win.locator('.tab').filter({hasText: 'Kubectl: local'}).locator('i.closer').click()
+    }
 
     /**
      * Call ui.withReload(async()=> { <code> }, 'Reason')


### PR DESCRIPTION
- Reload if extension enabling fails - sometimes after enabling extensions rancher goes back to "enable extensions" page https://github.com/rancher/kubewarden-ui/actions/runs/6375188301/job/17300660585

- Wait for YAML editor to load - allTextContents does not wait for element to be visible https://github.com/rancher/kubewarden-ui/actions/runs/6375188301/job/17303670466

- Fix shell bug matching previous prompt - wait for empty prompt after running command. Current solution can match prompt with text before pressing enter (string is still being typed) https://github.com/rancher/kubewarden-ui/actions/runs/6375188301/job/17305758440