### PR TITLE
Fix policy reporter service/deployment loading

### DIFF
--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -287,6 +287,9 @@ kubewarden:
     url:
       banner:
         unavailable: The Policy Reporter UI proxy URL is unavailble, please ensure that the UI is properly configured.
+    deployment:
+      banner:
+        unavailable: "The Policy Reporter UI Deployment is currently in a `{ state }` state, please wait."
     headers:
       label: Compliance
       description: When using the Kubewarden Audit Scanner, the results of the policy scans are stored using the PolicyReport Custom Resource.

--- a/tests/unit/components/PolicyReporter/PolicyReporter.spec.ts
+++ b/tests/unit/components/PolicyReporter/PolicyReporter.spec.ts
@@ -12,6 +12,7 @@ const defaultMocks = {
     getters: {
       'cluster/schemaFor': jest.fn(),
       'i18n/t':            jest.fn(),
+      'management/byId':   () => 'local'
     }
   }
 };
@@ -23,7 +24,11 @@ const defaultComputed = {
   reporterCrds:                 () => null,
   controllerNamespace:          () => null,
   controllerVersion:            () => null,
-  canShowReporter:              () => null
+  canShowReporter:              () => null,
+  allDeployments:               () => null,
+  controllerDeployments:        () => null,
+  reporterDeployment:           () => null,
+  reporterDeploymentState:      () => 'active'
 };
 
 const mockCanShowReporter = (version: String): Boolean => {


### PR DESCRIPTION
Fix #520 

This fixes the loading of the Policy Reporter UI by properly fetching all deployments and services for the computed properties to then the related resources.


https://github.com/rancher/kubewarden-ui/assets/40806497/13d76314-2bb6-417f-8c41-56b6b1209f80

