### PR TITLE
Restructure `refreshCharts` method

### DIFF
--- a/pkg/kubewarden/components/MetricsTab.vue
+++ b/pkg/kubewarden/components/MetricsTab.vue
@@ -1,6 +1,7 @@
 <script>
 import { mapGetters } from 'vuex';
 import isEmpty from 'lodash/isEmpty';
+import debounce from 'lodash/debounce';
 
 import {
   CATALOG, CONFIG_MAP, MONITORING, NAMESPACE, SERVICE
@@ -50,6 +51,12 @@ export default {
   mixins: [ResourceFetch],
 
   async fetch() {
+    this.debouncedRefreshCharts = debounce((init = false) => {
+      refreshCharts({
+        store: this.$store, chartName: 'rancher-monitoring', init
+      });
+    }, 500);
+
     const resourceMap = [
       {
         name:     CATALOG.APP,
@@ -92,7 +99,7 @@ export default {
     await allHash(hash);
 
     if ( this.showChecklist && !this.monitoringChart ) {
-      await refreshCharts({ store: this.$store, init: true });
+      this.debouncedRefreshCharts(true);
     }
 
     // If monitoring is installed look for the dashboard based on the METRICS_TYPE
@@ -126,7 +133,8 @@ export default {
       [MONITORING.SERVICEMONITOR]: null,
       [SERVICE]:                   null,
       metricsProxy:                null,
-      metricsService:              null
+      metricsService:              null,
+      debouncedRefreshCharts:      null
     };
   },
 

--- a/pkg/kubewarden/utils/chart.ts
+++ b/pkg/kubewarden/utils/chart.ts
@@ -1,48 +1,69 @@
 import { Chart } from '../types';
-
 import { handleGrowl } from './handle-growl';
 
 export interface RefreshConfig {
-  store: any,
-  retry?: number,
-  init?: boolean,
-  chart?: Chart
+  store: any;
+  chartName: string;
+  retry?: number;
+  init?: boolean;
 }
 
 export interface ReloadReady {
   reloadReady: boolean
 }
 
+/**
+ * Asynchronously refreshes charts by dispatching actions to the store. It attempts to
+ * find a specific chart by its name and, if not found, dispatches actions to refresh
+ * the chart catalog. This method will retry the operation up to a maximum of three times
+ * based on the retry parameter and the presence of the chart.
+ *
+ * @param {RefreshConfig} config - The configuration object for the refresh operation.
+ * @param {any} config.store - The Vuex store instance used for state management.
+ * @param {string} config.chartName - The name of the chart to be refreshed.
+ * @param {number} [config.retry=0] - The current retry attempt count. Defaults to 0.
+ * @param {boolean} [config.init=false] - A flag indicating whether the initial load
+ *        should prevent retries. Defaults to false.
+ *
+ * @returns {Promise<ReloadReady>} An object indicating whether the reload is ready.
+ *          Currently, it always returns an object with `reloadReady` set to false.
+ *
+ * @example
+ * // Example usage:
+ * refreshCharts({
+ *   store: myStore,
+ *   chartName: 'myChart',
+ *   retry: 0,
+ *   init: true
+ * }).then(result => {
+ *   console.log(result.reloadReady); // false
+ * });
+ */
 export async function refreshCharts(config: RefreshConfig): Promise<ReloadReady> {
-  const { store, init, chart } = config;
-  let { retry } = config;
+  const { store, chartName, init } = config;
+  let retry = config.retry ?? 0;
 
-  if ( !retry ) {
-    retry = 0;
+  while ( retry < 3 ) {
+    const rawCharts = store.getters['catalog/rawCharts'];
+    const chart = (Object.values(rawCharts) as Chart[])?.find(c => c?.chartName === chartName);
+
+    if ( !chart ) {
+      try {
+        store.dispatch('kubewarden/updateRefreshingCharts', true);
+        await store.dispatch('catalog/refresh');
+      } catch (e) {
+        handleGrowl({ error: e as any, store });
+      } finally {
+        store.dispatch('kubewarden/updateRefreshingCharts', false);
+      }
+
+      if ( retry < 2 && !init ) {
+        retry++;
+        continue;
+      }
+    }
+    break;
   }
-
-  try {
-    store.dispatch('kubewarden/updateRefreshingCharts', true);
-
-    await store.dispatch('catalog/refresh');
-  } catch (e) {
-    handleGrowl({ error: e as any, store });
-  }
-
-  if ( !chart && retry === 0 && !init ) {
-    store.dispatch('kubewarden/updateRefreshingCharts', true);
-
-    await store.dispatch('catalog/refresh');
-    await refreshCharts({
-      store, init, retry: retry + 1, chart
-    });
-  }
-
-  if ( !chart && retry === 1 && !init ) {
-    return { reloadReady: true };
-  }
-
-  store.dispatch('kubewarden/updateRefreshingCharts', false);
 
   return { reloadReady: false };
 }

--- a/pkg/kubewarden/utils/handle-growl.ts
+++ b/pkg/kubewarden/utils/handle-growl.ts
@@ -13,9 +13,10 @@ export interface GrowlConfig {
 
 export function handleGrowl(config: GrowlConfig): void {
   const error = config.error?.data || config.error;
+  const type = config.type || 'Error';
 
-  config.store.dispatch(`growl/${ config.type || 'error' }`, {
-    title:   error._statusText,
+  config.store.dispatch(`growl/${ type }`, {
+    title:   error._statusText || type,
     message: error.message,
     timeout: 5000,
   }, { root: true });


### PR DESCRIPTION
Fix #587 

This changes the use of the `refreshCharts` method to debounce the calls as to remove concurrent runs.

Restructured the `refreshCharts` method to require a `chartName` which will search the `catalog/rawCharts` getter to check for the existence of the chart rather than blindly refreshing. Also limits the amount of retries to 3.


https://github.com/rancher/kubewarden-ui/assets/40806497/1be3f5cb-0e2b-4911-a4cf-24c784e42469

