### PR TITLE
Disable policy server input when editing policy config

### DIFF
--- a/pkg/kubewarden/chart/kubewarden/admission/General.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/General.vue
@@ -156,6 +156,7 @@ export default {
             :value="value"
             :mode="mode"
             :options="policyServerOptions"
+            :disabled="!isCreate"
             :label="t('kubewarden.policyConfig.serverSelect.label')"
             :tooltip="t('kubewarden.policyConfig.serverSelect.tooltip')"
           />


### PR DESCRIPTION
Fix #540 

This disables the Policy Server input within a policy's config when not creating a new policy.


https://github.com/rancher/kubewarden-ui/assets/40806497/0cdf341c-75c5-4fcc-9ae5-95f1d65fa1ed

