### PR TITLE
Require `cattle-dashboards` namespace for metrics checklist

### DIFF
--- a/pkg/kubewarden/components/MetricsChecklist.vue
+++ b/pkg/kubewarden/components/MetricsChecklist.vue
@@ -17,6 +17,10 @@ import { serviceMonitorsConfigured } from '../modules/metricsConfig';
 
 export default {
   props: {
+    cattleDashboardNs: {
+      type:    Object,
+      default: null
+    },
     controllerApp: {
       type:    Object,
       default: null
@@ -78,11 +82,21 @@ export default {
         return this.t('kubewarden.monitoring.prerequisites.configMap.tooltip.appNotInstalled');
       }
 
-      if ( this.monitoringApp && !this.monitoringIsConfigured ) {
-        return this.t('kubewarden.monitoring.prerequisites.configMap.tooltip.appNotConfigured');
+      if ( this.monitoringApp ) {
+        if ( isEmpty(this.cattleDashboardNs) ) {
+          return this.t('kubewarden.monitoring.prerequisites.configMap.tooltip.nsNotFound');
+        }
+
+        if ( !this.monitoringIsConfigured ) {
+          return this.t('kubewarden.monitoring.prerequisites.configMap.tooltip.appNotConfigured');
+        }
       }
 
       return null;
+    },
+
+    dashboardButtonDisabled() {
+      return (!this.monitoringApp || isEmpty(this.cattleDashboardNs) || !this.monitoringIsConfigured);
     },
 
     emptyKubewardenDashboards() {
@@ -239,7 +253,7 @@ export default {
             data-testid="kw-monitoring-checklist-step-config-map-button"
             mode="grafanaDashboard"
             class="ml-10"
-            :disabled="!monitoringApp || !monitoringIsConfigured"
+            :disabled="dashboardButtonDisabled"
             @click="addDashboards"
           />
         </div>

--- a/pkg/kubewarden/components/MetricsChecklist.vue
+++ b/pkg/kubewarden/components/MetricsChecklist.vue
@@ -62,7 +62,7 @@ export default {
     },
 
     controllerLinkDisabled() {
-      return (!this.monitoringApp || !this.monitoringIsConfigured || !this.controllerChart || !this.controllerApp);
+      return (!this.monitoringApp || !this.monitoringIsConfigured || this.emptyKubewardenDashboards || !this.controllerChart || !this.controllerApp);
     },
 
     controllerLinkTooltip() {

--- a/pkg/kubewarden/components/TraceTable.vue
+++ b/pkg/kubewarden/components/TraceTable.vue
@@ -242,7 +242,7 @@ export default {
 </script>
 
 <template>
-  <Loading v-if="$fetchState.pending" />
+  <Loading v-if="$fetchState.pending" mode="relative" />
   <div v-else>
     <TraceChecklist
       v-if="showChecklist"

--- a/pkg/kubewarden/detail/policies.kubewarden.io.policyserver.vue
+++ b/pkg/kubewarden/detail/policies.kubewarden.io.policyserver.vue
@@ -196,11 +196,11 @@ export default {
         </template>
       </Tab>
 
-      <Tab name="policy-tracing" label="Tracing" :weight="98">
+      <Tab name="policy-tracing" label="Tracing" :weight="98" class="relative">
         <TraceTable :resource="resource" :related-policies="relatedPolicies" />
       </Tab>
 
-      <Tab #default="props" name="policy-metrics" label="Metrics" :weight="97">
+      <Tab #default="props" name="policy-metrics" label="Metrics" :weight="97" class="relative">
         <MetricsTab :resource="resource" :active="props.active" />
       </Tab>
     </ResourceTabs>
@@ -208,6 +208,10 @@ export default {
 </template>
 
 <style lang="scss" scoped>
+.relative {
+  position: relative;
+}
+
 .policy {
   &__mode {
     display: flex;

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -165,6 +165,7 @@ kubewarden:
         button: Add Dashboards
         tooltip:
           appNotInstalled: The Rancher Monitoring app is not yet installed.
+          nsNotFound: "The Namespace `cattle-dashboards` cannot be found."
           appNotConfigured: The Rancher Monitoring app is not configured correctly, please edit the configuration to add the appropriate Service Monitors.
       controllerConfig:
         label: The Kubewarden Controller must be configured to enable metrics. Follow <a href="https://docs.kubewarden.io/operator-manual/ui-extension/metrics#2-enable-telemetry-for-your-rancher-kubewarden-controller-resource" target="_blank" rel="noopener noreferrer nofollow">these steps</a> to properly configure the kubewarden-controller chart.

--- a/pkg/kubewarden/modules/grafana.ts
+++ b/pkg/kubewarden/modules/grafana.ts
@@ -37,7 +37,9 @@ export async function grafanaProxy(config: MetricsConfig): Promise<any> {
       return base + proxy + path;
     }
   } catch (e) {
-    handleGrowl({ error: e as GrowlConfig | any, store });
+    handleGrowl({
+      error: e as GrowlConfig | any, store, type: 'warning'
+    });
   }
 
   return null;
@@ -50,7 +52,9 @@ export async function grafanaService(store: any) {
       id:   'cattle-monitoring-system/rancher-monitoring-grafana'
     }, { root: true });
   } catch (e) {
-    handleGrowl({ error: e as GrowlConfig | any, store });
+    handleGrowl({
+      error: e as GrowlConfig | any, store, type: 'warning'
+    });
   }
 }
 
@@ -61,7 +65,9 @@ export async function findKubewardenDashboards(store: any) {
       selector: `kubewarden/part-of=cattle-kubewarden-system`
     });
   } catch (e) {
-    handleGrowl({ error: e as GrowlConfig | any, store });
+    handleGrowl({
+      error: e as GrowlConfig | any, store, type: 'warning'
+    });
   }
 }
 


### PR DESCRIPTION
Fix #538 

1. The "Add Dashboards" button is now also checking for the existence of the `cattle-dashboards` namespace and will be disabled with a tooltip explaining the situation if the namespace is not found.

https://github.com/rancher/kubewarden-ui/assets/40806497/330aed58-533b-4d71-ad53-d5cec5b2b8e2


3. The Error message is coming from the module that fetches the Grafana services, it is behaving as expected but I have updated the banner type to a "warning" rather than an "error" to keep it less alarming to the user.
![service-warning](https://github.com/rancher/kubewarden-ui/assets/40806497/81bf1cd1-4447-4a57-8d09-20925b4c6f5c)

