### PR TITLE
Add Unique service selector policy test

### DIFF
--- a/tests/e2e/pages/policies.page.ts
+++ b/tests/e2e/pages/policies.page.ts
@@ -7,8 +7,8 @@ import { BasePage } from '../rancher/basepage'
 export const apList = ['Custom Policy', 'Allow Privilege Escalation PSP', 'Allowed Fs Groups PSP', 'Allowed Proc Mount Types PSP', 'Apparmor PSP', 'Capabilities PSP', 'Container Resources',
   'Deprecated API Versions', 'Disallow Service Loadbalancer', 'Disallow Service Nodeport', 'Echo', 'Environment Variable Secrets Scanner', 'Environment Variable Policy', 'Flexvolume Drivers Psp',
   'Host Namespaces PSP', 'Hostpaths PSP', 'Ingress Policy', 'Namespace label propagator', 'Pod Privileged Policy', 'Pod Runtime', 'Readonly Root Filesystem PSP', 'Share PID namespace',
-  'Safe Annotations', 'Safe Labels', 'Seccomp PSP', 'Selinux PSP', 'Sysctl PSP', 'Trusted Repos', 'User Group PSP', 'Verify Image Signatures', 'volumeMounts', 'Volumes PSP', 'Unique Ingress host'] as const
-  // WIP: 'Unique service selector', 'CEL Policy'
+  'Safe Annotations', 'Safe Labels', 'Seccomp PSP', 'Selinux PSP', 'Sysctl PSP', 'Trusted Repos', 'User Group PSP', 'Verify Image Signatures', 'volumeMounts', 'Volumes PSP', 'Unique Ingress host',
+  'Unique service selector'] as const // WIP: 'CEL Policy'
 
 export const capList = [...apList, 'PSA Label Enforcer']
 


### PR DESCRIPTION
New policy is now available [on artifacthub](https://artifacthub.io/packages/kubewarden/unique-service-selector/unique-service-selector-policy).