### PR TITLE
Add readme tab to policy detail

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,15 +1,15 @@
 module.exports = {
   setupFilesAfterEnv:   ['./jest.setup.js'],
   modulePaths:          ['<rootDir>'],
-  moduleFileExtensions: ['js', 'json', 'vue', 'ts'],
+  moduleFileExtensions: ['js', 'json', 'vue', 'ts', 'tsx'],
   moduleNameMapper:     {
     '^~/(.*)$':         '<rootDir>/$1',
     '^~~/(.*)$':        '<rootDir>/$1',
     '^@/(.*)$':         '<rootDir>/$1',
     '@shell/(.*)':      '<rootDir>/node_modules/@rancher/shell/$1',
-    '@components/(.*)':
-      '<rootDir>/node_modules/@rancher/components/dist/@rancher/components.common.js',
+    '@components/(.*)': '<rootDir>/node_modules/@rancher/components/dist/@rancher/components.common.js',
     '@kubewarden/(.*)': '<rootDir>/pkg/kubewarden/$1',
+    '@tests/(.*)':      '<rootDir>/tests/$1'
   },
   transform: {
     '^.+\\.js$':   '<rootDir>/node_modules/babel-jest',

--- a/tests/unit/components/Policies/PolicyDetail.spec.ts
+++ b/tests/unit/components/Policies/PolicyDetail.spec.ts
@@ -1,0 +1,56 @@
+import { ARTIFACTHUB_PKG_ANNOTATION } from '@kubewarden/types';
+
+import { createWrapper } from '@tests/unit/utils/wrapper';
+import PolicyDetail from '@kubewarden/components/Policies/PolicyDetail.vue';
+
+const commonMocks = { $fetchState: { pending: false } };
+const commonComputed = { monitoringStatus: () => jest.fn() };
+
+const defaultPropsData = { resource: '', value: {} };
+const createPolicyDetailWrapper = createWrapper(PolicyDetail, commonMocks, commonComputed, defaultPropsData);
+
+describe('PolicyDetail.vue', () => {
+  it('computes dashboardVars correctly', () => {
+    const wrapper = createPolicyDetailWrapper({ propsData: { value: { id: 'test-id' } } });
+
+    expect(wrapper.vm.dashboardVars).toEqual({ policy_name: 'clusterwide-test-id' });
+  });
+
+  it('initializes policyReadme as null', () => {
+    const wrapper = createPolicyDetailWrapper();
+
+    expect(wrapper.vm.policyReadme).toBeNull();
+  });
+
+  it('fetches artifactHub package if available', async() => {
+    const wrapper = createPolicyDetailWrapper({
+      propsData: {
+        value: {
+          metadata:                  { annotations: { [ARTIFACTHUB_PKG_ANNOTATION]: true } },
+          artifactHubPackageVersion: jest.fn().mockResolvedValue({ readme: 'test-readme' })
+        }
+      }
+    });
+
+    await wrapper.vm.$nextTick;
+
+    expect(wrapper.vm.policyReadme).toBe('test-readme');
+  });
+
+  it('handles errors in fetch gracefully', async() => {
+    console.warn = jest.fn(); // eslint-disable-line no-console
+
+    const wrapper = createPolicyDetailWrapper({
+      propsData: {
+        value: {
+          metadata:                  { annotations: { [ARTIFACTHUB_PKG_ANNOTATION]: true } },
+          artifactHubPackageVersion: jest.fn().mockRejectedValue(new Error('fetch error'))
+        }
+      }
+    });
+
+    await wrapper.vm.$nextTick;
+
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Unable to fetch artifacthub package')); // eslint-disable-line no-console
+  });
+});

--- a/tests/unit/utils/wrapper.ts
+++ b/tests/unit/utils/wrapper.ts
@@ -1,0 +1,39 @@
+import Vue from 'vue';
+import { shallowMount, createLocalVue } from '@vue/test-utils';
+import Vuex from 'vuex';
+
+interface WrapperOptions {
+  propsData?: { [key: string]: any };
+  computed?: { [key: string]: any };
+  mocks?: { [key: string]: any };
+  stubs?: { [key: string]: any };
+}
+
+export const createWrapper = (Component: typeof Vue, commonMocks: any, commonComputed: any, defaultPropsData = {}) => {
+  const localVue = createLocalVue();
+
+  localVue.use(Vuex);
+
+  return (overrides: WrapperOptions = {}) => {
+    const mergedPropsData = {
+      ...defaultPropsData,
+      ...overrides.propsData,
+    };
+
+    const mountOptions = {
+      localVue,
+      ...overrides,
+      propsData: mergedPropsData,
+      computed:  {
+        ...commonComputed,
+        ...overrides.computed,
+      },
+      mocks: {
+        ...commonMocks,
+        ...overrides.mocks,
+      },
+    };
+
+    return shallowMount(Component, mountOptions);
+  };
+};


### PR DESCRIPTION
Fix #508 

This adds a Policy's readme retrieved from ArtifactHub as a tab within the Policy's detail page.


https://github.com/rancher/kubewarden-ui/assets/40806497/1534649e-d772-4d47-ba31-e16365d76fcc

