### PR TITLE
Fix tracing checklist Update Config button link

### DIFF
--- a/pkg/kubewarden/components/TraceChecklist.vue
+++ b/pkg/kubewarden/components/TraceChecklist.vue
@@ -33,8 +33,20 @@ export default {
   computed: {
     ...mapGetters(['currentCluster']),
 
-    disableChartInstall() {
-      return !this.openTelSvc || !this.jaegerQuerySvc;
+    controllerLinkTooltip() {
+      if ( this.controllerLinkDisabled ) {
+        return this.t('kubewarden.monitoring.prerequisites.controllerConfig.tooltip');
+      }
+
+      if ( !this.controllerApp ) {
+        return this.t('kubewarden.monitoring.prerequisites.controllerConfig.chartError');
+      }
+
+      return null;
+    },
+
+    controllerLinkDisabled() {
+      return !this.openTelSvc || !this.jaegerQuerySvc || !this.controllerApp;
     },
 
     tracingEnabled() {
@@ -47,7 +59,7 @@ export default {
   },
 
   methods: {
-    chartRoute() {
+    controllerAppRoute() {
       if ( this.controllerApp ) {
         const metadata = this.controllerApp.spec?.chart?.metadata;
 
@@ -98,10 +110,11 @@ export default {
         <div class="checklist__config">
           <p v-clean-html="t('kubewarden.tracing.config.label', {}, true)" />
           <button
+            v-clean-tooltip="controllerLinkTooltip"
             data-testid="kw-tracing-checklist-step-config-button"
             class="btn role-primary ml-10"
-            :disabled="disableChartInstall"
-            @click.prevent="chartRoute"
+            :disabled="controllerLinkDisabled"
+            @click="controllerAppRoute"
           >
             {{ t("kubewarden.tracing.config.link") }}
           </button>

--- a/pkg/kubewarden/components/TraceTable.vue
+++ b/pkg/kubewarden/components/TraceTable.vue
@@ -147,8 +147,8 @@ export default {
     },
 
     tracingConfiguration() {
-      if ( this.controllerChart ) {
-        return this.controllerChart?.spec?.values?.telemetry?.tracing;
+      if ( this.controllerApp ) {
+        return this.controllerApp?.spec?.values?.telemetry?.tracing;
       }
 
       return null;

--- a/pkg/kubewarden/components/TraceTable.vue
+++ b/pkg/kubewarden/components/TraceTable.vue
@@ -6,7 +6,8 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 
 import { CATALOG, SERVICE } from '@shell/config/types';
 import { KUBERNETES } from '@shell/config/labels-annotations';
-import ResourceManager from '@shell/mixins/resource-manager';
+import ResourceFetch from '@shell/mixins/resource-fetch';
+import { allHash } from '@shell/utils/promise';
 
 import { BadgeState } from '@components/BadgeState';
 import { Banner } from '@components/Banner';
@@ -14,7 +15,7 @@ import Loading from '@shell/components/Loading';
 import SortableTable from '@shell/components/SortableTable';
 
 import { TRACE_HEADERS } from '../config/table-headers';
-import { KUBEWARDEN, KUBEWARDEN_APPS, MODE_MAP, OPERATION_MAP } from '../types';
+import { KUBEWARDEN, KUBEWARDEN_CHARTS, MODE_MAP, OPERATION_MAP } from '../types';
 import { jaegerTraces } from '../modules/jaegerTracing';
 import { formatDuration } from '../utils/duration-format';
 
@@ -42,14 +43,19 @@ export default {
     BadgeState, Banner, Loading, SortableTable, TraceChecklist
   },
 
-  mixins: [ResourceManager],
+  mixins: [ResourceFetch],
 
   async fetch() {
-    if ( this.$store.getters['cluster/canList'](SERVICE) ) {
-      this.allServices = await this.$store.dispatch('cluster/findAll', { type: SERVICE });
+    const types = [CATALOG.APP, CATALOG.CLUSTER_REPO, SERVICE];
+    const hash = [];
+
+    for ( const type of types ) {
+      if ( this.$store.getters['cluster/canList'](type) ) {
+        hash.push(this.$fetchType(type));
+      }
     }
-    this.secondaryResourceData = this.secondaryResourceDataConfig();
-    await this.resourceManagerFetchSecondaryResources(this.secondaryResourceData);
+
+    await allHash(hash);
 
     if ( this.jaegerQuerySvc ) {
       const options = {
@@ -76,16 +82,29 @@ export default {
       TRACE_HEADERS,
       OPERATION_MAP,
 
-      apps:                  null,
-      controllerChart:       null,
-      allServices:           null,
-      specificValidations:   null,
-      secondaryResourceData: this.secondaryResourceDataConfig()
+      specificValidations: null
     };
   },
 
   computed: {
     ...mapGetters(['currentCluster']),
+    ...mapGetters({ charts: 'catalog/charts' }),
+
+    allApps() {
+      return this.$store.getters['cluster/all'](CATALOG.APP);
+    },
+
+    allServices() {
+      return this.$store.getters['cluster/all'](SERVICE);
+    },
+
+    controllerApp() {
+      return this.allApps?.find(app => app?.spec?.chart?.metadata?.name === KUBEWARDEN_CHARTS.CONTROLLER);
+    },
+
+    controllerChart() {
+      return this.charts?.find(chart => chart.chartName === KUBEWARDEN_CHARTS.CONTROLLER);
+    },
 
     groupField() {
       if ( this.isPolicyServer ) {
@@ -144,11 +163,7 @@ export default {
     },
 
     jaegerServices() {
-      if ( this.allServices ) {
-        return this.allServices.filter(svc => svc?.metadata?.labels?.['app.kubernetes.io/part-of'] === 'jaeger');
-      }
-
-      return null;
+      return this.allServices?.filter(svc => svc?.metadata?.labels?.['app.kubernetes.io/part-of'] === 'jaeger');
     },
 
     jaegerQuerySvc() {
@@ -166,11 +181,7 @@ export default {
     },
 
     openTelemetryServices() {
-      if ( this.allServices ) {
-        return this.allServices.filter(svc => svc?.metadata?.labels?.[KUBERNETES.MANAGED_NAME] === 'opentelemetry-operator');
-      }
-
-      return null;
+      return this.allServices?.filter(svc => svc?.metadata?.labels?.[KUBERNETES.MANAGED_NAME] === 'opentelemetry-operator');
     },
 
     openTelSvc() {
@@ -211,22 +222,6 @@ export default {
   },
 
   methods: {
-    secondaryResourceDataConfig() {
-      return {
-        data:      {
-          [CATALOG.APP]: {
-            applyTo: [
-              { var: 'apps' },
-              {
-                var:         'controllerChart',
-                parsingFunc: data => data.find(app => app?.metadata?.name === KUBEWARDEN_APPS.RANCHER_CONTROLLER)
-              }
-            ]
-          }
-        }
-      };
-    },
-
     modeColor(mode) {
       return this.MODE_MAP[mode];
     },
@@ -251,7 +246,7 @@ export default {
   <div v-else>
     <TraceChecklist
       v-if="showChecklist"
-      :controller-chart="controllerChart"
+      :controller-app="controllerApp"
       :tracing-configuration="tracingConfiguration"
       :jaeger-query-svc="jaegerQuerySvc"
       :open-tel-svc="openTelSvc"

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -146,7 +146,7 @@ kubewarden:
     config: 
       label: |
         Tracing must be <a href="https://docs.kubewarden.io/operator-manual/telemetry/tracing/quickstart#install-kubewarden" target="_blank" rel="noopener noreferrer nofollow">enabled and configured</a> with a Jaeger endpoint in the Kubewarden Controller chart.
-      link: Update Chart
+      link: Update Config
   monitoring:
     notInstalled: |
       The Monitoring app is not installed, this will will need to be installed and configured to enable metrics. Follow <a href="https://docs.kubewarden.io/operator-manual/telemetry/metrics/quickstart#install-prometheus" target="_blank" rel="noopener noreferrer nofollow">these steps</a> to add the Kubewarden ServiceMonitor for Prometheus.


### PR DESCRIPTION
Fix #529 

This fixes the Tracing Checklist link to update the kubewarden-controller chart by passing in the controller's app resource instead of the chart. Also updated the wording from "Update Chart" to "Update Config" to be consistent with the Metrics Checklist.

https://github.com/rancher/kubewarden-ui/assets/40806497/eb0887b2-ec70-4221-924b-136febf29bd9

