### PR TITLE
Add audit scanner test

### DIFF
--- a/tests/e2e/10-landing.spec.ts
+++ b/tests/e2e/10-landing.spec.ts
@@ -1,11 +1,11 @@
 import { test, expect } from './rancher-test';
-import { OverviewPage } from './pages/overview.page';
+import { KubewardenPage } from './pages/kubewarden.page';
 import { PolicyServersPage } from './pages/policyservers.page';
 import { AdmissionPoliciesPage } from './pages/admissionpolicies.page';
 import { ClusterAdmissionPoliciesPage } from './pages/clusteradmissionpolicies.page';
 
 test('Kubewarden Landing page', async({ page, ui }) => {
-  const kwPage = new OverviewPage(page);
+  const kwPage = new KubewardenPage(page);
   await kwPage.goto();
   await expect(page.getByRole('heading', { name: 'Welcome to Kubewarden' })).toBeVisible()
 

--- a/tests/e2e/50-policyreports.spec.ts
+++ b/tests/e2e/50-policyreports.spec.ts
@@ -29,8 +29,8 @@ test('PolicyReports', async({ page, ui }) => {
       await den.getByRole('textbox').fill('unsafelbl')
 
       // Customize because audit for "*" rules is skipped
-      await capPage.editYaml()
-      await ui.editYaml(ui.page, d => {
+      await ui.openYamlEditor()
+      await ui.editYaml(d => {
         d.spec.rules[0].apiGroups[0] = ""
         d.spec.rules[0].apiVersions[0] = "v1"
         d.spec.rules[0].resources[0] = "namespaces"

--- a/tests/e2e/60-tracing.spec.ts
+++ b/tests/e2e/60-tracing.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from './rancher-test';
+import { Chart, RancherAppsPage } from './pages/rancher-apps.page';
+import { PolicyServersPage } from './pages/policyservers.page';
+
+/**
+ * Expect timeout has to be increased after telemetry installation on local cluster
+ *
+ */
+test('Install opentelemetry & jaeger', async ({ page }) => {
+  const apps = new RancherAppsPage(page)
+  const otelChart: Chart = { title: 'opentelemetry-operator', name: 'opentelemetry-operator', namespace: 'open-telemetry', version: '0.38.0', check: 'opentelemetry-operator' }
+  const jaegerChart: Chart = { title: 'Jaeger Operator', namespace: 'jaeger', check: "jaeger-operator" }
+
+  // Install OpenTelemetry
+  await apps.addRepository('open-telemetry', 'https://open-telemetry.github.io/opentelemetry-helm-charts')
+  await apps.installChart(otelChart)
+
+  // Install Jaeger
+  await apps.installChart(jaegerChart, d => {
+    d.jaeger.create = "true"
+    d.rbac.clusterRole = "true"
+  })
+});
+
+test('Enable tracing in Kubewarden', async ({ page, ui }) => {
+  const apps = new RancherAppsPage(page)
+  await apps.updateApp('rancher-kubewarden-controller', d => {
+    d.telemetry.enabled = true
+    d.telemetry.tracing.jaeger.endpoint = "jaeger-operator-jaeger-collector.jaeger.svc.cluster.local:14250"
+    d.telemetry.tracing.jaeger.tls = {}
+    d.telemetry.tracing.jaeger.tls.insecure = true
+  })
+
+  // Wait until kubewarden controller and policyserver are restarted, it takes around 1m
+  await ui.shell(`for i in $(seq 60); do
+      echo "Retry #$i";
+      k logs -l app=kubewarden-policy-server-default -n cattle-kubewarden-system -c otc-container | grep -F 'Everything is ready.' && break || sleep 5;
+    done`)
+});
+
+test('Check traces are visible', async ({ page, ui }) => {
+  const tracingTab = page.getByRole('tablist').locator('li#policy-tracing')
+  const policiesTab = page.getByRole('tablist').locator('li#related-policies')
+  const logline = ui.getRow('tracing-privpod').row.first()
+
+  const psPage = new PolicyServersPage(page)
+  await psPage.goto()
+
+  // Create trace log line
+  await ui.shell('k run tracing-privpod --image=nginx:alpine --privileged')
+  console.warn('Workaround: Opentelemetry not installed warning before I generate traces')
+  await page.reload()
+
+  // Check logs on policy server
+  await ui.getRow('default').open()
+  await tracingTab.click()
+  await expect(logline).toBeVisible()
+
+  // Check logs on the policy
+  await policiesTab.click()
+  await ui.getRow('no-privileged-pod').open()
+  await tracingTab.click()
+  await expect(logline).toBeVisible()
+
+  // Cleanup
+  await ui.shell('k delete pod tracing-privpod')
+})

--- a/tests/e2e/exec.spec.ts
+++ b/tests/e2e/exec.spec.ts
@@ -1,10 +1,10 @@
 import { test } from './rancher-test'
-import { type Chart, RancherCommonPage } from './pages/rancher-common.page';
+import { type Chart, RancherAppsPage } from './pages/rancher-apps.page';
 
 const charts: Chart[] = [
-  {title: 'Jaeger Operator', namespace: 'jaeger', name: "jaeger-operator"},
-  {title: 'Monitoring', project: '(None)', name: "rancher-monitoring"},
-  {title: 'Kubewarden', project: 'Default', name: "rancher-kubewarden-controller"},
+  {title: 'Jaeger Operator', namespace: 'jaeger', check: "jaeger-operator"},
+  {title: 'Monitoring', project: '(None)', check: "rancher-monitoring"},
+  {title: 'Kubewarden', project: 'Default', check: "rancher-kubewarden-controller"},
 ]
 
 // Install chart from apps menu
@@ -12,15 +12,15 @@ const charts: Chart[] = [
 test('appInstall', async({ page}) => {
   const chart = charts.find(o => o.title === process.env.app) || charts[0]
 
-  const rancher = new RancherCommonPage(page)
-  await rancher.installApp(chart)
+  const apps = new RancherAppsPage(page)
+  await apps.installChart(chart)
 });
 
 // Upgrade without any changes will reload app yaml (patched by kubectl)
 // app='Jaeger Operator' pw test exec -g 'appUpdate' --headed
 test('appUpdate', async({ page }) => {
-    const chart = charts.find(o => o.title === process.env.app) || charts[0]
+    const app = process.env.app || 'jaeger-operator'
 
-    const rancher = new RancherCommonPage(page)
-    await rancher.updateApp(chart)
+    const apps = new RancherAppsPage(page)
+    await apps.updateApp(app)
 });

--- a/tests/e2e/pages/basepolicypage.ts
+++ b/tests/e2e/pages/basepolicypage.ts
@@ -54,14 +54,6 @@ export class BasePolicyPage extends BasePage {
     await this.ui.checkbox('Ignore Rancher Namespaces').setChecked(checked)
   }
 
-  async editYaml() {
-      // Give generated fields time to get registered
-      await this.page.waitForTimeout(200)
-      // Show yaml with edited settings
-      await this.page.getByRole('button', { name: 'Edit YAML' }).click()
-      await expect(this.page.getByTestId('kw-policy-config-yaml-editor')).toBeVisible()
-  }
-
   async open(p: Policy) {
     // Open list of policies
     await this.ui.createBtn.click()
@@ -91,7 +83,7 @@ export class BasePolicyPage extends BasePage {
     // Extra policy settings
     if (p.settings) {
       await p.settings(this.ui)
-      await this.editYaml()
+      await this.ui.openYamlEditor()
     }
   }
 

--- a/tests/e2e/pages/kubewarden.page.ts
+++ b/tests/e2e/pages/kubewarden.page.ts
@@ -1,7 +1,8 @@
 import { expect, Locator, Page } from '@playwright/test';
 import { BasePage } from './basepage';
+import { RancherAppsPage } from './rancher-apps.page';
 
-export class OverviewPage extends BasePage {
+export class KubewardenPage extends BasePage {
   readonly createPsBtn: Locator;
   readonly createApBtn: Locator;
   readonly createCapBtn: Locator;
@@ -58,21 +59,21 @@ export class OverviewPage extends BasePage {
 
     // ==================================================================================================
     // Rancher Application Metadata
-    await this.page.getByRole('button', { name: 'Next' }).click();
+    const apps = new RancherAppsPage(this.page)
+    await expect(apps.step1).toBeVisible()
+    await apps.nextBtn.click()
+    await expect(apps.step2).toBeVisible()
+
     // Rancher Application Values
     const schedule = this.ui.input('Schedule')
     await expect(schedule).toHaveValue('*/60 * * * *')
     await schedule.fill('*/1 * * * *')
     await this.ui.checkbox('Enable Policy Reporter').check()
 
-    // Enable telemetry
-    // await page.getByRole('button', { name: 'Edit YAML' }).click()
-    // await editYaml(page, d => d.telemetry.enabled = true )
-    // await page.getByRole('button', { name: 'Compare Changes' }).click()
-
-    await this.page.getByRole('button', { name: 'Install' }).click();
-    await expect(this.ui.helmPassRegex('rancher-kubewarden-crds')).toBeVisible({ timeout: 30_000 });
-    await expect(this.ui.helmPassRegex('rancher-kubewarden-controller')).toBeVisible({ timeout: 60_000 });
+    // Start installation
+    await apps.installBtn.click()
+    await apps.waitHelmSuccess('rancher-kubewarden-crds')
+    await apps.waitHelmSuccess('rancher-kubewarden-controller')
   }
 
   async whitelistArtifacthub() {

--- a/tests/e2e/pages/rancher-apps.page.ts
+++ b/tests/e2e/pages/rancher-apps.page.ts
@@ -1,0 +1,125 @@
+import type { Locator, Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { BasePage } from './basepage';
+
+export interface Chart {
+    title: string,    // Exact chart title displayed in Rancher
+    check: string,    // Used to check for helm success, chart name or tgz
+    name?: string,    // Desired chart name
+    version?: string,
+    namespace?: string,
+    project?: string,
+}
+
+export class RancherAppsPage extends BasePage {
+    readonly step1: Locator
+    readonly step2: Locator
+    readonly nextBtn: Locator
+    readonly installBtn: Locator
+    readonly updateBtn: Locator
+
+    constructor(page: Page) {
+        super(page, "dashboard/c/local/apps/charts")
+        this.step1 = page.getByRole('heading', { name: 'Install: Step 1' })
+        this.step2 = page.getByRole('heading', { name: 'Install: Step 2' })
+        this.nextBtn = page.getByRole('button', { name: 'Next' })
+        this.installBtn = page.getByRole('button', { name: 'Install' })
+        this.updateBtn = page.getByRole('button', { name: 'Update' })
+    }
+
+    /**
+     * Add helm charts repository to local cluster
+     * @param name
+     * @param url Git or http(s) url of the repository
+     */
+    async addRepository(name: string, url: string) {
+        await this.page.goto('dashboard/c/local/apps/catalog.cattle.io.clusterrepo/create')
+
+        await this.ui.input('Name *').fill(name)
+        if (url.endsWith('.git')) {
+            await this.page.getByRole('radio', { name: 'Git repository' }).check()
+            await this.ui.input('Git Repo URL *').fill(url)
+        } else {
+            await this.page.getByRole('radio', { name: 'http(s) URL' }).check()
+            await this.ui.input('Index URL *').fill(url)
+        }
+        await this.page.getByRole('button', { name: 'Create' }).click();
+
+        // Check repository state is Active
+        await this.ui.getRow(name).toBeActive()
+    }
+
+    /**
+     * Build regex matching successfull chart installation
+     * SUCCESS: helm upgrade ... rancher-kubewarden-defaults /home/shell/helm/kubewarden-defaults-1.7.3.tgz
+     * SUCCESS: helm [install|upgrade] [--generate-name=true|name]  /home/shell/helm/opentelemetry-operator-0.38.0.tgz
+     */
+    async waitHelmSuccess(text: string, timeout=60_000) {
+        // Can't match ^..$ because output is sometimes mixed up
+        const regex = new RegExp(`SUCCESS: helm.*${text}`)
+        const passedMsg = this.page.locator('div.logs-container').locator('span.msg').getByText(regex)
+        await expect(passedMsg).toBeVisible({ timeout: timeout })
+    }
+
+    async installChart(chart: Chart, yamlPatch?: Function | string, options?:{timeout?: number}) {
+        // Select chart by title
+        await this.page.goto('dashboard/c/local/apps/charts')
+        await expect(this.page.getByRole('heading', { name: 'Charts', exact: true })).toBeVisible()
+        await this.page.locator('.grid > .item').getByRole('heading', { name: chart.title, exact: true }).click()
+
+        if (chart.version) {
+            const versionPane = this.page.getByRole('heading', { name: 'Chart Versions', exact: true }).locator('..')
+            await versionPane.getByText('Show More', { exact: true }).click()
+            // Active version is bold text, not active are links
+            await versionPane.getByText(chart.version, { exact: true }).click()
+            await expect(versionPane.locator(`b:text-is("${chart.version}")`)).toBeVisible()
+        }
+        await this.installBtn.click()
+
+        // Chart metadata
+        await expect(this.step1).toBeVisible()
+        if (chart.name) {
+            await this.ui.input('Name').fill(chart.name)
+        }
+        if (chart.namespace) {
+            await this.ui.select('Namespace *', 'Create a New Namespace')
+            await this.ui.input('Namespace').fill(chart.namespace)
+        }
+        if (chart.project) {
+            await this.ui.select('Install into Project', chart.project)
+        }
+        await this.nextBtn.click()
+
+        // Chart questions
+        if (yamlPatch) {
+            await this.ui.openYamlEditor()
+            await this.ui.editYaml(yamlPatch)
+            await this.page.getByRole('button', { name: 'Compare Changes', exact: true }).click()
+        }
+
+        // Installation & Wait
+        await this.installBtn.click()
+        await this.waitHelmSuccess(chart.check, options?.timeout)
+    }
+
+    // Without parameters only for upgrade/reload
+    async updateApp(name: string, yamlPatch?: Function | string, options?:{timeout?: number}) {
+        await this.page.goto('dashboard/c/local/apps/catalog.cattle.io.app')
+        await expect(this.page.getByRole('heading', { name: 'Installed Apps' })).toBeVisible()
+
+        await this.ui.getRow(name).action('Edit/Upgrade')
+        await expect(this.page.getByRole('heading', { name: name })).toBeVisible()
+        await this.nextBtn.click()
+
+        // Chart questions
+        if (yamlPatch) {
+            await this.ui.openYamlEditor()
+            await this.ui.editYaml(yamlPatch)
+            await this.page.getByRole('button', { name: 'Compare Changes', exact: true }).click()
+        }
+
+        await this.updateBtn.click()
+        await this.waitHelmSuccess(name, options?.timeout)
+    }
+
+}

--- a/tests/e2e/pages/rancher-common.page.ts
+++ b/tests/e2e/pages/rancher-common.page.ts
@@ -1,13 +1,6 @@
 import { expect, Page } from '@playwright/test';
 import { BasePage } from './basepage';
 
-export interface Chart {
-  title: string,
-  name: string,
-  namespace?: string,
-  project?: string,
-}
-
 export class RancherCommonPage extends BasePage {
 
   constructor(page: Page) {
@@ -77,64 +70,6 @@ export class RancherCommonPage extends BasePage {
     await this.page.goto('/dashboard/prefs')
     await expect(this.page.getByRole('heading', { name: 'Advanced Features' })).toBeVisible()
     await this.ui.checkbox('Enable Extension developer features').setChecked(enabled)
-  }
-
-  /**
-   * Add helm charts repository to local cluster
-   * @param name
-   * @param url Git or http(s) url of the repository
-   */
-  async addRepository(name:string, url:string) {
-    await this.page.goto('dashboard/c/local/apps/catalog.cattle.io.clusterrepo/create')
-
-    await this.ui.input('Name *').fill(name)
-    if (url.endsWith('.git')) {
-      await this.page.getByRole('radio', { name: 'Git repository' }).check()
-      await this.ui.input('Git Repo URL *').fill(url)
-    } else {
-      await this.page.getByRole('radio', { name: 'http(s) URL' }).check()
-      await this.ui.input('Index URL *').fill(url)
-    }
-    await this.page.getByRole('button', { name: 'Create' }).click();
-
-    // Check repository state is Active
-    await this.ui.getRow(name).toBeActive()
-  }
-
-  async installApp(chart: Chart) {
-    // Select chart
-    await this.page.goto('dashboard/c/local/apps/charts')
-    await expect(this.page.getByRole('heading', { name: 'Charts', exact: true })).toBeVisible()
-    await this.page.locator('.grid > .item').getByRole('heading', { name: chart.title, exact: true }).click()
-    await this.page.getByRole('button', { name: 'Install' }).click()
-
-    // Select namespace or project
-    if (chart.namespace) {
-        await expect(this.page.getByRole('heading', { name: 'Install: Step 1' })).toBeVisible()
-        await this.ui.select('Namespace *', 'Create a New Namespace')
-        await this.ui.input('Namespace').fill(chart.namespace)
-    }
-    if (chart.project) {
-        await this.ui.select('Install into Project', chart.project)
-    }
-
-    // Installation & Wait
-    await this.page.getByRole('button', { name: 'Next' }).click() // readme
-    await this.page.getByRole('button', { name: 'Install' }).click()
-    await expect(this.ui.helmPassRegex(chart.name)).toBeVisible({timeout:300_000})
-  }
-
-  // Without parameters only for upgrade/reload
-  async updateApp(chart: Chart) {
-    await this.page.goto('dashboard/c/local/apps/catalog.cattle.io.app')
-    await expect(this.page.getByRole('heading', { name: 'Installed Apps' })).toBeVisible()
-
-    await this.ui.getRow(chart.name).action('Edit/Upgrade')
-    await expect(this.page.getByRole('heading', { name: chart.name })).toBeVisible()
-
-    await this.page.getByRole('button', { name: 'Next' }).click() // version
-    await this.page.getByRole('button', { name: 'Update' }).click()
-    await expect(this.ui.helmPassRegex(chart.name)).toBeVisible({timeout:300_000})
   }
 
 }

--- a/tests/e2e/policies.spec.ts
+++ b/tests/e2e/policies.spec.ts
@@ -88,14 +88,14 @@ async function setupVerifyImageSignatures(ui: RancherUI) {
   await ui.select('Signature Type', 'GithubAction')
   await ui.page.getByRole('button', {name: 'Add', exact: true}).click()
   await ui.input('Image*').fill('ghcr.io/kubewarden/*')
-  await ui.editYaml(ui.page, d => d.githubActions.owner = "kubewarden")
+  await ui.editYaml(d => d.githubActions.owner = "kubewarden")
 }
 
 async function setupEnvironmentVariablePolicy(ui: RancherUI) {
   await ui.page.getByRole('tab', { name: 'Settings' }).click()
   await ui.page.getByRole('button', {name: 'Add', exact: true}).click()
   await ui.select('Reject Operator', 'anyIn')
-  await ui.editYaml(ui.page, d => d.environmentVariables[0].name = "novar")
+  await ui.editYaml(d => d.environmentVariables[0].name = "novar")
 }
 
 async function setupUserGroupPSP(ui: RancherUI) {

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -22,7 +22,9 @@ export default defineConfig({
 
   // ===== Rancher specific config =====
   /* Maximum time one test can run for. */
-  timeout: 7 * 60_0000,
+  timeout: 7 * 60_000,
+  /* Expect timeout - increase from 5s to 10s because rancher is slow when loading pages */
+  expect: { timeout: 10_000 },
   /* Whether to report slow test files. */
   reportSlowTests: null,
   /* Path to the global setup file. */
@@ -37,7 +39,7 @@ export default defineConfig({
     /* Timeout for navigation actions like page.goto() */
     navigationTimeout: 60_000,
     /* Slows down Playwright operations by the specified amount of milliseconds. */
-    // launchOptions: { slowMo: 100 },
+    // launchOptions: { slowMo: 200 },
 
     ignoreHTTPSErrors: true,
     storageState: 'storageState.json',


### PR DESCRIPTION
- clean up editYaml methos
 - rename overviewPage to kubewardenPage
 - move code related to apps/charts to rancher-apps model
 - move installation of default policy server to corresponding model
 - get table row by text under Name column

Local run: https://github.com/kravciak/kubewarden-ui/actions/runs/6485951889/job/17613103544