### PR TITLE
Override rancher version by repository variable

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,34 +4,44 @@ on:
   workflow_dispatch:
     inputs:
       rancher:
+        description: Rancher version
         type: choice
-        default: 'rc'
-        description: Rancher
-        required: true
+        default: 'released'
         options:
-        - rc
-        - released
+        - 'released'
+        - '= 2.7.8'
+        - '> 2.7.9-0 < 2.8.0-0'
+        - '> 2.8.0-0 < 2.8.1-0'
       kubewarden:
+        description: Kubewarden version
         type: choice
         default: 'rc'
-        description: Kubewarden
         required: true
         options:
         - source
         - rc
         - released
       testsuite:
+        description: Testsuite
         type: choice
         default: 'install'
-        description: Testsuite
         required: true
         options:
-        - install (10 min)
-        - install + policies (10+30 min)
-
+        - install (15 min)
+        - install + policies (15+30 min)
       policyfilter:
-        type: string
         description: Policy Filter
+        type: string
+      k3s:
+        description: Kubernetes
+        type: choice
+        default: 'v1.26.9-k3s1'
+        required: true
+        options:
+        - v1.25.14-k3s1
+        - v1.26.9-k3s1
+        - v1.27.6-k3s1
+        - v1.28.2-k3s1
 
   pull_request:
     branches: main
@@ -45,7 +55,8 @@ on:
     - cron: "0 2 * * *"
 
 env:
-  K3S_VERSION: v1.25.9-k3s1
+  RANCHER: ${{ vars.RANCHER || 'released' }}
+  K3S_VERSION: ${{ inputs.k3s || 'v1.26.9-k3s1' }}
   K3D_CLUSTER_NAME: ${{ github.repository_owner }}-${{ github.event.repository.name }}-runner
 
 jobs:
@@ -73,12 +84,10 @@ jobs:
       run: |
         case ${{github.event_name}} in
           pull_request)
-            RANCHER=rc
             KUBEWARDEN=source
             TESTSUITE=install
             ;;
           schedule)
-            RANCHER=rc
             KUBEWARDEN=released
             TESTSUITE=policies
             ;;
@@ -88,14 +97,13 @@ jobs:
             TESTSUITE="${{ inputs.testsuite }}"
             ;;
           push)
-            RANCHER=released
             KUBEWARDEN=rc
             TESTSUITE=policies
         esac
 
         echo "Event: ${{github.event_name}}"
-        echo RANCHER=$RANCHER | tee -a $GITHUB_ENV
-        echo KUBEWARDEN=$KUBEWARDEN | tee -a $GITHUB_ENV
+        echo RANCHER="$RANCHER" | tee -a $GITHUB_ENV
+        echo KUBEWARDEN="$KUBEWARDEN" | tee -a $GITHUB_ENV
         echo TESTSUITE="$TESTSUITE" | tee -a $GITHUB_ENV
 
     # ==================================================================================================
@@ -121,15 +129,20 @@ jobs:
         kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml
         kubectl wait --for=condition=Available deployment --timeout=2m -n cert-manager --all
 
-        [ "${{ env.RANCHER }}" == 'rc' ] && RANCHER_DEVEL=1
+        # Translate to sematic version
+        [ "$RANCHER" == "released" ] && RANCHER='*'
+
+        # Rancher PSP is based on kubernetes version
         RANCHER_PSP=$(kubectl version -o json | jq -r '.serverVersion.minor <= "24"')
+
         helm repo add --force-update rancher-latest https://releases.rancher.com/server-charts/latest
+        helm search repo rancher-latest/rancher ${RANCHER:+--version "$RANCHER"}
         helm upgrade --install rancher rancher-latest/rancher --wait \
             --namespace cattle-system --create-namespace \
             --set hostname=$RANCHER_FQDN \
             --set bootstrapPassword=sa \
             --set global.cattle.psp.enabled=$RANCHER_PSP \
-            ${RANCHER_DEVEL:+--devel}
+            ${RANCHER:+--version "$RANCHER"}
 
         # Wait for rancher
         for i in {1..20}; do
@@ -140,7 +153,7 @@ jobs:
             [ $i -ne 20 ] && sleep 30 || { echo "Godot: pods not running"; exit 1; }
         done
 
-        echo "RANCHER_FQDN=$RANCHER_FQDN" >> $GITHUB_ENV
+        echo "RANCHER_FQDN=$RANCHER_FQDN" | tee -a $GITHUB_ENV
 
     # ==================================================================================================
     # Setup playwright ENV and run tests


### PR DESCRIPTION
- Rancher version
This allows to set up repository variable `RANCHER=value`. Value is sematic version that would be passed to helm command.

- Kubernetes version
Add choice for manually triggered runs to select kubernetes version


![Screenshot from 2023-10-18 10-35-53](https://github.com/rancher/kubewarden-ui/assets/538604/0334e37b-99f9-4af2-985d-39b57123db11)

