### PR TITLE
Add controller chart upgrade badge and tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,6 +28,6 @@
     "**/*.code-search": true
   },
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
 }


### PR DESCRIPTION
Fix #485 

This adds a badge/button to next to the kubewarden-controller version on the Dashboard page which will display when there is an upgrade available for the chart. This button leads to the chart upgrade view.


https://github.com/rancher/kubewarden-ui/assets/40806497/861d008c-215b-4de0-a3a9-027e2262d853

