### PR TITLE
Fix fetching of controllerChart from rancher store 

### DIFF
--- a/pkg/kubewarden/chart/kubewarden/policy-server/General.vue
+++ b/pkg/kubewarden/chart/kubewarden/policy-server/General.vue
@@ -1,5 +1,7 @@
 <script>
+import { mapGetters } from 'vuex';
 import isEmpty from 'lodash/isEmpty';
+
 import ResourceFetch from '@shell/mixins/resource-fetch';
 import { CATALOG } from '@shell/config/types';
 import { _CREATE } from '@shell/config/query-params';
@@ -72,12 +74,26 @@ export default {
   },
 
   computed: {
+    ...mapGetters({ charts: 'catalog/charts' }),
+
     isCreate() {
       return this.mode === _CREATE;
     },
 
     defaultsChart() {
-      return this.$store.getters['catalog/chart']({ chartName: KUBEWARDEN_CHARTS.DEFAULTS });
+      if ( this.kubewardenRepo ) {
+        return this.$store.getters['catalog/chart']({
+          repoName:  this.kubewardenRepo.repoName,
+          repoType:  this.kubewardenRepo.repoType,
+          chartName: KUBEWARDEN_CHARTS.DEFAULTS
+        });
+      }
+
+      return null;
+    },
+
+    kubewardenRepo() {
+      return this.charts?.find(chart => chart.chartName === KUBEWARDEN_CHARTS.DEFAULTS);
     },
 
     showVersionBanner() {

--- a/pkg/kubewarden/components/Dashboard/DashboardView.vue
+++ b/pkg/kubewarden/components/Dashboard/DashboardView.vue
@@ -69,7 +69,7 @@ export default {
         });
       }
 
-      return true;
+      return false;
     },
 
     /** Counts the current policy server pods - returns the status and total count */

