### PR TITLE
Fix jaeger trace request operation to always search for validation

### DIFF
--- a/pkg/kubewarden/modules/jaegerTracing.ts
+++ b/pkg/kubewarden/modules/jaegerTracing.ts
@@ -75,10 +75,9 @@ function jaegerTraceRequest(store: any, proxyUrl: any, policy: any, time?: any) 
   const lookbackTime = time || '2d';
 
   const options = `lookback=${ lookbackTime }&tags={"policy_id"%3A"${ name }"}`;
-  const operation = policy?.spec?.mode === 'monitor' ? 'policy_eval' : 'validation';
 
   // The service `kubewarden-policy-server` is **not** a k8s Service
-  apiPath = `api/traces?service=kubewarden-policy-server&operation=${ operation }&${ options }`;
+  apiPath = `api/traces?service=kubewarden-policy-server&operation=validation&${ options }`;
   const JAEGER_PATH = `${ proxyUrl + apiPath }`;
 
   return store.dispatch('cluster/request', { url: JAEGER_PATH });


### PR DESCRIPTION
This updates the `jaegerTraceRequest` method to remove the unnecessary operation constant which was originally changing the operation to `policy_eval` when a policy was in `monitor` mode. This is causing issues with the migration to the new request approach on the latest Policy Server (`1.10.0-rc2`).

Only checking for `validation` operations is compatible with all versions of Policy Server as the `policy_eval` operation always returned the same span objects as `validation`.

___Before:___
![before](https://github.com/rancher/kubewarden-ui/assets/40806497/589e4b9d-53c4-42ea-9539-9ec85b2f1222)



___After:___
![after](https://github.com/rancher/kubewarden-ui/assets/40806497/d8a8f6bb-cbbe-41bd-87b8-33fb00e54f16)

