### PR TITLE
Fix custom policy readme view component

### DIFF
--- a/pkg/kubewarden/components/Policies/Create.vue
+++ b/pkg/kubewarden/components/Policies/Create.vue
@@ -488,7 +488,7 @@ export default ({
       </template>
 
       <template #readme>
-        <Markdown v-if="packageValues.readme" data-testid="kw-policy-create-readme" :value="packageValues.readme" class="mb-20" />
+        <Markdown v-if="packageValues && packageValues.readme" data-testid="kw-policy-create-readme" :value="packageValues.readme" class="mb-20" />
       </template>
 
       <template #values>


### PR DESCRIPTION
Fix #526 

The Readme view is unable to load when using a custom policy as there is no readme, however, the condition that determines if the view was mounted was checking for the existence of `packageValues.readme`. This would cause an error if `packageValues` was `null` or `undefined`.

Added a separate check for `packageValues` in the addition to `packageValues.readme`.

https://github.com/rancher/kubewarden-ui/assets/40806497/eddb45d2-ea06-4574-8e3a-d1f4bd32f9d4


