### PR TITLE
Remove the vue-template-compiler package

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "sass-loader": "10.1.1",
     "ts-jest": "^29.0.5",
     "ts-loader": "~8.2.0",
-    "typescript": "4.1.6",
-    "vue-template-compiler": "2.7.14"
+    "typescript": "4.1.6"
   },
   "engines": {
     "node": ">=12"


### PR DESCRIPTION
This will remove the `vue-template-compiler` package and force the use of the library from the `@rancher/shell` package.

Reference this build failure when attempting to bump the package version on the shell: https://github.com/rancher/dashboard/actions/runs/7402719993/job/20141167950?pr=10222#step:4:2328