### PR TITLE
Add policy report integrations to other resource areas

### DIFF
--- a/pkg/kubewarden/components/Dashboard/InstallView.vue
+++ b/pkg/kubewarden/components/Dashboard/InstallView.vue
@@ -41,10 +41,16 @@ export default {
     this.reloadReady = false;
 
     if ( !this.hasSchema ) {
-      const hash = [
-        this.$fetchType(SERVICE),
-        this.$fetchType(CATALOG.CLUSTER_REPO)
-      ];
+      const inStore = this.currentProduct.inStore;
+      const hash = [];
+
+      if ( this.$store.getters[`${ inStore }/canList`](SERVICE) ) {
+        hash.push(this.$fetchType(SERVICE));
+      }
+
+      if ( this.$store.getters[`${ inStore }/canList`](CATALOG.CLUSTER_REPO) ) {
+        hash.push(this.$fetchType(CATALOG.CLUSTER_REPO));
+      }
 
       await allHash(hash);
 

--- a/pkg/kubewarden/components/PolicyReporter/ResourceTab.vue
+++ b/pkg/kubewarden/components/PolicyReporter/ResourceTab.vue
@@ -35,7 +35,7 @@ export default {
     const fetchedReports = await getFilteredReports(this.$store, this.resource);
 
     if ( this.isNamespaceResource ) {
-      this.reports = fetchedReports.results || [];
+      this.reports = fetchedReports?.results || [];
     } else {
       this.reports = fetchedReports || [];
     }

--- a/pkg/kubewarden/index.ts
+++ b/pkg/kubewarden/index.ts
@@ -45,10 +45,50 @@ export default function($plugin: IPlugin, args: any) {
     { component: () => import('./components/PolicyReporter/ReporterPanel.vue') }
   );
 
+  $plugin.addPanel(
+    PanelLocation.RESOURCE_LIST,
+    {
+      resource: [
+        POD,
+        WORKLOAD_TYPES.CRON_JOB,
+        WORKLOAD_TYPES.DAEMON_SET,
+        WORKLOAD_TYPES.DEPLOYMENT,
+        WORKLOAD_TYPES.JOB,
+        WORKLOAD_TYPES.STATEFUL_SET,
+        INGRESS,
+        SERVICE
+      ]
+    },
+    { component: () => import('./components/PolicyReporter/ReporterPanel.vue') }
+  );
+
   /** Columns */
   $plugin.addTableColumn(
     TableColumnLocation.RESOURCE,
     { path: [{ urlPath: 'explorer/projectsnamespaces', endsWith: true }] },
+    {
+      name:      'policy-reports',
+      labelKey:  'kubewarden.policyReporter.headers.label',
+      getValue:  (row: any) => row,
+      weight:    3,
+      formatter: 'PolicyReportSummary'
+    }
+  );
+
+  $plugin.addTableColumn(
+    TableColumnLocation.RESOURCE,
+    {
+      resource: [
+        POD,
+        WORKLOAD_TYPES.CRON_JOB,
+        WORKLOAD_TYPES.DAEMON_SET,
+        WORKLOAD_TYPES.DEPLOYMENT,
+        WORKLOAD_TYPES.JOB,
+        WORKLOAD_TYPES.STATEFUL_SET,
+        INGRESS,
+        SERVICE
+      ]
+    },
     {
       name:      'policy-reports',
       labelKey:  'kubewarden.policyReporter.headers.label',

--- a/tests/unit/components/Dashboard/DashboardView.spec.ts
+++ b/tests/unit/components/Dashboard/DashboardView.spec.ts
@@ -66,9 +66,11 @@ describe('component: DashboardView', () => {
     ];
 
     const wrapper = shallowMount(DashboardView as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      data() {
+        return { psPods: pods };
+      },
       computed:  {
         defaultsApp:        () => null,
-        policyServerPods:   () => pods,
         globalPolicies:     () => [],
         namespacedPolicies: () => [],
         version:            () => '1.25'


### PR DESCRIPTION
Fix #481 Fix #482 Fix #483

This adds the policy reports column to these resources:
- pods
- cronjobs
- daemonsets
- deployments
- jobs
- statefulsets
- ingresses
- services


https://github.com/rancher/kubewarden-ui/assets/40806497/226c6d71-3d47-407f-9002-b0bce44a388a

Also fixed an issue on the Dashboard page where the policy server pods and controller version badge not displaying correctly.

