### PR TITLE
Add ifHaveType to policy-reporter virtualType

### DIFF
--- a/pkg/kubewarden/config/kubewarden.ts
+++ b/pkg/kubewarden/config/kubewarden.ts
@@ -38,6 +38,7 @@ export function init($plugin: any, store: any) {
   virtualType({
     label:      store.getters['i18n/t']('kubewarden.policyReporter.title'),
     icon:       'notifier',
+    ifHaveType: KUBEWARDEN.POLICY_REPORT,
     name:       POLICY_REPORTER_PRODUCT,
     namespaced: false,
     weight:     95,


### PR DESCRIPTION
Fix #585 

This adds the `ifHaveType` property to the Policy Reporter's `virtualType`, which will hide the Policy Reporter menu item until the CRD for `policyreports.wgpolicyk8s.io` is installed.

___CRD not installed___
![kw1](https://github.com/rancher/kubewarden-ui/assets/40806497/36efbf43-8aa7-4899-800f-bbc34b3c3469)

___CRD installed, kw-controller does not have Policy Reports enabled___
![kw2](https://github.com/rancher/kubewarden-ui/assets/40806497/1ea73ddd-9a6d-4ba7-8759-06f9142de2b5)

___CRD installed, Policy Reports enabled___
![kw3](https://github.com/rancher/kubewarden-ui/assets/40806497/93b4e351-47a4-4985-bb92-0ce5fbfccdff)

