### PR TITLE
Filter policies targeting namespaced resources from AdmissionPolicy grid

### DIFF
--- a/pkg/kubewarden/chart/kubewarden/admission/Rules/Rule.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/Rules/Rule.vue
@@ -41,8 +41,6 @@ export default {
   components: { LabeledSelect },
 
   fetch() {
-    this.schemas = this.$store.getters[`${ this.currentProduct.inStore }/all`](SCHEMA);
-
     if ( this.isCreate && isEmpty(this.value?.apiGroups) ) {
       if ( !Array.isArray(this.value.apiGroups) ) {
         this.$set(this.value, 'apiGroups', []);
@@ -73,8 +71,7 @@ export default {
       operationOptions,
       apiGroupValues,
 
-      noResourceOptions: false,
-      schemas:           null
+      noResourceOptions: false
     };
   },
 
@@ -85,7 +82,9 @@ export default {
       const out = ['*'];
 
       if ( !isEmpty(this.apiGroups) ) {
-        this.apiGroups.map(g => out.push(g.id));
+        this.apiGroups.forEach((g) => {
+          out.push(g.id);
+        });
 
         const coreIndex = out.indexOf('core');
 
@@ -147,6 +146,10 @@ export default {
       const resourceSet = [...new Set(filtered?.map(f => f.attributes.resource))];
 
       return resourceSet.sort();
+    },
+
+    schemas() {
+      return this.$store.getters[`${ this.currentProduct.inStore }/all`](SCHEMA);
     }
   },
 

--- a/pkg/kubewarden/components/Policies/Create.vue
+++ b/pkg/kubewarden/components/Policies/Create.vue
@@ -500,16 +500,18 @@ export default ({
           <template #customSubtype>
             <div data-testid="kw-grid-subtype-card-custom" class="subtype custom" @click="selectType('custom')">
               <div class="subtype__metadata">
-                <div class="subtype__badge" :style="{ 'background-color': 'var(--darker)' }">
-                  <label>{{ t('kubewarden.customPolicy.badge') }}</label>
-                </div>
+                <div class="subtype__body">
+                  <div class="subtype__badge" :style="{ 'background-color': 'var(--darker)' }">
+                    <label>{{ t('kubewarden.customPolicy.badge') }}</label>
+                  </div>
 
-                <h4 class="subtype__label">
-                  {{ t('kubewarden.customPolicy.title') }}
-                </h4>
+                  <h4 class="subtype__label">
+                    {{ t('kubewarden.customPolicy.title') }}
+                  </h4>
 
-                <div class="subtype__description">
-                  {{ t('kubewarden.customPolicy.description') }}
+                  <div class="subtype__description">
+                    {{ t('kubewarden.customPolicy.description') }}
+                  </div>
                 </div>
               </div>
             </div>

--- a/pkg/kubewarden/modules/artifacthub.ts
+++ b/pkg/kubewarden/modules/artifacthub.ts
@@ -1,0 +1,63 @@
+import { ArtifactHubPackage } from '../types';
+
+/**
+ * Extracts resource kinds from a list of ArtifactHub packages with the `kubewarden/resources` annotation.
+ * @param artifactHubPackages
+ * @returns `string[]` | Resource kinds
+ */
+export function resourcesFromAnnotation(artifactHubPackages: ArtifactHubPackage[]): string[] | void {
+  const out: string[] = [];
+
+  const resources = artifactHubPackages?.flatMap((artifactHubPackage) => {
+    const annotation = artifactHubPackage?.data?.['kubewarden/resources'];
+
+    if ( annotation ) {
+      return annotation;
+    }
+  });
+
+  resources?.flatMap((resource) => {
+    if ( resource ) {
+      const split = resource.split(',');
+
+      if ( split.length > 1 ) {
+        split.forEach((s: string) => out.push(s));
+      } else {
+        out.push(resource);
+      }
+    }
+
+    return [];
+  })?.sort();
+
+  if ( !out || out?.length === 0 ) {
+    return [];
+  }
+
+  return [...new Set(out.filter(Boolean))];
+}
+
+/**
+ * Checks the resources within a ArtifactHub package's `kubewarden/resources` annotation to determine if
+ * the policy is targeting non-namespaced resources. Needed to gate CAP from AP grid.
+ * @param artifactHubPackage `schemas`
+ * @returns Boolean
+ */
+export function isGlobalPolicy(artifactHubPackage: ArtifactHubPackage, schemas: any): Boolean {
+  if ( artifactHubPackage ) {
+    const resources: string[] | undefined = artifactHubPackage.data?.['kubewarden/resources']?.split(',');
+    let targetsNonNamespaced: Boolean = false;
+
+    if ( resources ) {
+      for ( const resource of resources ) {
+        targetsNonNamespaced = schemas?.some((schema: any) => (
+          schema?.attributes?.kind === resource && (schema?.attributes?.namespaced === false || undefined)
+        ));
+      }
+    }
+
+    return targetsNonNamespaced;
+  }
+
+  return false;
+}

--- a/pkg/kubewarden/modules/core.ts
+++ b/pkg/kubewarden/modules/core.ts
@@ -1,3 +1,7 @@
+import isEmpty from 'lodash/isEmpty';
+
+import { SCHEMA } from '@shell/config/types';
+
 /**
  * To find the `type` of a resource that does not have the `group` listed, this
  * will split the `apiVersion` and concatenate it with the `kind`.
@@ -11,4 +15,26 @@ export function splitGroupKind(resource: any): string | void {
   if ( loweredKind && group ) {
     return `${ group }.${ loweredKind }`;
   }
+}
+
+export function namespacedGroups(store: any, apiGroups: any): any {
+  const schemas = store?.getters['cluster/all'](SCHEMA);
+
+  if ( !isEmpty(schemas) && !isEmpty(apiGroups) ) {
+    return schemas?.filter((schema: any) => {
+      let isNamespaced: Boolean = false;
+
+      for ( const group of apiGroups ) {
+        isNamespaced = schema?._group === group.id && !!(schema?.attributes?.namespaced === false || undefined);
+      }
+
+      if ( isNamespaced ) {
+        return schema;
+      }
+    }
+
+    );
+  }
+
+  return false;
 }

--- a/pkg/kubewarden/types.ts
+++ b/pkg/kubewarden/types.ts
@@ -1,3 +1,4 @@
+export * from './types/artifacthub';
 export * from './types/core';
 export * from './types/catalog.cattle.io.app';
 export * from './types/chart';

--- a/pkg/kubewarden/types/artifacthub.ts
+++ b/pkg/kubewarden/types/artifacthub.ts
@@ -1,0 +1,83 @@
+/* eslint-disable camelcase */
+export interface ArtifactHubPackage {
+  package_id: string,
+  name: string,
+  normalized_name: string,
+  category?: number,
+  is_operator?: boolean,
+  display_name: string,
+  description: string,
+  keywords?: string[],
+  home_url: string,
+  readme: string,
+  install: string,
+  links: [
+    {
+      url: string,
+      name: string,
+    }
+  ],
+  data?: {
+    'kubewarden/rules'?: string,
+    'kubewarden/mutation'?: string,
+    'kubewarden/resources'?: string,
+    'kubewarden/questions-ui'?: string,
+  },
+  version: string,
+  available_versions: [
+    {
+      version: string,
+      contains_security_updates?: boolean,
+      prerelease?: boolean,
+    }
+  ],
+  deprecated?: boolean,
+  contains_security_updates?: boolean,
+  prerelease?: boolean,
+  license: string,
+  signed?: boolean,
+  signatures?: string[],
+  containers_images?: [
+    {
+      name: string,
+      image: string,
+      whitelisted: boolean
+    }
+  ],
+  all_containers_images_whitelisted?: boolean,
+  provider?: string,
+  has_values_schema?: boolean,
+  has_changelog?: boolean,
+  maintainers?: [
+    {
+      name: string,
+      email: string,
+    }
+  ],
+  recommendations?: [
+    {
+      url: string,
+    }
+  ],
+  repository: {
+    repository_id: string,
+    name: string,
+    display_name: string,
+    url: string,
+    branch: string,
+    private?: boolean,
+    kind: number,
+    verified_publisher?: boolean,
+    official?: boolean,
+    cncf?: boolean,
+    scanner_disabled?: boolean,
+    organization_name?: string,
+    organization_display_name?: string,
+  },
+  stats?: {
+    subscriptions: number,
+    webhooks: number
+  },
+  production_organizations_count?: number
+}
+/* eslint-enable camelcase */


### PR DESCRIPTION
Fix #502 

When creating an AdmissionPolicy, this will filter out any policies from the Policy Grid that have a resource set in the `kubewarden/resources` annotation of the ArtifactHub metadata. For now that only equates to the [psa-label-enforcer-policy](https://github.com/kubewarden/psa-label-enforcer-policy/) as this targets the [`Namespace` resource.](https://github.com/kubewarden/psa-label-enforcer-policy/blob/df8757f1b766a81850e24cf33912afc1713decfb/artifacthub-pkg.yml#L105)

Also fixed some styling issues with the filtering inputs and policy cards within the policy grid.