### PR TITLE
Add filtering for AP rule sets to only include namespaced resources/groups

### DIFF
--- a/pkg/kubewarden/chart/kubewarden/admission/Rules/index.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/Rules/index.vue
@@ -1,12 +1,13 @@
 <script>
-import { mapGetters } from 'vuex';
 import { _CREATE, _VIEW } from '@shell/config/query-params';
+import { SCHEMA } from '@shell/config/types';
 import { removeAt } from '@shell/utils/array';
 
 import Loading from '@shell/components/Loading';
 
-import { KUBEWARDEN_APPS, ARTIFACTHUB_PKG_ANNOTATION } from '../../../../types';
 import Rule from './Rule';
+import { KUBEWARDEN, KUBEWARDEN_APPS, ARTIFACTHUB_PKG_ANNOTATION } from '~/pkg/kubewarden/types';
+import { namespacedGroups, namespacedSchemas } from '~/pkg/kubewarden/modules/core';
 
 export default {
   name: 'Rules',
@@ -24,8 +25,10 @@ export default {
 
   components: { Loading, Rule },
 
+  inject: ['chartType'],
+
   async fetch() {
-    await this.$store.dispatch(`${ this.currentProduct.inStore }/findAll`, { type: 'apigroup' });
+    await this.$store.dispatch('cluster/findAll', { type: 'apigroup' });
 
     this.rules = [];
 
@@ -39,10 +42,8 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['currentProduct']),
-
     apiGroups() {
-      return this.$store.getters[`${ this.currentProduct.inStore }/all`]('apigroup');
+      return this.$store.getters['cluster/all']('apigroup');
     },
 
     disabledRules() {
@@ -53,6 +54,26 @@ export default {
 
     isView() {
       return this.mode === _VIEW;
+    },
+
+    namespacedGroups() {
+      if ( this.chartType === KUBEWARDEN.ADMISSION_POLICY ) {
+        return namespacedGroups(this.$store, this.apiGroups);
+      }
+
+      return null;
+    },
+
+    namespacedSchemas() {
+      if ( this.chartType === KUBEWARDEN.ADMISSION_POLICY ) {
+        return namespacedSchemas(this.schemas);
+      }
+
+      return null;
+    },
+
+    schemas() {
+      return this.$store.getters['cluster/all'](SCHEMA);
     }
   },
 
@@ -79,6 +100,9 @@ export default {
         :disabled="disabledRules"
         :mode="mode"
         :api-groups="apiGroups"
+        :namespaced-groups="namespacedGroups"
+        :namespaced-schemas="namespacedSchemas"
+        :schemas="schemas"
       >
         <template v-if="!isView && !disabledRules" #removeRule>
           <button :data-testid="`kw-policy-rules-rule-remove-${ index }`" type="button" class="btn role-link p-0" @click="removeRule(index)">

--- a/pkg/kubewarden/modules/core.ts
+++ b/pkg/kubewarden/modules/core.ts
@@ -2,6 +2,8 @@ import isEmpty from 'lodash/isEmpty';
 
 import { SCHEMA } from '@shell/config/types';
 
+import { ApiGroup, Schema } from '../types';
+
 /**
  * To find the `type` of a resource that does not have the `group` listed, this
  * will split the `apiVersion` and concatenate it with the `kind`.
@@ -9,32 +11,67 @@ import { SCHEMA } from '@shell/config/types';
  * @returns `string | void` | Group type (e.g. `apps.deployment`)
  */
 export function splitGroupKind(resource: any): string | void {
-  const loweredKind = resource.kind?.toLowerCase();
-  const group = resource.apiVersion?.split('/')[0];
+  const loweredKind = resource?.kind?.toLowerCase();
+  const group = resource?.apiVersion?.split('/')[0];
 
   if ( loweredKind && group ) {
     return `${ group }.${ loweredKind }`;
   }
 }
 
-export function namespacedGroups(store: any, apiGroups: any): any {
-  const schemas = store?.getters['cluster/all'](SCHEMA);
+/**
+ * Find the schemas for a supplied `apiGroup`.
+ * @param store
+ * @param group: `ApiGroup | string` | Can either be a full apiGroup resource or the group id.
+ * @returns `Schema[]`
+ */
+export function schemasForGroup(store: any, group: ApiGroup | string): Schema[] {
+  const schemas: Schema[] = store?.getters['cluster/all'](SCHEMA) || [];
 
-  if ( !isEmpty(schemas) && !isEmpty(apiGroups) ) {
-    return schemas?.filter((schema: any) => {
-      let isNamespaced: Boolean = false;
-
-      for ( const group of apiGroups ) {
-        isNamespaced = schema?._group === group.id && !!(schema?.attributes?.namespaced === false || undefined);
-      }
-
-      if ( isNamespaced ) {
-        return schema;
-      }
-    }
-
-    );
+  if ( isEmpty(schemas) || isEmpty(group) ) {
+    return [];
   }
 
-  return false;
+  return schemas.filter((schema) => {
+    if ( typeof group === 'string' ) {
+      return schema._group === group;
+    }
+
+    return schema._group === group.id;
+  });
+}
+
+/**
+ * Filters supplied apiGroups that contain `namespaced` resources.
+ * @param store
+ * @param apiGroups `ApiGroup[]`
+ * @returns `ApiGroup[]`
+ */
+export function namespacedGroups(store: any, apiGroups: ApiGroup[]): ApiGroup[] | void {
+  const schemas: Schema[] = store?.getters['cluster/all'](SCHEMA);
+
+  if ( isEmpty(schemas) || isEmpty(apiGroups) ) {
+    return;
+  }
+
+  return apiGroups.reduce((filteredGroups: ApiGroup[], group: ApiGroup) => {
+    const filteredSchemas: Schema[] = schemasForGroup(store, group);
+
+    const out = filteredSchemas?.some(schema => !(schema?.attributes?.namespaced === false || undefined));
+
+    if ( out || group.id === 'core' ) {
+      filteredGroups.push(group);
+    }
+
+    return filteredGroups;
+  }, []);
+}
+
+/**
+ * Filteres supplied schemas with `namespaced` resources.
+ * @param schemas `Schema[]`
+ * @returns `Schema[] | void`
+ */
+export function namespacedSchemas(schemas: Schema[]): Schema[] | void {
+  return schemas?.filter(schema => !(schema?.attributes?.namespaced === false || undefined));
 }

--- a/pkg/kubewarden/types.ts
+++ b/pkg/kubewarden/types.ts
@@ -8,4 +8,5 @@ export * from './types/jaeger';
 export * from './types/metrics';
 export * from './types/policy';
 export * from './types/policy-reporter';
+export * from './types/rancher';
 export * from './types/service';

--- a/pkg/kubewarden/types/core.ts
+++ b/pkg/kubewarden/types/core.ts
@@ -53,3 +53,21 @@ export type Metadata = {
   state?: State;
   uid: string;
 }
+
+export type ApiGroup = {
+  id: string,
+  type: string,
+  links: {
+    self: string
+  },
+  versions?: [
+    {
+      groupVersion: string,
+      version: string,
+    }
+  ],
+  preferredVersion?: {
+    groupVersion: string,
+    version: string
+  }
+}

--- a/pkg/kubewarden/types/rancher.ts
+++ b/pkg/kubewarden/types/rancher.ts
@@ -1,0 +1,48 @@
+export type ResourceField = {
+  type: string,
+  nullable: boolean,
+  create: boolean,
+  required?: boolean,
+  update: boolean,
+  description: string
+}
+
+export type AttributeColumn = {
+  name: string,
+  type: string,
+  format: string,
+  description: string,
+  priority: number,
+  field: string
+}
+
+export type Schema = {
+  id: string,
+  type: string,
+  links: {
+    collection?: string,
+    self: string,
+  },
+  description: string,
+  pluralName?: string,
+  resourceMethods?: string[],
+  resourceFields?: {
+    apiVersion: ResourceField,
+    kind: ResourceField,
+    metadata: ResourceField,
+    spec: ResourceField,
+    status: ResourceField
+  },
+  collectionMethods?: string[],
+  attributes?: {
+    columns: AttributeColumn[],
+    group: string,
+    kind: string,
+    namespaced?: boolean,
+    resource?: string,
+    verbs: string[],
+    version: string,
+  },
+  _id: string,
+  _group: string,
+}

--- a/tests/unit/charts/admission/Rules.spec.ts
+++ b/tests/unit/charts/admission/Rules.spec.ts
@@ -17,7 +17,7 @@ describe('component: Rules', () => {
         return { rules: policyConfig.spec.rules };
       },
       propsData: { value: { policy: policyConfig } },
-      provide:   { chartType: KUBEWARDEN.ADMISSION_POLICY },
+      provide:   { chartType: KUBEWARDEN.CLUSTER_ADMISSION_POLICY },
       computed:  {
         currentProduct: () => {
           return { inStore: 'cluster' };
@@ -28,9 +28,9 @@ describe('component: Rules', () => {
         $fetchState: { pending: false },
         $store:      {
           getters: {
-            currentStore:               () => 'current_store',
-            'current_store/all':        jest.fn(),
-            'i18n/t':                   jest.fn()
+            currentStore:         () => 'current_store',
+            'cluster/all':        jest.fn(),
+            'i18n/t':             jest.fn()
           },
         }
       }

--- a/tests/unit/components/Policies/PolicyGrid.spec.ts
+++ b/tests/unit/components/Policies/PolicyGrid.spec.ts
@@ -3,10 +3,16 @@ import { DefaultProps } from 'vue/types/options';
 import { shallowMount } from '@vue/test-utils';
 import { describe, expect, it } from '@jest/globals';
 
+import { KUBEWARDEN } from '@kubewarden/types';
+
 import PolicyGrid from '@kubewarden/components/Policies/PolicyGrid.vue';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 
 import policyPackages from '../../templates/policyPackages.js';
+
+const defaultComputed = { allSchemas: jest.fn() };
+const defaultMocks = { $store: { getters: { 'i18n/t': jest.fn() } } };
+const defaultProvide = { chartType: KUBEWARDEN.ADMISSION_POLICY };
 
 describe('component: PolicyGrid', () => {
   it('should render custom card when provided empty packages', () => {
@@ -15,7 +21,9 @@ describe('component: PolicyGrid', () => {
 
     const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
       propsData: { targetNamespace: 'default', value: packages },
-      mocks:     { $store: { getters: { 'i18n/t': jest.fn() } } },
+      mocks:     defaultMocks,
+      provide:   defaultProvide,
+      computed:  defaultComputed,
       slots:     { customSubtype }
     });
 
@@ -28,7 +36,9 @@ describe('component: PolicyGrid', () => {
     const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
       propsData:  { targetNamespace: 'default', value: policyPackages },
       directives: { tooltip: jest.fn() },
-      mocks:      { $store: { getters: { 'i18n/t': jest.fn() } } },
+      mocks:      defaultMocks,
+      provide:    defaultProvide,
+      computed:   defaultComputed,
       slots:      { customSubtype }
     });
 
@@ -40,7 +50,9 @@ describe('component: PolicyGrid', () => {
     const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
       propsData:  { targetNamespace: 'default', value: policyPackages },
       directives: { tooltip: jest.fn() },
-      mocks:      { $store: { getters: { 'i18n/t': jest.fn() } } }
+      mocks:      defaultMocks,
+      provide:    defaultProvide,
+      computed:   defaultComputed
     });
 
     const selects = wrapper.findAllComponents(LabeledSelect);
@@ -52,7 +64,9 @@ describe('component: PolicyGrid', () => {
     const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
       propsData:  { targetNamespace: 'default', value: policyPackages },
       directives: { tooltip: jest.fn() },
-      mocks:      { $store: { getters: { 'i18n/t': jest.fn() } } }
+      mocks:      defaultMocks,
+      provide:    defaultProvide,
+      computed:   defaultComputed
     });
 
     expect(wrapper.html()).toContain('Allow Privilege Escalation PSP');
@@ -69,7 +83,9 @@ describe('component: PolicyGrid', () => {
     const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
       propsData:  { targetNamespace: 'default', value: policyPackages },
       directives: { tooltip: jest.fn() },
-      mocks:      { $store: { getters: { 'i18n/t': jest.fn() } } },
+      mocks:      defaultMocks,
+      provide:    defaultProvide,
+      computed:   defaultComputed,
     });
 
     const selects = wrapper.findAllComponents(LabeledSelect);
@@ -81,7 +97,9 @@ describe('component: PolicyGrid', () => {
     const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
       propsData:  { targetNamespace: 'default', value: policyPackages },
       directives: { tooltip: jest.fn() },
-      mocks:      { $store: { getters: { 'i18n/t': jest.fn() } } }
+      mocks:      defaultMocks,
+      provide:    defaultProvide,
+      computed:   defaultComputed
     });
 
     expect(wrapper.html()).toContain('Allow Privilege Escalation PSP');
@@ -100,7 +118,9 @@ describe('component: PolicyGrid', () => {
     const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
       propsData:  { targetNamespace: 'default', value: policyPackages },
       directives: { tooltip: jest.fn() },
-      mocks:      { $store: { getters: { 'i18n/t': jest.fn() } } }
+      mocks:      defaultMocks,
+      provide:    defaultProvide,
+      computed:   defaultComputed
     });
 
     const selects = wrapper.findAllComponents(LabeledSelect);
@@ -112,7 +132,9 @@ describe('component: PolicyGrid', () => {
     const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
       propsData:  { targetNamespace: 'default', value: policyPackages },
       directives: { tooltip: jest.fn() },
-      mocks:      { $store: { getters: { 'i18n/t': jest.fn() } } }
+      mocks:      defaultMocks,
+      provide:    defaultProvide,
+      computed:   defaultComputed
     });
 
     expect(wrapper.html()).toContain('Allow Privilege Escalation PSP');


### PR DESCRIPTION
Fix #563 

This adds filtering for the "API Groups" and "Resource type" options within an Admission Policy's rule set to only include apiGroups that contain `namespaced` resources and resources that are `namespaced`.