### PR TITLE
Remove prometheus config from metrics checklist

### DIFF
--- a/pkg/kubewarden/components/MetricsTab.vue
+++ b/pkg/kubewarden/components/MetricsTab.vue
@@ -19,7 +19,6 @@ import { KUBEWARDEN, KUBEWARDEN_CHARTS, KubewardenDashboardLabels, KubewardenDas
 import { handleGrowl } from '../utils/handle-growl';
 import { refreshCharts } from '../utils/chart';
 import { grafanaProxy } from '../modules/grafana';
-import { monitoringIsConfigured } from '../modules/metricsConfig';
 
 import MetricsChecklist from './MetricsChecklist';
 
@@ -189,28 +188,16 @@ export default {
       return this.allConfigMaps.filter(configMap => configMap?.metadata?.labels?.[KubewardenDashboardLabels.DASHBOARD]);
     },
 
+    kubewardenControllerServiceMonitor() {
+      return this.allServiceMonitors?.find(sm => sm?.spec?.selector?.matchLabels?.[KUBERNETES.MANAGED_NAME] === KUBEWARDEN_CHARTS.CONTROLLER);
+    },
+
     monitoringApp() {
       return this.allApps?.find(app => app?.spec?.chart?.metadata?.name === 'rancher-monitoring');
     },
 
     monitoringChart() {
       return this.charts?.find(chart => chart.chartName === 'rancher-monitoring');
-    },
-
-    monitoringServiceMonitorsSpec() {
-      if ( this.monitoringApp ) {
-        return this.monitoringApp.spec?.values?.prometheus?.additionalServiceMonitors;
-      }
-
-      return null;
-    },
-
-    monitoringIsConfigured() {
-      return monitoringIsConfigured({
-        serviceMonitorSpec: this.monitoringServiceMonitorsSpec,
-        controllerApp:      this.controllerApp,
-        policyServerSvcs:   this.policyServerSvcs
-      });
     },
 
     openTelemetryServices() {
@@ -254,7 +241,7 @@ export default {
       const monitoringEnabled = this.controllerApp?.spec?.values?.telemetry?.metrics?.enabled;
       const grafanaDashboardsInstalled = !isEmpty(this.kubewardenGrafanaDashboards);
 
-      return !this.openTelSvc || !this.monitoringApp || !monitoringEnabled || !this.monitoringIsConfigured || !grafanaDashboardsInstalled;
+      return !this.openTelSvc || !this.monitoringApp || !monitoringEnabled || !grafanaDashboardsInstalled;
     }
   }
 };
