### PR TITLE
Allow to find table rows by columns

### DIFF
--- a/tests/e2e/50-policyreports.spec.ts
+++ b/tests/e2e/50-policyreports.spec.ts
@@ -3,6 +3,13 @@ import { Policy } from './pages/basepolicypage';
 import { ClusterAdmissionPoliciesPage } from './pages/clusteradmissionpolicies.page';
 import { PolicyReporterPage } from './pages/policyreporter.page';
 
+const testNs = 'audit-unsafe-ns'
+const testPod = 'audit-pod-privileged'
+const policyLabels = 'audit-safelabels'
+const policyPrivpod = 'no-privileged-pod' // recommended policy
+
+const expect_2m = expect.configure({timeout:2*60_000})
+
 /**
  * Prerequisities:
  *  - Audit scanner is enabled and set to run every minute during controller installation.
@@ -14,14 +21,14 @@ import { PolicyReporterPage } from './pages/policyreporter.page';
  *  - check errors are reported
  *  - delete policy and resources and check error are gone
  */
-test('PolicyReports', async({ page, ui }) => {
+test('New resources should be reported', async({ page, ui, nav }) => {
   const capPage = new ClusterAdmissionPoliciesPage(page)
   const reporter = new PolicyReporterPage(page)
-  const expect_2m = expect.configure({timeout:2*60_000})
 
   const p: Policy = {
     title: 'Safe Labels',
     mode: 'Monitor',
+    name: policyLabels,
     settings: async () => {
       await page.getByRole('tab', { name: 'Settings' }).click()
       const den = page.locator('.row').filter({hasText:'Denied labels'})
@@ -41,29 +48,57 @@ test('PolicyReports', async({ page, ui }) => {
   // Create policy and resources that break rules
   await capPage.goto()
   await ui.shell(
-    'k create ns audit-unsafe-ns',
-    'k label ns audit-unsafe-ns unsafelbl=secret',
-    'k run privpod -n audit-unsafe-ns --image=nginx:alpine --privileged',
+    `k create ns ${testNs}`,
+    `k label ns ${testNs} unsafelbl=secret`,
+    `k run ${testPod} -n ${testNs} --image=nginx:alpine --privileged`,
   )
-  const policy_row = await capPage.create(p, {wait: true})
+  await capPage.create(p, {wait: true})
 
   // Check that audit reported unsafe label and privileged pod
-  await reporter.goto()
+  await nav.explorer('Kubewarden', 'Policy Reporter')
   await expect_2m(reporter.failCpBanner).toHaveText('1')
-  await expect_2m(reporter.failNsBanner).toContainText('audit-unsafe-ns')
+  await expect_2m(reporter.failNsBanner).toContainText(testNs)
   await reporter.selectTab('Policy Reports')
-  await expect(reporter.failNsTable.getByRole('cell', {name: 'privpod', exact: true})).toBeVisible()
+  await expect(reporter.failNsTable.getByRole('cell', {name: testPod, exact: true})).toBeVisible()
   await reporter.selectTab('ClusterPolicy Reports')
-  await expect(reporter.failCpTable.getByRole('cell', {name: 'audit-unsafe-ns', exact: true})).toBeVisible()
+  await expect(reporter.failCpTable.getByRole('cell', {name: testNs, exact: true})).toBeVisible()
 
-  // Cleanup & check results are gone
-  await ui.shell('k delete ns audit-unsafe-ns')
-  await capPage.goto()
-  await policy_row.delete()
-  await reporter.goto()
+})
+
+test('Check reports on resources details page', async({ page, ui, nav }) => {
+  const ORIGIN = process.env.ORIGIN || (process.env.API ? 'source' : 'rc');
+  test.skip(ORIGIN === 'released', 'Requires kubewarden UI > 1.3.0')
+
+  const complianceTab = page.getByRole('tablist').locator('li#policy-report-tab')
+  // Check Pods Compliance column
+  await nav.explorer('Workloads', 'Pods')
+  const failrow = ui.getRow(testPod, {group: testNs})
+  await expect(failrow.column('Compliance').locator('div.bg-error')).toHaveText('1')
+  await expect(failrow.column('Compliance').locator('div.bg-success')).toHaveText('5')
+
+  // Check Compliance tab on pod details
+  await failrow.open()
+  await complianceTab.click()
+  await expect(ui.getRow({'Policy': policyPrivpod}).column('Status')).toHaveText('fail')
+
+  // Check namespace
+  await nav.explorer('Cluster', 'Projects/Namespaces')
+  await ui.getRow(testNs).open()
+  await complianceTab.click()
+  await expect(ui.getRow({Name: testPod, Policy: policyPrivpod}).column('Status')).toHaveText('fail')
+})
+
+test('Cleanup & check results are gone', async({ page, ui, nav }) => {
+  const reporter = new PolicyReporterPage(page)
+
+  await nav.explorer('Kubewarden', 'ClusterAdmissionPolicies')
+  await ui.shell(`k delete ns ${testNs}`)
+  await ui.getRow(policyLabels).delete()
+
+  await nav.explorer('Kubewarden', 'Policy Reporter')
   await expect_2m(reporter.failCpBanner).toHaveText('0')
   await reporter.selectTab('Policy Reports')
-  await expect(reporter.failNsTable.getByText('privpod')).not.toBeVisible()
+  await expect(reporter.failNsTable.getByText(testPod)).not.toBeVisible()
   await reporter.selectTab('ClusterPolicy Reports')
-  await expect(reporter.failCpTable.getByText('audit-unsafe-ns')).not.toBeVisible()
+  await expect(reporter.failCpTable.getByText(testNs)).not.toBeVisible()
 });

--- a/tests/e2e/components/table-row.ts
+++ b/tests/e2e/components/table-row.ts
@@ -2,15 +2,32 @@ import { expect, Locator } from '@playwright/test';
 import { RancherUI } from '../pages/rancher-ui';
 
 /**
- * Builds xpath expression to get column index by it's name
- * @param name Name of the table column
- * @returns xpath expression to get index of the column
+ * Compare text of current element with parameter(s)
+ * @param args
+ * @returns XPath predicate: normalize-space(.)="args[0]" [or ...]
  */
-function xpath_colIndex(...names: string[]):string {
-  // Transform: names > normalize-space(.)="names[0]" [or ...]
-  const selector = names.map(str => `normalize-space(.)="${str}"`).join(" or ")
-  // Find thead > th with requested name and count how many th was before it
-  return `count(ancestor::table[1]/thead/tr/th[${selector}]/preceding-sibling::th)+1`
+function text_is(...args: string[]):string {
+  return args.map(str => `normalize-space(.)="${str}"`).join(" or ")
+}
+
+/**
+ * Get table column index by it's name
+ * @param name Name of the table column
+ * @returns XPath predicate: count(ancestor::table[1]/thead/tr/th[normalize-space(.)="Name"]/preceding-sibling::th)+1
+ */
+function column_index(...names: string[]):string {
+  // Find thead > th with requested name and count how many th were before it
+  return `count(ancestor::table[1]/thead/tr/th[${text_is(...names)}]/preceding-sibling::th)+1`
+}
+
+/**
+ * Get table column by name and find cell with specified text
+ * @param column find table column with this name
+ * @param text find table cell with this text in selected column
+ * @returns XPath predicate: td[count(ancestor::table[1]/thead/tr/th[normalize-space(.)="Name"]/preceding-sibling::th)+1][normalize-space(.)="podname"]
+ */
+function xpath_column_selector(column: string, text: string) {
+  return `xpath=td[${column_index(column)}][${text_is(text)}]`
 }
 
 export class TableRow {
@@ -22,21 +39,43 @@ export class TableRow {
 
   /**
    *
-   * @param page is required by row actions menu since it's not child of the table
-   * @param name of the row, it is searched under "Name" column by default
-   * @param group When there are multiple tbodies filter by group-tab
-   *
+   * @param ui Page is required by row actions menu since it's not child of the table
+   * @param arg:string name of the row, looks for value under "Name" column
+   * @param arg:object row value under selected column(s) {column1: "value", "column 2": "value2"}
+   * @param options.group When there are multiple tbodies filter by group-tab (Project, Namespace, ..)
    */
-  constructor(ui: RancherUI, name: string, options?: {group?: string}) {
-    let tbody = ui.page.locator('table.sortable-table > tbody')
+  constructor(ui: RancherUI, arg: string | { [key: string]: string }, options?: {group?: string}) {
+    let table = ui.page.locator('table.sortable-table > tbody')
+
+    // Filter by project / namespace
     if (options?.group) {
-      tbody = tbody.filter({has: ui.page.getByRole('cell', {name: options.group, exact: true})})
+      const groupRegex = new RegExp(`^((Project|Namespace): )?${options.group}`)
+      table = table.filter({has: ui.page.getByRole('cell', {name: groupRegex})})
     }
+    let rows = table.locator('tr.main-row')
+
+    // Filter by argument
+    if (typeof arg === 'string') {
+      rows = rows.filter({has: ui.page.locator(xpath_column_selector('Name', arg)) })
+    } else if (typeof arg === 'object') {
+      for (const colName in arg) {
+        const colValue = arg[colName]
+        rows = rows.filter({has: ui.page.locator(xpath_column_selector(colName, colValue)) })
+      }
+    }
+    this.row = rows
 
     this.ui = ui
-    this.row = tbody.locator(`xpath=tr[td[${xpath_colIndex("Name")}][normalize-space(.)="${name}"]]`)
     this.name = this.column('Name')
     this.status = this.column('Status', 'State')
+  }
+
+  /**
+   * @param names header(s) of the column, you can provide alternative names (State|Status)
+   * @returns table cell (td) that is under requested column. Returns first cell if no match was found
+   */
+  column(...names: string[]) {
+    return this.row.locator(`xpath=td[${column_index(...names)}]`)
   }
 
   async toBeVisible() {
@@ -47,14 +86,6 @@ export class TableRow {
 
   async toBeActive(timeout = 200_000) {
     await expect(this.status).toHaveText('Active', {timeout: timeout})
-  }
-
-  /**
-   * @param names header of the column, you can provide alternative names (State|Status)
-   * @returns table cell (td) that is under requested column. Returns first cell if no match was found
-   */
-  column(...names: string[]) {
-      return this.row.locator(`xpath=td[${xpath_colIndex(...names)}]`)
   }
 
   async action(name: string) {

--- a/tests/e2e/pages/rancher-apps.page.ts
+++ b/tests/e2e/pages/rancher-apps.page.ts
@@ -61,7 +61,7 @@ export class RancherAppsPage extends BasePage {
         await expect(passedMsg).toBeVisible({ timeout: timeout })
     }
 
-    async installChart(chart: Chart, yamlPatch?: Function | string, options?:{timeout?: number}) {
+    async installChart(chart: Chart, options?:{questions?: () => Promise<void>, yamlPatch?: Function | string, timeout?: number}) {
         // Select chart by title
         await this.page.goto('dashboard/c/local/apps/charts')
         await expect(this.page.getByRole('heading', { name: 'Charts', exact: true })).toBeVisible()
@@ -91,9 +91,10 @@ export class RancherAppsPage extends BasePage {
         await this.nextBtn.click()
 
         // Chart questions
-        if (yamlPatch) {
+        if (options?.questions) await options.questions()
+        if (options?.yamlPatch) {
             await this.ui.openYamlEditor()
-            await this.ui.editYaml(yamlPatch)
+            await this.ui.editYaml(options.yamlPatch)
             await this.page.getByRole('button', { name: 'Compare Changes', exact: true }).click()
         }
 
@@ -103,7 +104,7 @@ export class RancherAppsPage extends BasePage {
     }
 
     // Without parameters only for upgrade/reload
-    async updateApp(name: string, yamlPatch?: Function | string, options?:{timeout?: number}) {
+    async updateApp(name: string, options?:{questions?: () => Promise<void>, yamlPatch?: Function | string, timeout?: number}) {
         await this.page.goto('dashboard/c/local/apps/catalog.cattle.io.app')
         await expect(this.page.getByRole('heading', { name: 'Installed Apps' })).toBeVisible()
 
@@ -112,9 +113,10 @@ export class RancherAppsPage extends BasePage {
         await this.nextBtn.click()
 
         // Chart questions
-        if (yamlPatch) {
+        if (options?.questions) await options.questions()
+        if (options?.yamlPatch) {
             await this.ui.openYamlEditor()
-            await this.ui.editYaml(yamlPatch)
+            await this.ui.editYaml(options.yamlPatch)
             await this.page.getByRole('button', { name: 'Compare Changes', exact: true }).click()
         }
 

--- a/tests/e2e/pages/rancher-ui.ts
+++ b/tests/e2e/pages/rancher-ui.ts
@@ -55,9 +55,8 @@ export class RancherUI {
 
     // ==================================================================================================
     // Table Handler
-
-    getRow(name: string, options?: {group?: string}) {
-        return new TableRow(this, name, {group: options?.group})
+    getRow(arg: string | { [key: string]: string }, options?: {group?: string}) {
+        return new TableRow(this, arg, options)
     }
 
     // ==================================================================================================


### PR DESCRIPTION
- Allow to find table rows by columns
- Use questions instead of yaml to set up tracing on controller
- Add test for audit reports in rancher explorer (skipped until 1.3.0)