### PR TITLE
Add initial Fleet deployment utils - determine ps module image for fleet

### DIFF
--- a/pkg/kubewarden/modules/fleet.ts
+++ b/pkg/kubewarden/modules/fleet.ts
@@ -20,32 +20,19 @@ export function isFleetDeployment(app: CatalogApp): Boolean {
 
 /**
  * Finds and returns the first `FleetBundle` from an array of `FleetBundle`s that meets a specific condition.
- * This function skips any `FleetBundle` that contains a resource named 'Chart.yaml' with a specified unwanted string in its `name` property.
+ * This function skips any `FleetBundle` that contains a chart that matches a specified unwanted chart name.
  * It then searches for a resource within each `FleetBundle` that has content including a specified `kind`.
  *
  * @param context - The string value to be matched within the `kind` property of a resource's content in each `FleetBundle`.
  * @param fleetBundles - An array of `FleetBundle` objects to be searched.
- * @param skipName? - The string value to be skipped. If a `FleetBundle` contains a 'Chart.yaml' resource with a `name` property matching this value, the bundle is skipped.
+ * @param skipChart? - The chart name string value to be skipped. If a `FleetBundle` contains a chart matching this value, the bundle is skipped.
  * @returns The first matching `FleetBundle` if found, or `null` if no match is found.
  */
-export function findFleetContent(context: string, fleetBundles: FleetBundle[], skipName?: string): FleetBundle | null {
+export function findFleetContent(context: string, fleetBundles: FleetBundle[], skipChart?: string): FleetBundle | null {
   if ( !isEmpty(fleetBundles) ) {
     for ( const bundle of fleetBundles ) {
-      if ( skipName ) {
-        // Check for Chart.yaml and skip if it contains the specific name
-        const chartYamlResource = bundle?.spec?.resources?.find(resource => resource.name === 'Chart.yaml');
-
-        if ( chartYamlResource ) {
-          try {
-            const chartYaml = jsyaml.load(chartYamlResource.content) as any;
-
-            if ( chartYaml?.name === skipName ) {
-              continue; // Skip this bundle
-            }
-          } catch (e) {
-            continue; // Skip this bundle if there's an error parsing
-          }
-        }
+      if ( skipChart && bundle?.spec?.helm?.chart === skipChart ) {
+        continue; // Skip this bundle
       }
 
       // Process the bundle for the context

--- a/pkg/kubewarden/modules/fleet.ts
+++ b/pkg/kubewarden/modules/fleet.ts
@@ -1,0 +1,96 @@
+import isEmpty from 'lodash/isEmpty';
+import jsyaml from 'js-yaml';
+
+import { FLEET } from '@shell/config/labels-annotations';
+import { CatalogApp, FleetBundle } from '@kubewarden/types';
+
+/**
+ * Determines if an App contains the annotation for a Fleet Bundle: 'fleet.cattle.io/bundle-id'
+ *
+ * @param app `CatalogApp`
+ * @returns Boolean
+ */
+export function isFleetDeployment(app: CatalogApp): Boolean {
+  if ( app ) {
+    return !!app.spec?.chart?.metadata?.annotations?.[FLEET.BUNDLE_ID];
+  }
+
+  return false;
+}
+
+/**
+ * Finds and returns the first `FleetBundle` from an array of `FleetBundle`s that meets a specific condition.
+ * This function skips any `FleetBundle` that contains a resource named 'Chart.yaml' with a specified unwanted string in its `name` property.
+ * It then searches for a resource within each `FleetBundle` that has content including a specified `kind`.
+ *
+ * @param context - The string value to be matched within the `kind` property of a resource's content in each `FleetBundle`.
+ * @param fleetBundles - An array of `FleetBundle` objects to be searched.
+ * @param skipName? - The string value to be skipped. If a `FleetBundle` contains a 'Chart.yaml' resource with a `name` property matching this value, the bundle is skipped.
+ * @returns The first matching `FleetBundle` if found, or `null` if no match is found.
+ */
+export function findFleetContent(context: string, fleetBundles: FleetBundle[], skipName?: string): FleetBundle | null {
+  if ( !isEmpty(fleetBundles) ) {
+    for ( const bundle of fleetBundles ) {
+      if ( skipName ) {
+        // Check for Chart.yaml and skip if it contains the specific name
+        const chartYamlResource = bundle?.spec?.resources?.find(resource => resource.name === 'Chart.yaml');
+
+        if ( chartYamlResource ) {
+          try {
+            const chartYaml = jsyaml.load(chartYamlResource.content) as any;
+
+            if ( chartYaml?.name === skipName ) {
+              continue; // Skip this bundle
+            }
+          } catch (e) {
+            continue; // Skip this bundle if there's an error parsing
+          }
+        }
+      }
+
+      // Process the bundle for the context
+      const matchingResource = bundle?.spec?.resources?.find(resource => resource.content.includes(`kind: ${ context }`));
+
+      if ( matchingResource ) {
+        return bundle;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Retrieves a module string in the format `${global.cattle.systemDefaultRegistry}/${policyServer.image.repository}:${policyServer.image.tag}`
+ * from a `FleetBundle` that matches a given context. The function uses `findFleetContent` to find the appropriate `FleetBundle`
+ * and then extracts the necessary properties from the 'values.yaml' file within that bundle.
+ *
+ * @param context - The context string used to find the matching `FleetBundle` via `findFleetContent`.
+ * @param fleetBundles - An array of `FleetBundle` objects to search through.
+ * @returns A module string in the specified format if all properties are found, or `null` if the `FleetBundle` does not exist or the properties are not found.
+ */
+export function getPolicyServerModule(fleetBundles: FleetBundle[]): string | null {
+  const fleetBundle = findFleetContent('PolicyServer', fleetBundles, 'kubewarden-crds');
+
+  if ( fleetBundle ) {
+    const valuesYamlResource = fleetBundle.spec.resources.find(resource => resource.name === 'values.yaml');
+
+    if ( valuesYamlResource ) {
+      try {
+        const valuesYaml = jsyaml.load(valuesYamlResource.content) as any;
+
+        const systemDefaultRegistry = valuesYaml?.global?.cattle?.systemDefaultRegistry;
+        const repository = valuesYaml?.policyServer?.image?.repository;
+        const tag = valuesYaml?.policyServer?.image?.tag;
+
+        if ( systemDefaultRegistry && repository && tag ) {
+          return `${ systemDefaultRegistry }/${ repository }:${ tag }`;
+        }
+      } catch (e) {
+        console.warn('Error parsing YAML:', e); // eslint-disable-line no-console
+      }
+    }
+  }
+
+  return null;
+}

--- a/pkg/kubewarden/plugins/kubewarden-class.js
+++ b/pkg/kubewarden/plugins/kubewarden-class.js
@@ -4,10 +4,7 @@ import isEmpty from 'lodash/isEmpty';
 import semver from 'semver';
 
 import SteveModel from '@shell/plugins/steve/steve-class';
-import {
-  STATES,
-  STATES_ENUM,
-} from '@shell/plugins/dashboard-store/resource-class';
+import { STATES, STATES_ENUM } from '@shell/plugins/dashboard-store/resource-class';
 import { MANAGEMENT, SERVICE } from '@shell/config/types';
 import { isArray } from '@shell/utils/array';
 import { addParams } from '@shell/utils/url';

--- a/pkg/kubewarden/store/kubewarden/actions.ts
+++ b/pkg/kubewarden/store/kubewarden/actions.ts
@@ -1,4 +1,6 @@
-import { PolicyReport, PolicyTraceConfig, PolicyTrace } from '../../types';
+import {
+  CatalogApp, CustomResourceDefinition, PolicyReport, PolicyTraceConfig, PolicyTrace
+} from '../../types';
 
 export default {
   updateAirGapped({ commit }: any, val: Boolean) {
@@ -37,5 +39,19 @@ export default {
   // Charts
   updateRefreshingCharts({ commit }: any, val: Boolean) {
     commit('updateRefreshingCharts', val);
+  },
+
+  // Catalog
+  updateControllerApp({ commit }: any, val: CatalogApp) {
+    commit('updateControllerApp', val);
+  },
+  removeControllerApp({ commit }: any, val: CatalogApp) {
+    commit('removeControllerApp', val);
+  },
+  updateKubewardenCrds({ commit }: any, val: CustomResourceDefinition) {
+    commit('updateKubewardenCrds', val);
+  },
+  removeKubewardenCrds({ commit }: any, val: CustomResourceDefinition) {
+    commit('removeKubewardenCrds', val);
   }
 };

--- a/pkg/kubewarden/store/kubewarden/getters.ts
+++ b/pkg/kubewarden/store/kubewarden/getters.ts
@@ -1,12 +1,14 @@
-import { PolicyReport, PolicyTraceConfig } from '../../types';
+import { CatalogApp, CustomResourceDefinition, PolicyReport, PolicyTraceConfig } from '../../types';
 import { StateConfig } from './index';
 
 export default {
-  airGapped:              (state: StateConfig): Boolean => state.airGapped,
-  hideBannerDefaults:     (state: StateConfig): Boolean => state.hideBannerDefaults,
-  hideBannerArtifactHub:  (state: StateConfig): Boolean => state.hideBannerArtifactHub,
-  hideBannerAirgapPolicy: (state: StateConfig): Boolean => state.hideBannerAirgapPolicy,
-  policyReports:          (state: StateConfig): PolicyReport[] => state.policyReports,
-  policyTraces:           (state: StateConfig): PolicyTraceConfig[] => state.policyTraces,
-  refreshingCharts:       (state: StateConfig): Boolean => state.refreshingCharts,
+  airGapped:               (state: StateConfig): Boolean => state.airGapped,
+  hideBannerDefaults:      (state: StateConfig): Boolean => state.hideBannerDefaults,
+  hideBannerArtifactHub:   (state: StateConfig): Boolean => state.hideBannerArtifactHub,
+  hideBannerAirgapPolicy:  (state: StateConfig): Boolean => state.hideBannerAirgapPolicy,
+  controllerApp:           (state: StateConfig): CatalogApp | null => state.controllerApp,
+  kubewardenCrds:          (state: StateConfig): CustomResourceDefinition[] => state.kubewardenCrds,
+  policyReports:           (state: StateConfig): PolicyReport[] => state.policyReports,
+  policyTraces:            (state: StateConfig): PolicyTraceConfig[] => state.policyTraces,
+  refreshingCharts:        (state: StateConfig): Boolean => state.refreshingCharts,
 };

--- a/pkg/kubewarden/store/kubewarden/index.ts
+++ b/pkg/kubewarden/store/kubewarden/index.ts
@@ -1,6 +1,13 @@
 import { CoreStoreSpecifics, CoreStoreConfig } from '@shell/core/types';
 
-import { KUBEWARDEN_PRODUCT_NAME, PolicyReport, PolicyTraceConfig } from '../../types';
+import {
+  KUBEWARDEN_PRODUCT_NAME,
+  CatalogApp,
+  CustomResourceDefinition,
+  FleetGitRepo,
+  PolicyReport,
+  PolicyTraceConfig
+} from '../../types';
 
 import getters from './getters';
 import mutations from './mutations';
@@ -8,9 +15,12 @@ import actions from './actions';
 
 export interface StateConfig {
   airGapped: Boolean,
+  fleetRepos: FleetGitRepo[],
   hideBannerDefaults: Boolean,
   hideBannerArtifactHub: Boolean,
   hideBannerAirgapPolicy: Boolean,
+  controllerApp: CatalogApp | null,
+  kubewardenCrds: CustomResourceDefinition[],
   policyReports: PolicyReport[]
   policyTraces: PolicyTraceConfig[],
   refreshingCharts: Boolean,
@@ -21,9 +31,12 @@ const kubewardenFactory = (config: StateConfig): CoreStoreSpecifics => {
     state: (): StateConfig => {
       return {
         airGapped:              config.airGapped,
+        fleetRepos:             config.fleetRepos,
         hideBannerDefaults:     config.hideBannerDefaults,
         hideBannerArtifactHub:  config.hideBannerArtifactHub,
         hideBannerAirgapPolicy: config.hideBannerAirgapPolicy,
+        controllerApp:          config.controllerApp,
+        kubewardenCrds:         config.kubewardenCrds,
         policyReports:          config.policyReports,
         policyTraces:           config.policyTraces,
         refreshingCharts:       config.refreshingCharts
@@ -41,9 +54,12 @@ const config: CoreStoreConfig = { namespace: KUBEWARDEN_PRODUCT_NAME };
 export default {
   specifics: kubewardenFactory({
     airGapped:              false,
+    fleetRepos:             [],
     hideBannerDefaults:     false,
     hideBannerArtifactHub:  false,
     hideBannerAirgapPolicy: false,
+    controllerApp:          null,
+    kubewardenCrds:         [],
     policyReports:          [],
     policyTraces:           [],
     refreshingCharts:       false

--- a/pkg/kubewarden/store/kubewarden/mutations.ts
+++ b/pkg/kubewarden/store/kubewarden/mutations.ts
@@ -1,4 +1,6 @@
-import { PolicyReport, PolicyTrace, PolicyTraceConfig } from '../../types';
+import {
+  CatalogApp, CustomResourceDefinition, PolicyReport, PolicyTrace, PolicyTraceConfig
+} from '../../types';
 import { StateConfig } from './index';
 
 export default {
@@ -13,6 +15,64 @@ export default {
   },
   updateHideBannerAirgapPolicy(state: StateConfig, val: Boolean) {
     state.hideBannerAirgapPolicy = val;
+  },
+
+  /**
+   * Updates/Adds Kubewarden Controller App into state
+   * @param state
+   * @param app `CatalogApp`
+   */
+  updateControllerApp(state: StateConfig, app: CatalogApp) {
+    if ( state.controllerApp?.id === app?.id ) {
+      state.controllerApp.metadata = app.metadata;
+      state.controllerApp.spec = app.spec;
+      state.controllerApp.status = app.status;
+    } else {
+      state.controllerApp = app;
+    }
+  },
+
+  /**
+   * Removes Kubewarden Controller App by ID
+   * @param state
+   * @param app `CatalogApp`
+   */
+  removeControllerApp(state: StateConfig, app: CatalogApp) {
+    const existing = state.controllerApp?.id === app?.id;
+
+    if ( existing ) {
+      state.controllerApp = null;
+    }
+  },
+
+  /**
+   * Updates/Adds CRD to state
+   * @param state
+   * @param crd `CustomResourceDefinition`
+   */
+  updateKubewardenCrds(state: StateConfig, crd: CustomResourceDefinition) {
+    const existingCrd = state.kubewardenCrds.find(c => c?.metadata?.name === crd?.metadata?.name);
+
+    if ( existingCrd ) {
+      existingCrd.metadata = crd.metadata;
+      existingCrd.spec = crd.spec;
+      existingCrd.status = crd.status;
+    } else {
+      state.kubewardenCrds.push(crd);
+    }
+  },
+
+  /**
+   * Removes CRD from state by `crd.metadata.name`
+   * @param state
+   * @param crd `CustomResourceDefinition`
+   */
+  removeKubewardenCrds(state: StateConfig, crd: CustomResourceDefinition) {
+    const idx = state.kubewardenCrds.findIndex(c => c?.metadata?.name === crd?.metadata?.name);
+
+    if ( idx !== -1 ) {
+      state.kubewardenCrds.splice(idx, 1);
+    }
   },
 
   /**

--- a/pkg/kubewarden/types.ts
+++ b/pkg/kubewarden/types.ts
@@ -2,6 +2,7 @@ export * from './types/artifacthub';
 export * from './types/core';
 export * from './types/catalog.cattle.io.app';
 export * from './types/chart';
+export * from './types/fleet';
 export * from './types/grafana';
 export * from './types/kubewarden';
 export * from './types/jaeger';

--- a/pkg/kubewarden/types/core.ts
+++ b/pkg/kubewarden/types/core.ts
@@ -1,3 +1,5 @@
+export type Label = { [key: string]: string };
+
 export type Links = {
   remove?: string;
   self?: string;
@@ -40,6 +42,17 @@ export type Relationship = {
   state: string
 }
 
+export type MatchExpression = {
+  key: string,
+  operator: string,
+  values: string[]
+}
+
+export type Selector = {
+  matchExpressions?: MatchExpression[],
+  matchLabels?: Label
+}
+
 export type Metadata = {
   annotations?: {[key: string]: string},
   creationTimestamp: string;
@@ -69,5 +82,53 @@ export type ApiGroup = {
   preferredVersion?: {
     groupVersion: string,
     version: string
+  }
+}
+
+export type CustomResourceDefinition = {
+  apiVersion: string,
+  kind: string,
+  metadata: Metadata,
+  spec: {
+    conversion: {
+      strategy: string,
+    },
+    group: string,
+    names: {
+      kind: string,
+      listKind?: string,
+      plural: string,
+      singular: string,
+    },
+    scope?: string,
+    versions?: [
+      {
+        additionalPrinterColumns?: [
+          {
+            description: string,
+            jsonPath: string,
+            name: string,
+            type: string,
+          }
+        ],
+        name: string,
+        schema: any,
+        served?: boolean,
+        storage?: boolean,
+        subresources?: {
+          status: {}
+        }
+      }
+    ]
+  },
+  status?: {
+    acceptedNames?: {
+      kind: string,
+      listKind: string,
+      plural: string,
+      singular: string,
+    },
+    conditions?: Array<Condition>,
+    storedVersions?: string[]
   }
 }

--- a/pkg/kubewarden/types/fleet.ts
+++ b/pkg/kubewarden/types/fleet.ts
@@ -1,0 +1,282 @@
+import { Label, Condition, Metadata, Selector } from './core';
+
+export type FleetGitRepo = {
+  apiVersion: string,
+  kind: string,
+  metadata: Metadata,
+  spec: {
+    branch?: string,
+    correctDrift?: {
+      enabled?: boolean,
+      force?: string,
+      keepFailHistory?: string,
+    },
+    insecureSkipTLSVerify?: boolean,
+    paths?: string[],
+    repo?: string,
+    targets?: [
+      {
+        clusterName?: string,
+      },
+      {
+        clusterGroup?: string,
+        clusterGroupSelector?: Selector,
+        clusterName?: string,
+        clusterSelector?: Selector,
+        name?: string,
+      }
+    ],
+    caBundle?: string,
+    clientSecretName?: string,
+    forceSyncGeneration?: string,
+    helmRepoURLRegex?: string,
+    helmSecretName?: string,
+    helmSecretNameForPaths?: string,
+    imageScanCommit?: {
+      authorEmail?: string,
+      authorName?: string,
+      messageTemplate?: string,
+    },
+    imageScanInterval?: string,
+    keepResources?: string,
+    paused?: string,
+    pollingInterval?: string,
+    revision?: string,
+    serviceAccount?: string,
+    targetNamespace?: string,
+  },
+  status: {
+    commit?: string,
+    conditions: Condition[],
+    desiredReadyClusters?: number,
+    display?: {
+      readyBundleDeployments: string,
+    },
+    gitJobStatus?: string,
+    lastSyncedImageScanTime?: string,
+    observedGeneration?: number,
+    readyClusters?: number,
+    resourceCounts?: {
+      desiredReady: number,
+      missing: number,
+      modified: number,
+      notReady: number,
+      orphaned: number,
+      ready: number,
+      unknown: number,
+      waitApplied: number
+    },
+    resources?: [
+      {
+        apiVersion: string,
+        id: string,
+        kind: string,
+        name: string,
+        state: string,
+        type: string,
+      },
+    ],
+    summary?: {
+      desiredReady: number,
+      ready: number
+    }
+  }
+}
+
+export type FleetBundle = {
+  apiVersion: string,
+  kind: string,
+  metadata: Metadata,
+  spec: {
+    correctDrift: {
+      enabled: boolean,
+      force: boolean,
+      keepFailHistory: boolean
+    },
+    defaultNamespace: string,
+    dependsOn: [
+      {
+        name: string,
+        selector: Selector
+      }
+    ],
+    diff: {
+      comparePatches: [
+        {
+          apiVersion: string,
+          jsonPointers: string[],
+          kind: string,
+          name: string,
+          namespace: string,
+          operations: [
+            {
+              op: string,
+              path: string,
+              value: string
+            }
+          ]
+        }
+      ]
+    },
+    forceSyncGeneration: number,
+    helm: {
+      atomic: boolean,
+      chart: string,
+      disableDNS: boolean,
+      disablePreProcess: boolean,
+      force: boolean,
+      maxHistory: number,
+      releaseName: string,
+      repo: string,
+      skipSchemaValidation: boolean,
+      takeOwnership: boolean,
+      timeoutSeconds: number,
+      values: any,
+      valuesFiles: string[],
+      valuesFrom: [
+        {
+          configMapKeyRef: {
+            key: string,
+            name: string,
+            namespace: string
+          },
+          secretKeyRef: {
+            key: string,
+            name: string,
+            namespace: string
+          }
+        }
+      ],
+      version: string,
+      waitForJobs: boolean
+    },
+    ignore: {
+      conditions: any
+    },
+    keepResources: boolean,
+    kustomize: {
+      dir: string
+    },
+    namespace: string,
+    namespaceAnnotations: Label,
+    namespaceLabels: Label,
+    paused: boolean,
+    resources: [
+      {
+        content: string,
+        encoding: string,
+        name: string
+      }
+    ],
+    rolloutStrategy: {
+      autoPartitionSize: string,
+      maxUnavailable: string,
+      maxUnavailablePartitions: string,
+      partitions: [
+        {
+          clusterGroup: string,
+          clusterGroupSelector: Selector,
+          clusterName: string,
+          clusterSelector: Selector,
+          maxUnavailable: string,
+          name: string
+        }
+      ]
+    },
+    serviceAccount: string,
+    targetRestrictions: [
+      {
+        clusterGroup: string,
+        clusterGroupSelector: Selector,
+        clusterName: string,
+        clusterSelector: Selector,
+        name: string
+      }
+    ],
+    targets: [
+      {
+        clusterGroup: string,
+        clusterGroupSelector: Selector,
+        clusterName: string,
+        clusterSelector: Selector,
+        correctDrift: {
+          enabled: boolean,
+          force: boolean,
+          keepFailHistory: boolean
+        },
+        defaultNamespace: string,
+        diff: {
+          comparePatches: [
+            {
+              apiVersion: string,
+              jsonPointers: [
+                string
+              ],
+              kind: string,
+              name: string,
+              namespace: string,
+              operations: [
+                {
+                  op: string,
+                  path: string,
+                  value: string
+                }
+              ]
+            }
+          ]
+        },
+        doNotDeploy: boolean,
+        forceSyncGeneration: number,
+        helm: {
+          atomic: boolean,
+          chart: string,
+          disableDNS: boolean,
+          disablePreProcess: boolean,
+          force: boolean,
+          maxHistory: number,
+          releaseName: string,
+          repo: string,
+          skipSchemaValidation: boolean,
+          takeOwnership: boolean,
+          timeoutSeconds: number,
+          values: any,
+          valuesFiles: string[],
+          valuesFrom: [
+            {
+              configMapKeyRef: {
+                key: string,
+                name: string,
+                namespace: string
+              },
+              secretKeyRef: {
+                key: string,
+                name: string,
+                namespace: string
+              }
+            }
+          ],
+          version: string,
+          waitForJobs: boolean
+        },
+        ignore: {
+          conditions: any
+        },
+        keepResources: boolean,
+        kustomize: {
+          dir: string
+        },
+        name: string,
+        namespace: string,
+        namespaceAnnotations: Label,
+        namespaceLabels: Label,
+        serviceAccount: string,
+        yaml: {
+          overlays: string[]
+        }
+      }
+    ],
+    yaml: {
+      overlays: string[]
+    }
+  }
+}

--- a/pkg/kubewarden/types/kubewarden.ts
+++ b/pkg/kubewarden/types/kubewarden.ts
@@ -28,6 +28,16 @@ export const KUBEWARDEN = {
   CLUSTER_POLICY_REPORT:    'wgpolicyk8s.io.clusterpolicyreport'
 };
 
+/* eslint-disable no-unused-vars */
+export enum KUBEWARDEN_CRD {
+  ADMISSION_POLICY = 'admissionpolicies.policies.kubewarden.io',
+  CLUSTER_ADMISSION_POLICY = 'clusteradmissionpolicies.policies.kubewarden.io',
+  POLICY_SERVER = 'policyservers.policies.kubewarden.io',
+  POLICY_REPORT = 'policyreports.wgpolicyk8s.io',
+  CLUSTER_POLICY_REPORT = 'clusterpolicyreports.wgpolicyk8s.io'
+}
+/* eslint-enable no-unused-vars */
+
 export type Rule = {
   apiGroups: string[],
   apiVersions: string[],
@@ -77,7 +87,7 @@ export type Policy = {
   kind: string,
   metadata: Metadata,
   spec: {
-    backgroundAudit?: true,
+    backgroundAudit?: boolean,
     mode: string,
     module: string,
     mutating?: boolean,


### PR DESCRIPTION
Fix #572 

This fixes the version checking for the Policy Server module image when Kubewarden is deployed with Fleet. As specific Helm charts are not returnable from the Fleet store, a few utilities needed to be created in order to parse the Fleet Bundles and extract the information from the resources content.


https://github.com/rancher/kubewarden-ui/assets/40806497/2d464274-9199-4609-9642-3ec08787559b

