### PR TITLE
Fix fleet repository url

### DIFF
--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -106,8 +106,8 @@ test('03b Install Kubewarden by Fleet', async({ page, ui }) => {
   const fleetPage = new RancherFleetPage(page)
   const repoRow = await fleetPage.addRepository({
     name       : 'therepo',
-    url        : 'https://github.com/kravciak/kubewarden-ui.git',
-    branch     : 'fleet',
+    url        : 'https://github.com/rancher/kubewarden-ui.git',
+    branch     : 'main',
     selfHealing: true,
     paths      : ['tests/e2e/fleet/'],
     workspace  : 'fleet-local',


### PR DESCRIPTION
Replace fleet url/branch that was used for testing. Should fix nightly test:
![Screenshot from 2024-02-08 11-09-24](https://github.com/rancher/kubewarden-ui/assets/538604/d901056d-a078-4cc7-93d4-8cce9cb3cd30)
