### PR TITLE
Add warning banner to Metrics checklist for conflicting configmaps

### DIFF
--- a/pkg/kubewarden/components/MetricsChecklist.vue
+++ b/pkg/kubewarden/components/MetricsChecklist.vue
@@ -21,6 +21,10 @@ export default {
       type:    Object,
       default: null
     },
+    conflictingGrafanaDashboards: {
+      type:    Array,
+      default: null
+    },
     controllerApp: {
       type:    Object,
       default: null
@@ -102,7 +106,10 @@ export default {
     },
 
     dashboardButtonDisabled() {
-      return (!this.monitoringApp || isEmpty(this.cattleDashboardNs));
+      return (!this.monitoringApp ||
+              isEmpty(this.cattleDashboardNs) ||
+              (!this.hasKubewardenDashboards && !!this.conflictingGrafanaDashboards.length)
+      );
     },
 
     hasKubewardenDashboards() {
@@ -151,6 +158,10 @@ export default {
       }
 
       return null;
+    },
+
+    showConflictingDashboardsBanner() {
+      return !this.hasKubewardenDashboards && !isEmpty(this.conflictingGrafanaDashboards);
     }
   },
 
@@ -314,6 +325,24 @@ export default {
           />
         </div>
       </div>
+      <Banner
+        v-if="showConflictingDashboardsBanner"
+        color="error"
+      >
+        <div class="conflicting-banner">
+          <p>
+            {{ t('kubewarden.monitoring.prerequisites.configMap.conflictingDashboardsBanner', { count: conflictingGrafanaDashboards.length }, true) }}
+          </p>
+          <n-link
+            v-for="configMap of conflictingGrafanaDashboards"
+            :key="configMap.metadata.name"
+            :to="configMap.detailLocation"
+            class="text-bold"
+          >
+            {{ configMap.metadata.name }}
+          </n-link>
+        </div>
+      </Banner>
 
       <div class="checklist__step mb-20" data-testid="kw-monitoring-checklist-step-controller-config">
         <i class="icon mr-10" :class="badgeIcon(metricsEnabled)" />
@@ -355,5 +384,10 @@ export default {
   &__step {
     min-height: 40px;
   }
+}
+
+.conflicting-banner {
+  display: flex;
+  flex-direction: column;
 }
 </style>

--- a/pkg/kubewarden/components/MetricsTab.vue
+++ b/pkg/kubewarden/components/MetricsTab.vue
@@ -184,7 +184,17 @@ export default {
     },
 
     cattleDashboardNs() {
-      return this.allNamespaces.find(ns => ns?.metadata?.name === 'cattle-dashboards');
+      return this.allNamespaces?.find(ns => ns?.metadata?.name === 'cattle-dashboards');
+    },
+
+    conflictingGrafanaDashboards() {
+      return this.allConfigMaps?.filter((configMap) => {
+        const name = configMap?.metadata?.name;
+
+        if ( name ) {
+          return name === KubewardenDashboards.POLICY_SERVER || name === KubewardenDashboards.POLICY;
+        }
+      });
     },
 
     controllerApp() {
@@ -202,7 +212,7 @@ export default {
     },
 
     kubewardenGrafanaDashboards() {
-      return this.allConfigMaps.filter(configMap => configMap?.metadata?.labels?.[KubewardenDashboardLabels.DASHBOARD]);
+      return this.allConfigMaps?.filter(configMap => configMap?.metadata?.labels?.[KubewardenDashboardLabels.DASHBOARD]);
     },
 
     kubewardenServiceMonitor() {
@@ -281,6 +291,7 @@ export default {
     <MetricsChecklist
       v-if="showChecklist"
       :cattle-dashboard-ns="cattleDashboardNs"
+      :conflicting-grafana-dashboards="conflictingGrafanaDashboards"
       :controller-app="controllerApp"
       :controller-chart="controllerChart"
       :kubewarden-service-monitor="kubewardenServiceMonitor"

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -174,6 +174,11 @@ kubewarden:
       configMap:
         label: Grafana Dashboards (ConfigMaps) for the Policy Servers and for Kubewarden Policies must be created.
         button: Add Dashboards
+        conflictingDashboardsBanner: |-
+          {count, plural,
+          =1 {There is a conflicting ConfigMap, this must be deleted before proceeding:}
+          other {There are conflicting ConfigMaps, the following must be deleted before proceeding:}
+          }
       controllerConfig:
         label: The Kubewarden Controller must be configured to enable metrics. Follow <a href="https://docs.kubewarden.io/operator-manual/ui-extension/metrics#2-enable-telemetry-for-your-rancher-kubewarden-controller-resource" target="_blank" rel="noopener noreferrer nofollow">these steps</a> to properly configure the kubewarden-controller chart.
         button: Edit Config

--- a/tests/unit/components/MetricsChecklist.spec.ts
+++ b/tests/unit/components/MetricsChecklist.spec.ts
@@ -1,0 +1,148 @@
+import { createWrapper } from '@tests/unit/utils/wrapper';
+
+import MetricsChecklist from '@kubewarden/components/MetricsChecklist.vue';
+
+const commonMocks = {
+  $store: {
+    getters: {
+      currentCluster: () => ({ id: 'test-cluster' }),
+      'i18n/t':       () => jest.fn(),
+    }
+  },
+  $router: jest.fn(),
+  $route:  jest.fn(),
+};
+
+const commonComputed = { hasKubewardenDashboards: () => false };
+
+const defaultPropsData = {};
+
+const createMetricChecklistWrapper = createWrapper(MetricsChecklist, commonMocks, commonComputed, defaultPropsData);
+
+describe('MetricChecklist.vue', () => {
+  it('shows the conflicting dashboards banner when there are conflicting dashboards and no Kubewarden dashboards', () => {
+    const conflictingGrafanaDashboards = [{ metadata: { name: 'Dashboard1' } }];
+
+    const wrapper = createMetricChecklistWrapper({
+      propsData: { conflictingGrafanaDashboards },
+      computed:  { hasKubewardenDashboards: () => false },
+      stubs:     {
+        'n-link': { template: '<span />' },
+        Banner:   { template: '<span />' },
+      }
+    });
+
+    expect(wrapper.vm.showConflictingDashboardsBanner).toBe(true);
+  });
+
+  it('does not show the conflicting dashboards banner when there are no conflicting dashboards', () => {
+    const wrapper = createMetricChecklistWrapper({
+      propsData: { conflictingGrafanaDashboards: [] },
+      computed:  { hasKubewardenDashboards: () => false },
+      stubs:     {
+        'n-link': { template: '<span />' },
+        Banner:   { template: '<span />' },
+      }
+    });
+
+    expect(wrapper.vm.showConflictingDashboardsBanner).toBe(false);
+  });
+
+  it('does not show the conflicting dashboards banner when there are Kubewarden dashboards, even if there are conflicting dashboards', () => {
+    const conflictingGrafanaDashboards = [{ metadata: { name: 'Dashboard1' } }];
+
+    const wrapper = createMetricChecklistWrapper({
+      propsData: { conflictingGrafanaDashboards },
+      computed:  { hasKubewardenDashboards: () => true }, // Simulate presence of KubeWarden dashboards
+      stubs:     {
+        'n-link': { template: '<span />' },
+        Banner:   { template: '<span />' },
+      }
+    });
+
+    expect(wrapper.vm.showConflictingDashboardsBanner).toBe(false);
+  });
+
+  it('disables the dashboard button when there is no monitoring app', () => {
+    const wrapper = createMetricChecklistWrapper({
+      propsData: {
+        monitoringApp:                null,
+        cattleDashboardNs:            {},
+        conflictingGrafanaDashboards: [],
+      },
+      stubs: {
+        'n-link': { template: '<span />' },
+        Banner:   { template: '<span />' },
+      }
+    });
+
+    expect(wrapper.vm.dashboardButtonDisabled).toBe(true);
+  });
+
+  it('disables the dashboard button when the cattleDashboardNs is empty', () => {
+    const wrapper = createMetricChecklistWrapper({
+      propsData: {
+        monitoringApp:                {},
+        cattleDashboardNs:            null,
+        conflictingGrafanaDashboards: [],
+      },
+      stubs: {
+        'n-link': { template: '<span />' },
+        Banner:   { template: '<span />' },
+      }
+    });
+
+    expect(wrapper.vm.dashboardButtonDisabled).toBe(true);
+  });
+
+  it('disables the dashboard button when there are conflicting Grafana dashboards', () => {
+    const wrapper = createMetricChecklistWrapper({
+      propsData: {
+        monitoringApp:                {},
+        cattleDashboardNs:            {},
+        conflictingGrafanaDashboards: [{ metadata: { name: 'Dashboard1' } }],
+      },
+      stubs: {
+        'n-link': { template: '<span />' },
+        Banner:   { template: '<span />' },
+      }
+    });
+
+    expect(wrapper.vm.dashboardButtonDisabled).toBe(true);
+  });
+
+  it('enables the dashboard button when monitoring app is present, cattleDashboardNs is not empty, and there are no conflicting Grafana dashboards', () => {
+    const wrapper = createMetricChecklistWrapper({
+      propsData: {
+        monitoringApp:                {},
+        cattleDashboardNs:            { someKey: 'someValue' },
+        conflictingGrafanaDashboards: [],
+      },
+      stubs: {
+        'n-link': { template: '<span />' },
+        Banner:   { template: '<span />' },
+      }
+    });
+
+    expect(wrapper.vm.dashboardButtonDisabled).toBe(false);
+  });
+
+  it('enables the dashboard button when monitoring app is present, cattleDashboardNs is not empty, kubewarden dashboards exists and there are conflicting Grafana dashboards', () => {
+    const conflictingGrafanaDashboards = [{ metadata: { name: 'Dashboard1' } }];
+
+    const wrapper = createMetricChecklistWrapper({
+      propsData: {
+        monitoringApp:                {},
+        cattleDashboardNs:            { someKey: 'someValue' },
+        conflictingGrafanaDashboards,
+      },
+      computed:  { hasKubewardenDashboards: () => true },
+      stubs:    {
+        'n-link': { template: '<span />' },
+        Banner:   { template: '<span />' },
+      }
+    });
+
+    expect(wrapper.vm.dashboardButtonDisabled).toBe(false);
+  });
+});


### PR DESCRIPTION
Fix #600 

The main issue causing the old dashboards from not being located is due to the `kubewarden/dashboard` label that we are [currently searching for](https://github.com/rancher/kubewarden-ui/blob/4865424c81b1303d09781c40a80d9fdbdb4ce82c/pkg/kubewarden/components/MetricsTab.vue#L204-L206). This is a new label that previously wasn't being added to the Grafana dashboard ConfigMaps prior to the MetricsChecklist component. Now when we add the ConfigMaps from the UI we [create them with the label `kubewarden/dashboard`](https://github.com/rancher/kubewarden-ui/blob/4865424c81b1303d09781c40a80d9fdbdb4ce82c/pkg/kubewarden/modules/grafana.ts#L100-L125) to easily distinguish Grafana dashboards.

Now there is a Banner that will appear under the Dashboard step in the checklist which will appear when there are conflicting ConfigMap names that do not contain the `kubewarden/dashboard` label. It lists the ConfigMaps which are conflicting and provides a link to their detail view for easy deletion. 

I felt it was more appropriate to inform the user to delete these old ConfigMaps rather than creating new ones with alternate names.


https://github.com/rancher/kubewarden-ui/assets/40806497/e71993e9-0112-4190-9614-b5bd477c8324

