### PR TITLE
Fix new namespace creation when creating admission policy

### DIFF
--- a/pkg/kubewarden/chart/kubewarden/admission/General.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/General.vue
@@ -71,7 +71,14 @@ export default {
     return {
       policy,
       initialPolicyMode: null,
+      isNamespaceNew:    false
     };
+  },
+
+  watch: {
+    isNamespaceNew(neu) {
+      this.$set(this.value, 'isNamespaceNew', neu);
+    }
   },
 
   created() {
@@ -142,8 +149,10 @@ export default {
           :value="policy"
           :description-hidden="true"
           :namespaced="!isGlobal"
+          :namespace-new-allowed="true"
           name-key="metadata.name"
           namespace-key="metadata.namespace"
+          @isNamespaceNew="isNamespaceNew = $event"
         />
       </div>
     </div>


### PR DESCRIPTION
Fix #541 

This fixes the ability to create new namespaces when creating Admission Policies.


https://github.com/rancher/kubewarden-ui/assets/40806497/26e6b116-13e2-4fa1-a73c-550ab66e27df

