### PR TITLE
Disable policy server name input when not creating

### DIFF
--- a/pkg/kubewarden/chart/kubewarden/policy-server/General.vue
+++ b/pkg/kubewarden/chart/kubewarden/policy-server/General.vue
@@ -154,6 +154,7 @@ export default {
           v-model="name"
           data-testid="ps-config-name-input"
           :mode="mode"
+          :disabled="!isCreate"
           :label="t('nameNsDescription.name.label')"
           :placeholder="t('nameNsDescription.name.placeholder')"
           required


### PR DESCRIPTION
Fix #558 

This disables the Policy Server name input when not creating.


https://github.com/rancher/kubewarden-ui/assets/40806497/9b913281-fc74-425e-97a9-8eacd53d3f85

