### PR TITLE
Remove telemetry after tests

### DIFF
--- a/tests/e2e/components/table-row.ts
+++ b/tests/e2e/components/table-row.ts
@@ -105,10 +105,10 @@ export class TableRow {
     }
 
     @step
-    async delete() {
+    async delete(options?: { timeout?: number }) {
       await this.action('Delete')
       await this.ui.page.getByTestId('prompt-remove-confirm-button').click()
-      await expect(this.row).not.toBeVisible()
+      await expect(this.row).not.toBeVisible(options)
     }
 
     async open() {


### PR DESCRIPTION
OpenTelemetry, Jaeger, Monitoring have high requirements for system resources.
We are testing on 16GB system, so follow-up tests might fail.

Possibly failed on this, rancher page failed to open: https://github.com/rancher/kubewarden-ui/actions/runs/7033754615/job/19140294287