### PR TITLE
Fix mutation annotation condition - Fix policy readme formatting

### DIFF
--- a/pkg/kubewarden/components/Policies/Create.vue
+++ b/pkg/kubewarden/components/Policies/Create.vue
@@ -13,7 +13,7 @@ import { Banner } from '@components/Banner';
 
 import AsyncButton from '@shell/components/AsyncButton';
 import Loading from '@shell/components/Loading';
-import ChartReadme from '@shell/components/ChartReadme';
+import Markdown from '@shell/components/Markdown';
 import Wizard from '@shell/components/Wizard';
 
 import {
@@ -35,7 +35,7 @@ export default ({
     AsyncButton,
     Banner,
     Loading,
-    ChartReadme,
+    Markdown,
     Wizard,
     PolicyGrid,
     Values
@@ -488,7 +488,7 @@ export default ({
       </template>
 
       <template #readme>
-        <ChartReadme v-if="packageValues" data-testid="kw-policy-create-readme" :version-info="packageValues" class="mb-20" />
+        <Markdown v-if="packageValues.readme" data-testid="kw-policy-create-readme" :value="packageValues.readme" class="mb-20" />
       </template>
 
       <template #values>

--- a/pkg/kubewarden/components/Policies/PolicyGrid.vue
+++ b/pkg/kubewarden/components/Policies/PolicyGrid.vue
@@ -165,7 +165,11 @@ export default {
 
   methods: {
     hasAnnotation(subtype, annotation) {
-      return subtype.data?.[annotation];
+      if ( subtype.data?.[annotation] && subtype.data?.[annotation] !== 'false' ) {
+        return true;
+      }
+
+      return false;
     },
 
     refresh() {
@@ -323,6 +327,10 @@ export default {
 
 <style lang="scss" scoped>
 $margin: 10px;
+
+::v-deep .vs__selected {
+  height: auto !important;
+}
 
 .step {
   &__policies {


### PR DESCRIPTION
Fix #491 Fix #492 

This fixes the annotation condition for mutating policies and the readme formatting during policy creation.

We were initially just checking for the existence of the annotation `kubewarden/mutation` to determine if it was a mutating policy. Now this checks for the existence and the truthy value.

The formatting of the Policy's readme was due to the `ChartReadme` component, the "breaks" mentioned in the issue were not `<br/>` tags but `margin`. Also if the readme had a level one header (e.g. `# Configuration`) these were automatically hidden.

___Mutation badge___
![mutation-fix](https://github.com/rancher/kubewarden-ui/assets/40806497/6a963363-7e00-4e49-8d7c-a41e3f79bb8f)


___Readme___
![readme-fix](https://github.com/rancher/kubewarden-ui/assets/40806497/aa56b993-38f6-484d-bc21-3cd25db225c6)
