### PR TITLE
Update removeEmptyAttrs method to keep false booleans

### DIFF
--- a/pkg/kubewarden/utils/object.ts
+++ b/pkg/kubewarden/utils/object.ts
@@ -5,7 +5,7 @@ export function removeEmptyAttrs(obj: any) {
   Object.keys(obj).forEach((key: any) => {
     const value = obj[key];
 
-    if ( !value || value === '' || (Array.isArray(value) && !value.length) || (isObject(value) && isEmpty(value)) ) {
+    if ( value === undefined || value === null || value === '' || (Array.isArray(value) && !value.length) || (isObject(value) && isEmpty(value)) ) {
       delete obj[key];
     } else if ( isObject(value) ) {
       removeEmptyAttrs(value);


### PR DESCRIPTION
Fix #516 

The issue was created by the `removeEmptyAttrs` method, it would remove any property that had a falsy value including a `boolean`. This has been updated to allow any `false` booleans, including `backgroundAudit: false`.


https://github.com/rancher/kubewarden-ui/assets/40806497/5c083bc0-8282-4727-b45b-e1fffef986d4

