### PR TITLE
Wait for controller chart to be available for updating tracing config

### DIFF
--- a/pkg/kubewarden/components/DefaultsBanner.vue
+++ b/pkg/kubewarden/components/DefaultsBanner.vue
@@ -9,13 +9,14 @@ import { Banner } from '@components/Banner';
 import { KUBEWARDEN_CHARTS } from '../types';
 import { getLatestStableVersion } from '../plugins/kubewarden-class';
 import { handleGrowl } from '../utils/handle-growl';
+import { refreshCharts } from '../utils/chart';
 
 export default {
   components: { Banner },
 
   async fetch() {
-    if ( this.$store.getters[`cluster/canList`](CATALOG.CLUSTER_REPO) ) {
-      await this.$store.dispatch('catalog/refresh');
+    if ( !this.defaultsChart ) {
+      await refreshCharts({ store: this.$store, init: true });
     }
   },
 

--- a/pkg/kubewarden/components/MetricsTab.vue
+++ b/pkg/kubewarden/components/MetricsTab.vue
@@ -83,7 +83,7 @@ export default {
 
     await allHash(hash);
 
-    if ( this.showChecklist ) {
+    if ( this.showChecklist && !this.monitoringChart ) {
       await refreshCharts({ store: this.$store, init: true });
     }
 

--- a/pkg/kubewarden/components/TraceChecklist.vue
+++ b/pkg/kubewarden/components/TraceChecklist.vue
@@ -14,6 +14,10 @@ export default {
       type:    Object,
       default: null
     },
+    controllerChart: {
+      type:    Object,
+      default: null
+    },
     tracingConfiguration: {
       type:    Object,
       default: null
@@ -34,11 +38,11 @@ export default {
     ...mapGetters(['currentCluster']),
 
     controllerLinkTooltip() {
-      if ( this.controllerLinkDisabled ) {
+      if ( !this.openTelSvc || !this.jaegerQuerySvc ) {
         return this.t('kubewarden.monitoring.prerequisites.controllerConfig.tooltip');
       }
 
-      if ( !this.controllerApp ) {
+      if ( !this.controllerApp || !this.controllerChart ) {
         return this.t('kubewarden.monitoring.prerequisites.controllerConfig.chartError');
       }
 
@@ -46,7 +50,7 @@ export default {
     },
 
     controllerLinkDisabled() {
-      return !this.openTelSvc || !this.jaegerQuerySvc || !this.controllerApp;
+      return !this.openTelSvc || !this.jaegerQuerySvc || !this.controllerApp || !this.controllerChart;
     },
 
     tracingEnabled() {

--- a/pkg/kubewarden/components/TraceTable.vue
+++ b/pkg/kubewarden/components/TraceTable.vue
@@ -88,7 +88,7 @@ export default {
 
   computed: {
     ...mapGetters(['currentCluster']),
-    ...mapGetters({ charts: 'catalog/charts' }),
+    ...mapGetters({ charts: 'catalog/charts', refreshingCharts: 'kubewarden/refreshingCharts' }),
 
     allApps() {
       return this.$store.getters['cluster/all'](CATALOG.APP);
@@ -242,7 +242,7 @@ export default {
 </script>
 
 <template>
-  <Loading v-if="$fetchState.pending" mode="relative" />
+  <Loading v-if="$fetchState.pending || refreshingCharts" mode="relative" />
   <div v-else>
     <TraceChecklist
       v-if="showChecklist"

--- a/pkg/kubewarden/components/TraceTable.vue
+++ b/pkg/kubewarden/components/TraceTable.vue
@@ -247,6 +247,7 @@ export default {
     <TraceChecklist
       v-if="showChecklist"
       :controller-app="controllerApp"
+      :controller-chart="controllerChart"
       :tracing-configuration="tracingConfiguration"
       :jaeger-query-svc="jaegerQuerySvc"
       :open-tel-svc="openTelSvc"

--- a/pkg/kubewarden/detail/policies.kubewarden.io.policyserver.vue
+++ b/pkg/kubewarden/detail/policies.kubewarden.io.policyserver.vue
@@ -1,5 +1,7 @@
 <script>
 import { mapGetters } from 'vuex';
+import isEmpty from 'lodash/isEmpty';
+
 import { _CREATE } from '@shell/config/query-params';
 import { allHash } from '@shell/utils/promise';
 import CreateEditView from '@shell/mixins/create-edit-view';
@@ -11,7 +13,6 @@ import ResourceTabs from '@shell/components/form/ResourceTabs';
 import ResourceTable from '@shell/components/ResourceTable';
 import Tab from '@shell/components/Tabbed/Tab';
 
-import { isEmpty } from 'lodash';
 import { RELATED_HEADERS } from '../config/table-headers';
 
 import MetricsTab from '../components/MetricsTab';

--- a/pkg/kubewarden/store/kubewarden/actions.ts
+++ b/pkg/kubewarden/store/kubewarden/actions.ts
@@ -32,5 +32,10 @@ export default {
   },
   removePolicyTraceById({ commit }: any, policy: PolicyTraceConfig, trace: PolicyTrace) {
     commit('removePolicyTraceById', policy, trace);
+  },
+
+  // Charts
+  updateRefreshingCharts({ commit }: any, val: Boolean) {
+    commit('updateRefreshingCharts', val);
   }
 };

--- a/pkg/kubewarden/store/kubewarden/getters.ts
+++ b/pkg/kubewarden/store/kubewarden/getters.ts
@@ -7,5 +7,6 @@ export default {
   hideBannerArtifactHub:  (state: StateConfig): Boolean => state.hideBannerArtifactHub,
   hideBannerAirgapPolicy: (state: StateConfig): Boolean => state.hideBannerAirgapPolicy,
   policyReports:          (state: StateConfig): PolicyReport[] => state.policyReports,
-  policyTraces:           (state: StateConfig): PolicyTraceConfig[] => state.policyTraces
+  policyTraces:           (state: StateConfig): PolicyTraceConfig[] => state.policyTraces,
+  refreshingCharts:       (state: StateConfig): Boolean => state.refreshingCharts,
 };

--- a/pkg/kubewarden/store/kubewarden/index.ts
+++ b/pkg/kubewarden/store/kubewarden/index.ts
@@ -12,7 +12,8 @@ export interface StateConfig {
   hideBannerArtifactHub: Boolean,
   hideBannerAirgapPolicy: Boolean,
   policyReports: PolicyReport[]
-  policyTraces: PolicyTraceConfig[]
+  policyTraces: PolicyTraceConfig[],
+  refreshingCharts: Boolean,
 }
 
 const kubewardenFactory = (config: StateConfig): CoreStoreSpecifics => {
@@ -24,7 +25,8 @@ const kubewardenFactory = (config: StateConfig): CoreStoreSpecifics => {
         hideBannerArtifactHub:  config.hideBannerArtifactHub,
         hideBannerAirgapPolicy: config.hideBannerAirgapPolicy,
         policyReports:          config.policyReports,
-        policyTraces:           config.policyTraces
+        policyTraces:           config.policyTraces,
+        refreshingCharts:       config.refreshingCharts
       };
     },
 
@@ -43,7 +45,8 @@ export default {
     hideBannerArtifactHub:  false,
     hideBannerAirgapPolicy: false,
     policyReports:          [],
-    policyTraces:           []
+    policyTraces:           [],
+    refreshingCharts:       false
   }),
   config
 };

--- a/pkg/kubewarden/store/kubewarden/mutations.ts
+++ b/pkg/kubewarden/store/kubewarden/mutations.ts
@@ -83,5 +83,9 @@ export default {
     if ( idx && idx !== -1 ) {
       existingPolicyObj?.traces.splice(idx, 1);
     }
+  },
+
+  updateRefreshingCharts(state: StateConfig, val: Boolean) {
+    state.refreshingCharts = val;
   }
 };

--- a/pkg/kubewarden/utils/chart.ts
+++ b/pkg/kubewarden/utils/chart.ts
@@ -22,12 +22,16 @@ export async function refreshCharts(config: RefreshConfig): Promise<ReloadReady>
   }
 
   try {
+    store.dispatch('kubewarden/updateRefreshingCharts', true);
+
     await store.dispatch('catalog/refresh');
   } catch (e) {
     handleGrowl({ error: e as any, store });
   }
 
   if ( !chart && retry === 0 && !init ) {
+    store.dispatch('kubewarden/updateRefreshingCharts', true);
+
     await store.dispatch('catalog/refresh');
     await refreshCharts({
       store, init, retry: retry + 1, chart
@@ -37,6 +41,8 @@ export async function refreshCharts(config: RefreshConfig): Promise<ReloadReady>
   if ( !chart && retry === 1 && !init ) {
     return { reloadReady: true };
   }
+
+  store.dispatch('kubewarden/updateRefreshingCharts', false);
 
   return { reloadReady: false };
 }


### PR DESCRIPTION
This will add a condition to the tracing checklist step to update the kubewarden-controller config that will disable the button if the chart is still loading or not found.