### PR TITLE
Separate Namespaced and Clusterwide policies

### DIFF
--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -3,7 +3,7 @@ import { RancherCommonPage } from './pages/rancher-common.page'
 import { RancherExtensionsPage } from './pages/rancher-extensions.page'
 import { KubewardenPage } from './pages/kubewarden.page'
 import { PolicyServersPage } from './pages/policyservers.page'
-import { policyList } from './pages/policies.page'
+import { apList, capList } from './pages/policies.page'
 import { RancherAppsPage } from './pages/rancher-apps.page'
 
 // source (yarn dev) | rc (add github repo) | released (just install)
@@ -86,15 +86,25 @@ test('04 Install default policyserver', async({ page }) => {
   await psPage.installDefault({ recommended: true, mode: 'monitor' })
 })
 
-test('05 Whitelist artifacthub', async({ page, ui, nav }) => {
-  const kwPage = new KubewardenPage(page)
+test('05 Whitelist Artifact Hub', async({ page, ui, nav }) => {
+  const policyCards = page.getByTestId(/^kw-grid-subtype-card/)
+
   await nav.explorer('Kubewarden', 'ClusterAdmissionPolicies')
   await ui.button('Create').click()
 
+  // Check counts before ArtifactHub
   await expect(page.getByRole('heading', { name: 'Custom Policy' })).toBeVisible()
-  await expect(page.locator('.subtype')).toHaveCount(1)
+  await expect(policyCards).toHaveCount(1)
 
-  await kwPage.whitelistArtifacthub()
+  // Whitelist ArtifactHub
+  await expect(page.getByText('Official Kubewarden policies are hosted on ArtifactHub')).toBeVisible()
+  await ui.button('Add ArtifactHub To Whitelist').click()
+
+  // Check counts after ArtifactHub
   await expect(page.getByRole('heading', { name: 'Pod Privileged Policy' })).toBeVisible()
-  await expect(page.locator('.subtype')).toHaveCount(policyList.length, { timeout: 5_000 })
+  await expect(policyCards).toHaveCount(capList.length)
+
+  await nav.explorer('Kubewarden', 'AdmissionPolicies')
+  await ui.button('Create').click()
+  await expect(policyCards).toHaveCount(apList.length)
 })

--- a/tests/e2e/pages/kubewarden.page.ts
+++ b/tests/e2e/pages/kubewarden.page.ts
@@ -37,10 +37,10 @@ export class KubewardenPage extends BasePage {
       const welcomeStep = this.page.getByText('Kubewarden is a policy engine for Kubernetes.')
       const addRepoStep = this.page.getByRole('heading', { name: 'Repository', exact: true })
       const appInstallStep = this.page.getByRole('heading', { name: 'Kubewarden App Install', exact: true })
-      const installBtn = this.page.getByRole('button', { name: 'Install Kubewarden', exact: true })
-      const addRepoBtn = this.page.getByRole('button', { name: 'Add Kubewarden Repository', exact: true })
+      const installBtn = this.ui.button('Install Kubewarden')
+      const addRepoBtn = this.ui.button('Add Kubewarden Repository')
       const failRepo = this.page.getByText('Unable to fetch Kubewarden Helm chart')
-      const failRepoBtn = this.page.getByRole('button', { name: 'Reload', exact: true })
+      const failRepoBtn = this.ui.button('Reload')
 
       // Welcome screen
       await this.goto()
@@ -92,10 +92,5 @@ export class KubewardenPage extends BasePage {
       await apps.installBtn.click()
       await apps.waitHelmSuccess('rancher-kubewarden-crds', { keepLog: true })
       await apps.waitHelmSuccess('rancher-kubewarden-controller')
-    }
-
-    async whitelistArtifacthub() {
-      await expect(this.page.getByText('Official Kubewarden policies are hosted on ArtifactHub')).toBeVisible()
-      await this.page.getByRole('button', { name: 'Add ArtifactHub To Whitelist' }).click()
     }
 }

--- a/tests/e2e/pages/policies.page.ts
+++ b/tests/e2e/pages/policies.page.ts
@@ -4,12 +4,14 @@ import { TableRow } from '../components/table-row'
 import { step } from '../rancher-test'
 import { BasePage } from './basepage'
 
-export const policyList = ['Custom Policy', 'Allow Privilege Escalation PSP', 'Allowed Fs Groups PSP', 'Allowed Proc Mount Types PSP', 'Apparmor PSP', 'Capabilities PSP',
+export const apList = ['Custom Policy', 'Allow Privilege Escalation PSP', 'Allowed Fs Groups PSP', 'Allowed Proc Mount Types PSP', 'Apparmor PSP', 'Capabilities PSP',
   'Deprecated API Versions', 'Disallow Service Loadbalancer', 'Disallow Service Nodeport', 'Echo', 'Environment Variable Secrets Scanner', 'Environment Variable Policy', 'Flexvolume Drivers Psp',
-  'Host Namespaces PSP', 'Hostpaths PSP', 'Ingress Policy', 'Namespace label propagator', 'Pod Privileged Policy', 'Pod Runtime', 'PSA Label Enforcer', 'Readonly Root Filesystem PSP',
+  'Host Namespaces PSP', 'Hostpaths PSP', 'Ingress Policy', 'Namespace label propagator', 'Pod Privileged Policy', 'Pod Runtime', 'Readonly Root Filesystem PSP',
   'Safe Annotations', 'Safe Labels', 'Seccomp PSP', 'Selinux PSP', 'Sysctl PSP', 'Trusted Repos', 'User Group PSP', 'Verify Image Signatures', 'volumeMounts', 'Volumes PSP', 'Unique Ingress host'] as const
 
-export type policyTitle = typeof policyList[number]
+export const capList = [...apList, 'PSA Label Enforcer']
+
+export type policyTitle = typeof capList[number]
 export type PolicyKind = 'AdmissionPolicy' | 'ClusterAdmissionPolicy'
 
 export interface Policy {

--- a/tests/e2e/policies.spec.ts
+++ b/tests/e2e/policies.spec.ts
@@ -1,6 +1,6 @@
 import { test } from './rancher-test'
 import type { RancherUI } from './components/rancher-ui'
-import { Policy, policyTitle, policyList, generateName, ClusterAdmissionPoliciesPage } from './pages/policies.page'
+import { Policy, policyTitle, capList, generateName, ClusterAdmissionPoliciesPage } from './pages/policies.page'
 import { PolicyServersPage } from './pages/policyservers.page'
 
 test.describe.configure({ mode: 'parallel' })
@@ -106,7 +106,7 @@ test.afterAll(async({ browser }) => {
 })
 
 // Generate installation test for every policy
-for (const title of policyList) {
+for (const title of capList) {
   test(`install: ${title}`, async({ page }) => {
     const { settings, skip } = policySettingsMap[title] || {}
     // Skip broken policies


### PR DESCRIPTION
Depends on release of https://github.com/rancher/kubewarden-ui/pull/560

Separate definition of `AP` & `CAP` and add check for their count.