--- a/pkg/kubewarden/components/Dashboard/InstallView.vue
+++ b/pkg/kubewarden/components/Dashboard/InstallView.vue
@@ -109,7 +109,7 @@ export default {
 
   computed: {
     ...mapGetters(['currentCluster', 'currentProduct']),
-    ...mapGetters({ allRepos: 'catalog/repos', t: 'i18n/t' }),
+    ...mapGetters({ charts: 'catalog/charts', t: 'i18n/t' }),
 
     isAirgap() {
       return this.$store.getters['kubewarden/airGapped'];
@@ -120,15 +120,19 @@ export default {
     },
 
     controllerChart() {
-      return this.$store.getters['catalog/chart']({ chartName: KUBEWARDEN_CHARTS.CONTROLLER });
+      if ( this.kubewardenRepo ) {
+        return this.$store.getters['catalog/chart']({
+          repoName:  this.kubewardenRepo.repoName,
+          repoType:  this.kubewardenRepo.repoType,
+          chartName: KUBEWARDEN_CHARTS.CONTROLLER
+        });
+      }
+
+      return null;
     },
 
     kubewardenRepo() {
-      if ( !this.isAirgap ) {
-        return this.allRepos?.find(r => r.spec.url === KUBEWARDEN_REPO);
-      }
-
-      return this.controllerChart;
+      return this.charts?.find(chart => chart.chartName === KUBEWARDEN_CHARTS.CONTROLLER);
     },
 
     shellEnabled() {

--- a/pkg/kubewarden/components/DefaultsBanner.vue
+++ b/pkg/kubewarden/components/DefaultsBanner.vue
@@ -30,9 +30,22 @@ export default {
 
   computed: {
     ...mapGetters(['currentCluster']),
+    ...mapGetters({ charts: 'catalog/charts', t: 'i18n/t' }),
 
     defaultsChart() {
-      return this.$store.getters['catalog/chart']({ chartName: KUBEWARDEN_CHARTS.DEFAULTS });
+      if ( this.kubewardenRepo ) {
+        return this.$store.getters['catalog/chart']({
+          repoName:  this.kubewardenRepo.repoName,
+          repoType:  this.kubewardenRepo.repoType,
+          chartName: KUBEWARDEN_CHARTS.DEFAULTS
+        });
+      }
+
+      return null;
+    },
+
+    kubewardenRepo() {
+      return this.charts?.find(chart => chart.chartName === KUBEWARDEN_CHARTS.DEFAULTS);
     },
   },
 

--- a/pkg/kubewarden/components/MetricsBanner.vue
+++ b/pkg/kubewarden/components/MetricsBanner.vue
@@ -39,10 +39,23 @@ export default {
 
   computed: {
     ...mapGetters(['currentProduct']),
+    ...mapGetters({ charts: 'catalog/charts' }),
     ...monitoringStatus(),
 
     monitoringChart() {
-      return this.$store.getters['catalog/chart']({ chartName: 'rancher-monitoring' });
+      if ( this.rancherRepo ) {
+        return this.$store.getters['catalog/chart']({
+          repoName:  this.kubewardenRepo.repoName,
+          repoType:  this.kubewardenRepo.repoType,
+          chartName: 'rancher-monitoring'
+        });
+      }
+
+      return null;
+    },
+
+    rancherRepo() {
+      return this.charts?.find(chart => chart.chartName === 'rancher-monitoring');
     }
   },
 

--- a/tests/unit/detail/PolicyServer.spec.ts
+++ b/tests/unit/detail/PolicyServer.spec.ts
@@ -50,7 +50,8 @@ describe('component: PolicyServer', () => {
             currentCluster:                  () => 'current_cluster',
             currentProduct:                  () => 'current_product',
             'current_product/all':           jest.fn(),
-            'i18n/t':                        jest.fn()
+            'i18n/t':                        jest.fn(),
+            'kubewarden/policyTraces':       () => TraceTestData
           },
         }
       },
@@ -111,7 +112,8 @@ describe('component: PolicyServer', () => {
             currentCluster:                  () => 'current_cluster',
             currentProduct:                  () => 'current_product',
             'current_product/all':           jest.fn(),
-            'i18n/t':                        jest.fn()
+            'i18n/t':                        jest.fn(),
+            'kubewarden/policyTraces':       () => TraceTestData
           },
         }
       },
@@ -152,7 +154,8 @@ describe('component: PolicyServer', () => {
             currentCluster:                  () => 'current_cluster',
             currentProduct:                  () => 'current_product',
             'current_product/all':           jest.fn(),
-            'i18n/t':                        jest.fn()
+            'i18n/t':                        jest.fn(),
+            'kubewarden/policyTraces':       () => TraceTestData
           },
         }
       },

--- a/tests/unit/templates/policyTraces.js
+++ b/tests/unit/templates/policyTraces.js
@@ -1,6 +1,7 @@
 export default [
   {
     policyName: 'disallow-np',
+    cluster:    'current_cluster',
     traces:     [
       {
         id:              '8bb0ad38f130c28f544491ea03a10b40',
@@ -32,6 +33,7 @@ export default [
   },
   {
     policyName: 'do-not-run-as-root',
+    cluster:    'current_cluster',
     traces:     [
       {
         id:        '0de3e0c42e65bee1589d712288c50ffc',
@@ -73,6 +75,7 @@ export default [
   },
   {
     policyName: 'do-not-share-host-paths',
+    cluster:    'current_cluster',
     traces:     [
       {
         id:        '6737aab871b84c88e0d72fe9ccd1c0ad',
@@ -90,6 +93,7 @@ export default [
   },
   {
     policyName: 'drop-capabilities',
+    cluster:    'current_cluster',
     traces:     [
       {
         id:        '6b45b47c049c232930506009ea6e3208',
@@ -107,6 +111,7 @@ export default [
   },
   {
     policyName: 'no-host-namespace-sharing',
+    cluster:    'current_cluster',
     traces:     [
       {
         id:        '1032644de83d5e3d19e292f870084dec',
@@ -124,6 +129,7 @@ export default [
   },
   {
     policyName: 'no-privilege-escalation',
+    cluster:    'current_cluster',
     traces:     [
       {
         id:        'd300801925447ca66a605e242c78902e',
@@ -165,6 +171,7 @@ export default [
   },
   {
     policyName: 'no-privileged-pod',
+    cluster:    'current_cluster',
     traces:     [
       {
         id:        '3c9375e05d413606bac9e21d17f1326b',


### PR DESCRIPTION
Related: https://github.com/kubewarden/kubewarden-controller/issues/465#issuecomment-1766102809

This fixes an issue with Rancher `2.8.0-rc1` where the Installation page was unable to find the kubewarden-controller chart even when the repository that contains the chart can be found. This issue was introduced by https://github.com/rancher/dashboard/pull/9806 - which applied new properties to the `catalog/chart` getter. 

Originally to obtain a chart this method did not require a repo name and repo type, now if a `repoName` and `repoType` are not passed along with the `chartName` it [will return nothing](https://github.com/rancher/dashboard/blob/a731478d208b1723040ec3db54f4b35bf124d59b/shell/store/catalog.js#L110-L121). This caused the controller chart to never be found, I have since added a method to retrieve the repo name and type, but ultimately this should be fixed on the dashboard side.

This same behavior was also found when searching for the kubewarden-defaults chart, thus causing the installation banner to not display correctly.

https://github.com/rancher/kubewarden-ui/assets/40806497/8582b68d-998a-4a8b-91d7-ecb000c0d0fd
