### PR TITLE
Run tests on imported cluster

### DIFF
--- a/tests/e2e/10-landing.spec.ts
+++ b/tests/e2e/10-landing.spec.ts
@@ -8,7 +8,7 @@ test('Brief check of landing pages', async({ page, ui, nav }) => {
     // Header contains version
     const head = page.locator('div.head')
     await expect(head.getByRole('heading', { name: 'Welcome to Kubewarden' })).toBeVisible()
-    await expect(head.getByText(/App Version:\s+v[1-9]/)).toBeVisible()
+    await expect(head.getByText(/App Version:\s+v[1-9][0-9.]+[0-9]/)).toBeVisible()
 
     // Recommended policies stats
     await expect1m(page.getByText('Active 1 of 1 Pods / 100%')).toBeVisible()

--- a/tests/e2e/60-telemetry.spec.ts
+++ b/tests/e2e/60-telemetry.spec.ts
@@ -78,7 +78,7 @@ test.describe('Tracing', () => {
     const logline = ui.tableRow('tracing-privpod').row.first()
 
     // Create trace log line
-    await nav.cluster('local')
+    await nav.cluster()
     await shell.privpod({ name: 'tracing-privpod' })
     // Check logs on policy server
     await nav.pserver('default', 'Tracing')

--- a/tests/e2e/90-allpolicies.spec.ts
+++ b/tests/e2e/90-allpolicies.spec.ts
@@ -6,7 +6,7 @@ import { PolicyServersPage } from './pages/policyservers.page'
 test.describe.configure({ mode: 'parallel' })
 
 const polmode = 'Monitor'
-const pserver = { name: process.env.server || 'policies-private-ps' }
+const pserver = { name: process.env.CI ? 'allpolicies-pserver' : 'default' }
 const polkeep = !!process.env.keep || false
 
 type PolicySettings = {
@@ -21,14 +21,20 @@ const policySettingsMap: Partial<Record<policyTitle, PolicySettings>> = {
   'Namespace label propagator' : { settings: setupNamespaceLabelPropagator },
   'PSA Label Enforcer'         : { settings: setupPSALabelEnforcer },
   'Selinux PSP'                : { settings: setupSelinuxPSP },
-  'Trusted Repos'              : { settings: trustedRepos },
+  'Trusted Repos'              : { settings: setupTrustedRepos },
   'User Group PSP'             : { settings: setupUserGroupPSP },
   'Verify Image Signatures'    : { settings: setupVerifyImageSignatures },
-  'Container Resources'        : { skip: 'https://github.com/kubewarden/container-resources-policy/issues/6' },
+  'Container Resources'        : { settings: setupContainerResources, skip: 'https://github.com/kubewarden/container-resources-policy/issues/10' },
   volumeMounts                 : { settings: setupVolumeMounts },
 }
 
-async function trustedRepos(ui: RancherUI) {
+async function setupContainerResources(ui: RancherUI) {
+  await ui.input('Default CPU requested').fill('100m')
+  await ui.input('Default CPU limit').fill('200m')
+  await ui.input('Max CPU limit allowed').fill('500m')
+}
+
+async function setupTrustedRepos(ui: RancherUI) {
   await ui.button('Add').first().click()
   await ui.page.getByRole('textbox').last().fill('registry.my-corp.com')
 }

--- a/tests/e2e/components/kubectl-shell.ts
+++ b/tests/e2e/components/kubectl-shell.ts
@@ -27,7 +27,7 @@ export class Shell {
 
     // Close terminal
     async close() {
-      await this.win.locator('.tab').filter({ hasText: 'Kubectl: local' }).locator('i.closer').click()
+      await this.win.locator('.tab', { hasText: 'Kubectl:' }).locator('i.closer').click()
     }
 
     /**

--- a/tests/e2e/components/kubectl-shell.ts
+++ b/tests/e2e/components/kubectl-shell.ts
@@ -7,6 +7,7 @@ export class Shell {
     readonly prompt: Locator
     readonly cursor: Locator
     readonly status: Locator
+    readonly connected: Locator
 
     constructor(private readonly page: Page) {
       this.win = this.page.locator('div#windowmanager')
@@ -14,6 +15,8 @@ export class Shell {
       this.prompt = this.win.locator('div.xterm-rows>div:has(span)').filter({ hasText: '>' }).last()
       // Textarea where we type commands
       this.cursor = this.win.getByLabel('Terminal input', { exact: true })
+      // Connected message
+      this.connected = this.win.locator('.status').getByText('Connected', { exact: true })
       // Exit status of last command
       this.status = this.prompt.locator('xpath=preceding-sibling::div[1]')
     }
@@ -21,7 +24,7 @@ export class Shell {
     // Open terminal
     async open() {
       await this.page.locator('#btn-kubectl').click()
-      await expect(this.win.locator('.status').getByText('Connected', { exact: true })).toBeVisible({ timeout: 30_000 })
+      await expect(this.connected).toBeVisible({ timeout: 30_000 })
       await expect(this.prompt).toBeVisible()
     }
 

--- a/tests/e2e/pages/kubewarden.page.ts
+++ b/tests/e2e/pages/kubewarden.page.ts
@@ -18,7 +18,7 @@ export class KubewardenPage extends BasePage {
 
     async goto(): Promise<void> {
       // await this.nav.explorer('Kubewarden')
-      await this.page.goto('dashboard/c/local/kubewarden')
+      await this.nav.goto('dashboard/c/local/kubewarden')
     }
 
     getPane(name: Pane) {

--- a/tests/e2e/pages/kubewarden.page.ts
+++ b/tests/e2e/pages/kubewarden.page.ts
@@ -1,6 +1,7 @@
 import { expect, test, Locator, Page } from '@playwright/test'
 import { RancherAppsPage } from '../rancher/rancher-apps.page'
 import { BasePage } from '../rancher/basepage'
+import { Shell } from '../components/kubectl-shell'
 
 type Pane = 'Policy Servers' | 'Admission Policies' | 'Cluster Admission Policies'
 
@@ -35,8 +36,10 @@ export class KubewardenPage extends BasePage {
       // ==================================================================================================
       // Requirements Dialog
       const welcomeStep = this.page.getByText('Kubewarden is a policy engine for Kubernetes.')
+      const certStep = this.page.getByText('Install Cert-Manager Package')
       const addRepoStep = this.page.getByRole('heading', { name: 'Repository', exact: true })
       const appInstallStep = this.page.getByRole('heading', { name: 'Kubewarden App Install', exact: true })
+      const shellBtn = this.page.getByRole('button', { name: 'Open Kubectl Shell' })
       const installBtn = this.ui.button('Install Kubewarden')
       const addRepoBtn = this.ui.button('Add Kubewarden Repository')
       const failRepo = this.page.getByText('Unable to fetch Kubewarden Helm chart')
@@ -46,6 +49,20 @@ export class KubewardenPage extends BasePage {
       await this.goto()
       await expect(welcomeStep).toBeVisible()
       await installBtn.click()
+
+      // Cert-Manager
+      await certStep.or(addRepoBtn).waitFor()
+      if (await certStep.isVisible()) {
+        // Copy command by clicking and read it from clipboard
+        await this.page.locator('code.copy').click()
+        const copiedText = await this.page.evaluate(() => navigator.clipboard.readText())
+        expect(copiedText).toContain('kubectl')
+        // Run copied command in shell
+        await shellBtn.click()
+        const shell = new Shell(this.page)
+        await expect(shell.prompt).toBeVisible()
+        await shell.run(copiedText as string)
+      }
 
       // Add repository screen
       await expect(addRepoStep).toBeVisible()
@@ -68,8 +85,6 @@ export class KubewardenPage extends BasePage {
         await expect(welcomeStep).toBeVisible()
         await installBtn.click()
       }
-
-      // Cert-Manager
 
       // Redirection to rancher app installer
       await expect(appInstallStep).toBeVisible()

--- a/tests/e2e/pages/kubewarden.page.ts
+++ b/tests/e2e/pages/kubewarden.page.ts
@@ -18,8 +18,8 @@ export class KubewardenPage extends BasePage {
     }
 
     async goto(): Promise<void> {
-      // await this.nav.explorer('Kubewarden')
-      await this.nav.goto('dashboard/c/local/kubewarden')
+      await this.nav.explorer('Kubewarden')
+      // await this.nav.goto('dashboard/c/local/kubewarden')
     }
 
     getPane(name: Pane) {
@@ -46,7 +46,10 @@ export class KubewardenPage extends BasePage {
       const failRepoBtn = this.ui.button('Reload')
 
       // Welcome screen
-      await this.goto()
+      await this.ui.withReload(async() => {
+        await this.goto()
+      }, 'Kubewarden extension not visible')
+
       await expect(welcomeStep).toBeVisible()
       await installBtn.click()
 

--- a/tests/e2e/pages/policies.page.ts
+++ b/tests/e2e/pages/policies.page.ts
@@ -8,6 +8,7 @@ export const apList = ['Custom Policy', 'Allow Privilege Escalation PSP', 'Allow
   'Deprecated API Versions', 'Disallow Service Loadbalancer', 'Disallow Service Nodeport', 'Echo', 'Environment Variable Secrets Scanner', 'Environment Variable Policy', 'Flexvolume Drivers Psp',
   'Host Namespaces PSP', 'Hostpaths PSP', 'Ingress Policy', 'Namespace label propagator', 'Pod Privileged Policy', 'Pod Runtime', 'Readonly Root Filesystem PSP', 'Share PID namespace',
   'Safe Annotations', 'Safe Labels', 'Seccomp PSP', 'Selinux PSP', 'Sysctl PSP', 'Trusted Repos', 'User Group PSP', 'Verify Image Signatures', 'volumeMounts', 'Volumes PSP', 'Unique Ingress host'] as const
+  // WIP: 'Unique service selector', 'CEL Policy'
 
 export const capList = [...apList, 'PSA Label Enforcer']
 

--- a/tests/e2e/pages/policies.page.ts
+++ b/tests/e2e/pages/policies.page.ts
@@ -159,7 +159,7 @@ export class AdmissionPoliciesPage extends BasePolicyPage {
 
     async goto(): Promise<void> {
       await this.nav.explorer('Kubewarden', 'AdmissionPolicies')
-      // await this.page.goto('dashboard/c/local/kubewarden/policies.kubewarden.io.admissionpolicy')
+      // await this.nav.goto('dashboard/c/local/kubewarden/policies.kubewarden.io.admissionpolicy')
     }
 
     async setNamespace(name: string) {
@@ -181,7 +181,7 @@ export class ClusterAdmissionPoliciesPage extends BasePolicyPage {
 
     async goto(): Promise<void> {
       await this.nav.explorer('Kubewarden', 'ClusterAdmissionPolicies')
-      // await this.page.goto('dashboard/c/local/kubewarden/policies.kubewarden.io.clusteradmissionpolicy')
+      // await this.nav.goto('dashboard/c/local/kubewarden/policies.kubewarden.io.clusteradmissionpolicy')
     }
 
     async setIgnoreRancherNS(checked: boolean) {

--- a/tests/e2e/pages/policyreporter.page.ts
+++ b/tests/e2e/pages/policyreporter.page.ts
@@ -20,7 +20,7 @@ export class PolicyReporterPage extends BasePage {
 
     async goto(): Promise<void> {
       // await this.nav.explorer('Kubewarden', 'Policy Reporter')
-      await this.page.goto('dashboard/c/local/kubewarden/policy-reporter')
+      await this.nav.goto('dashboard/c/local/kubewarden/policy-reporter')
     }
 
     async selectTab(name: 'Dashboard' | 'Policy Reports' | 'ClusterPolicy Reports' | 'Logs') {

--- a/tests/e2e/pages/policyservers.page.ts
+++ b/tests/e2e/pages/policyservers.page.ts
@@ -22,7 +22,7 @@ export class PolicyServersPage extends BasePage {
 
     async goto(): Promise<void> {
       // await this.nav.explorer('Kubewarden', 'PolicyServers')
-      await this.page.goto('dashboard/c/local/kubewarden/policies.kubewarden.io.policyserver')
+      await this.nav.goto('dashboard/c/local/kubewarden/policies.kubewarden.io.policyserver')
     }
 
     async setName(name: string) {

--- a/tests/e2e/rancher/rancher-apps.page.ts
+++ b/tests/e2e/rancher/rancher-apps.page.ts
@@ -31,7 +31,7 @@ export class RancherAppsPage extends BasePage {
 
     async goto(): Promise<void> {
       // await this.nav.explorer('Apps', 'Charts')
-      await this.page.goto('dashboard/c/local/apps/charts')
+      await this.nav.goto('dashboard/c/local/apps/charts')
     }
 
     /**

--- a/tests/e2e/rancher/rancher-common.page.ts
+++ b/tests/e2e/rancher/rancher-common.page.ts
@@ -32,7 +32,7 @@ export class RancherCommonPage extends BasePage {
      * @param filter Use #id or exact name of the filter
      */
   async setNamespaceFilter(filter: string) {
-    await this.nav.cluster('local')
+    await this.nav.cluster()
     await expect(this.page.getByRole('heading', { name: 'Cluster Dashboard' })).toBeVisible()
 
     const nsMenu = this.page.getByTestId('namespaces-menu')

--- a/tests/e2e/rancher/rancher-extensions.page.ts
+++ b/tests/e2e/rancher/rancher-extensions.page.ts
@@ -19,7 +19,7 @@ export class RancherExtensionsPage extends BasePage {
     }
 
     async enable(rancherRepo = true, partnersRepo = true) {
-      await this.nav.mainNav('Extensions')
+      await this.goto()
       await expect(this.page.getByRole('heading', { name: 'Extension support is not enabled' })).toBeVisible()
 
       // Enable extensions

--- a/tests/e2e/rancher/rancher-fleet.page.ts
+++ b/tests/e2e/rancher/rancher-fleet.page.ts
@@ -24,7 +24,7 @@ export class RancherFleetPage extends BasePage {
 
     async goto(): Promise<void> {
       // await this.nav.fleet('', 'Dashboard')
-      await this.page.goto('dashboard/c/local/fleet')
+      await this.nav.goto('dashboard/c/local/fleet')
     }
 
     @step

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,5 +1,5 @@
 import type { FullConfig } from '@playwright/test'
-import { request } from '@playwright/test'
+import { expect, request } from '@playwright/test'
 
 async function globalSetup(config: FullConfig) {
   const { baseURL, storageState } = config.projects[0].use
@@ -15,6 +15,16 @@ async function globalSetup(config: FullConfig) {
 
   // Save signed-in state to 'storageState.json'.
   await requestContext.storageState({ path: storageState as string })
+
+  // Get clusterId from displayName
+  const clusterName = process.env.CLUSTER
+  if (clusterName) {
+    const req = await requestContext.get(`/v1/provisioning.cattle.io.clusters/fleet-default/${clusterName}`)
+    expect(req.ok()).toBeTruthy()
+    const reqJson = await req.json()
+    process.env.CLUSTER_ID = reqJson.status.clusterName
+  }
+
   await requestContext.dispose()
 }
 


### PR DESCRIPTION
Running tests on imported cluster still requires manual setup - install rancher and import cluster.
Then you can focus tested cluster by it's name: `CLUSTER=theimported yarn playwright test -x`.

- added cert-manager test for https://github.com/rancher/kubewarden-ui/issues/586
- added reload workaround since kubewarden menu item sometimes does not show after installation (probably caused by  rancher limiting the amount of calls to the store for performance issues)
- added setup function for Container Resources policy (test still skipped)