@@ -268,6 +255,7 @@ export default {
       :cattle-dashboard-ns="cattleDashboardNs"
       :controller-app="controllerApp"
       :controller-chart="controllerChart"
+      :kubewarden-controller-service-monitor="kubewardenControllerServiceMonitor"
       :kubewarden-dashboards="kubewardenGrafanaDashboards"
       :monitoring-app="monitoringApp"
       :monitoring-chart="monitoringChart"

--- a/pkg/kubewarden/components/TraceChecklist.vue
+++ b/pkg/kubewarden/components/TraceChecklist.vue
@@ -63,6 +63,12 @@ export default {
   },
 
   methods: {
+    badgeIcon(prop) {
+      return {
+        'icon-dot-open': !prop, 'icon-checkmark': prop, 'text-success': prop
+      };
+    },
+
     controllerAppRoute() {
       if ( this.controllerApp ) {
         const metadata = this.controllerApp.spec?.chart?.metadata;
@@ -102,15 +108,15 @@ export default {
     />
     <div class="checklist__container mt-20 mb-20">
       <div class="checklist__step mt-20 mb-20" data-testid="kw-tracing-checklist-step-open-tel">
-        <i class="icon mr-10" :class="{ 'icon-dot-open': !openTelSvc,'icon-checkmark': openTelSvc }" />
+        <i class="icon mr-10" :class="badgeIcon(openTelSvc)" />
         <p v-clean-html="t('kubewarden.tracing.openTelemetry', {}, true)" />
       </div>
       <div class="checklist__step mb-20" data-testid="kw-tracing-checklist-step-jaeger">
-        <i class="icon mr-10" :class="{ 'icon-dot-open': !jaegerQuerySvc,'icon-checkmark': jaegerQuerySvc }" />
+        <i class="icon mr-10" :class="badgeIcon(jaegerQuerySvc)" />
         <p v-clean-html="t('kubewarden.tracing.jaeger', {}, true)" p />
       </div>
       <div class="checklist__step mb-20" data-testid="kw-tracing-checklist-step-config">
-        <i class="icon mr-10" :class="{ 'icon-dot-open': !tracingEnabled,'icon-checkmark': tracingEnabled }" />
+        <i class="icon mr-10" :class="badgeIcon(tracingEnabled)" />
         <div class="checklist__config">
           <p v-clean-html="t('kubewarden.tracing.config.label', {}, true)" />
           <button

--- a/pkg/kubewarden/formatters/PolicySummaryGraph.vue
+++ b/pkg/kubewarden/formatters/PolicySummaryGraph.vue
@@ -42,7 +42,7 @@ export default {
       const out = {};
 
       for ( const r of this.relatedPolicies ) {
-        const state = r.status?.policyStatus;
+        const state = r?.status?.policyStatus;
         const textColor = colorForStatus(state);
         const key = `${ textColor }/${ state }`;
 

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -156,17 +156,18 @@ kubewarden:
       description: There are a few resources which need to be installed and configured correctly for monitoring to be available.
       warning: The deployments of these resources can take a few minutes to become active.
       monitoringApp:
-        label: The Rancher Monitoring app must be installed with the Kubewarden Service Monitors added to the Prometheus spec. Follow the <a href="https://docs.kubewarden.io/operator-manual/ui-extension/metrics#install" target="_blank" rel="noopener noreferrer nofollow">documentation</a> to configure Prometheus.
+        label: The Rancher Monitoring app must be installed. Follow the <a href="https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/monitoring-alerting-guides/enable-monitoring" target="_blank" rel="noopener noreferrer nofollow">documentation</a> to install and enable Rancher Monitoring.
         install: Install App
         edit: Edit Config
         chartError: The Rancher Monitoring chart cannot be found, ensure the repository exists and try reloading the page.
+      serviceMonitor:
+        label: A Service Monitor for the Kubewarden Controller must be created. Follow the <a href="https://docs.kubewarden.io/operator-manual/telemetry/metrics/quickstart" target="_blank" rel="noopener noreferrer nofollow">documentation</a> to create the additional Service Monitors.
       configMap:
         label: Grafana Dashboards (ConfigMaps) for the Policy Servers and for Kubewarden Policies must be created.
         button: Add Dashboards
         tooltip:
           appNotInstalled: The Rancher Monitoring app is not yet installed.
           nsNotFound: "The Namespace `cattle-dashboards` cannot be found."
-          appNotConfigured: The Rancher Monitoring app is not configured correctly, please edit the configuration to add the appropriate Service Monitors.
       controllerConfig:
         label: The Kubewarden Controller must be configured to enable metrics. Follow <a href="https://docs.kubewarden.io/operator-manual/ui-extension/metrics#2-enable-telemetry-for-your-rancher-kubewarden-controller-resource" target="_blank" rel="noopener noreferrer nofollow">these steps</a> to properly configure the kubewarden-controller chart.
         button: Edit Config

--- a/pkg/kubewarden/types/metrics.ts
+++ b/pkg/kubewarden/types/metrics.ts
@@ -13,3 +13,13 @@ export interface ServiceMonitorSpec {
     matchLabels?: {[key: string]: string}
   }
 }
+
+export interface ServiceMonitor {
+  apiVersion: string,
+  kind: string,
+  metadata: {
+    name: string
+    namespace: string
+  },
+  spec: ServiceMonitorSpec
+}


### PR DESCRIPTION
Fix #548 

This removes the check for `additionalServiceMonitors` added to the Prometheus config and instead checks for the existence of a `ServiceMonitor` that has a selector pointing to the `kubewarden-controller`. The new step for service monitors will _not_ block the checklist from succeeding.

Also changed the colors of the checkmarks to be green.

![1](https://github.com/rancher/kubewarden-ui/assets/40806497/7c8c7c6b-fdd0-4275-85eb-a27b94ace5c4)
