### PR TITLE
Allow availability of pre-release policies in PolicyGrid

### DIFF
--- a/pkg/kubewarden/modules/artifacthub.ts
+++ b/pkg/kubewarden/modules/artifacthub.ts
@@ -21,7 +21,7 @@ export function resourcesFromAnnotation(artifactHubPackages: ArtifactHubPackage[
       const split = resource.split(',');
 
       if ( split.length > 1 ) {
-        split.forEach((s: string) => out.push(s));
+        split.forEach((s: string) => out.push(s.trim()));
       } else {
         out.push(resource);
       }

--- a/tests/unit/components/Policies/PolicyGrid.spec.ts
+++ b/tests/unit/components/Policies/PolicyGrid.spec.ts
@@ -9,10 +9,18 @@ import PolicyGrid from '@kubewarden/components/Policies/PolicyGrid.vue';
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 
 import policyPackages from '../../templates/policyPackages.js';
+import schemas from '../../templates/schemas.js';
 
 const defaultComputed = { allSchemas: jest.fn() };
-const defaultMocks = { $store: { getters: { 'i18n/t': jest.fn() } } };
-const defaultProvide = { chartType: KUBEWARDEN.ADMISSION_POLICY };
+const defaultMocks = {
+  $store: {
+    getters: {
+      'i18n/t':    jest.fn(),
+      'prefs/get': () => false
+    }
+  }
+};
+const defaultProvide = { chartType: KUBEWARDEN.CLUSTER_ADMISSION_POLICY };
 
 describe('component: PolicyGrid', () => {
   it('should render custom card when provided empty packages', () => {
@@ -73,6 +81,7 @@ describe('component: PolicyGrid', () => {
     expect(wrapper.html()).toContain('Signed Test Policy');
     expect(wrapper.html()).toContain('Test Policy 2');
 
+    await wrapper.vm.$nextTick();
     await wrapper.setData({ organizations: ['evil'] });
 
     expect(wrapper.html()).not.toContain('Allow Privilege Escalation PSP');
@@ -90,7 +99,7 @@ describe('component: PolicyGrid', () => {
 
     const selects = wrapper.findAllComponents(LabeledSelect);
 
-    expect(selects.at(1).props().options).toStrictEqual(['PSP', 'privilege escalation'] as String[]);
+    expect(selects.at(1).props().options).toStrictEqual(['PSP', 'privilege escalation', 'compliance', 'deprecated API', 'namespace', 'psa', 'kubewarden'] as String[]);
   });
 
   it('filters shown cards by keywords when selected', async() => {
@@ -106,14 +115,15 @@ describe('component: PolicyGrid', () => {
     expect(wrapper.html()).toContain('Signed Test Policy');
     expect(wrapper.html()).toContain('Test Policy 2');
 
-    await wrapper.setData({ keywords: ['PSP'] });
+    await wrapper.vm.$nextTick();
+    await wrapper.setData({ keywords: ['PSP'], organizations: [] });
 
     expect(wrapper.html()).not.toContain('Signed Test Policy');
     expect(wrapper.html()).toContain('Test Policy 2');
   });
 
   it('should render correct resource options in LabeledSelect', () => {
-    const options: String[] = ['Deployment', 'Replicaset', 'Statefulset', 'Daemonset', 'Replicationcontroller', 'Job', 'Cronjob', 'Pod'];
+    const options: String[] = ['Deployment', 'Replicaset', 'Statefulset', 'Daemonset', 'Replicationcontroller', 'Job', 'Cronjob', 'Pod', '*', 'Namespace'];
 
     const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
       propsData:  { targetNamespace: 'default', value: policyPackages },
@@ -141,10 +151,86 @@ describe('component: PolicyGrid', () => {
     expect(wrapper.html()).toContain('Signed Test Policy');
     expect(wrapper.html()).toContain('Test Policy 2');
 
-    await wrapper.setData({ category: ['Daemonset'] });
+    await wrapper.vm.$nextTick();
+    await wrapper.setData({ category: ['Daemonset'], organizations: [] });
 
     expect(wrapper.html()).not.toContain('Signed Test Policy');
     expect(wrapper.html()).toContain('Test Policy 2');
     expect(wrapper.html()).toContain('Allow Privilege Escalation PSP');
+  });
+
+  it('excludes release candidates when showPreRelease is false', () => {
+    const wrapper = shallowMount(PolicyGrid, {
+      propsData:  { targetNamespace: 'default', value: policyPackages },
+      directives: { tooltip: jest.fn() },
+      mocks:      defaultMocks,
+      provide:    defaultProvide,
+      computed:   defaultComputed,
+    });
+
+    const filteredPackages = wrapper.vm.filteredPackages;
+
+    const containsRc = filteredPackages.some(pkg => pkg.name === 'container-resources');
+
+    expect(containsRc).toBe(false);
+  });
+
+  it('includes release candidates when showPreRelease is true', () => {
+    const wrapper = shallowMount(PolicyGrid, {
+      propsData:  { targetNamespace: 'default', value: policyPackages },
+      directives: { tooltip: jest.fn() },
+      mocks:      {
+        $store: {
+          getters: {
+            'i18n/t':    jest.fn(),
+            'prefs/get': () => true
+          }
+        }
+      },
+      provide:    defaultProvide,
+      computed:   defaultComputed,
+    });
+
+    const filteredPackages = wrapper.vm.filteredPackages;
+    const containsRc = filteredPackages.some(pkg => pkg.name === 'container-resources');
+
+    expect(containsRc).toBe(true);
+  });
+
+  it('includes deprecated-api-versions policy when showPreRelease is false', () => {
+    const wrapper = shallowMount(PolicyGrid, {
+      propsData:  { targetNamespace: 'default', value: policyPackages },
+      directives: { tooltip: jest.fn() },
+      mocks:      {
+        $store: {
+          getters: {
+            'i18n/t':    jest.fn(),
+            'prefs/get': () => false
+          }
+        }
+      },
+      provide:    defaultProvide,
+      computed:   defaultComputed,
+    });
+
+    const filteredPackages = wrapper.vm.filteredPackages;
+    const containsRc = filteredPackages.some(pkg => pkg.name === 'deprecated-api-versions');
+
+    expect(containsRc).toBe(true);
+  });
+
+  it('should hide policies defined as cluster admission policies when creating admission policy', () => {
+    const wrapper = shallowMount(PolicyGrid, {
+      propsData:  { targetNamespace: 'default', value: policyPackages },
+      directives: { tooltip: jest.fn() },
+      mocks:      defaultMocks,
+      provide:    { chartType: KUBEWARDEN.ADMISSION_POLICY },
+      computed:   { allSchemas: () => schemas },
+    });
+
+    const filteredPackages = wrapper.vm.filteredPackages;
+    const containsCap = filteredPackages.some(pkg => pkg.name === 'psa-label-enforcer');
+
+    expect(containsCap).toBe(false);
   });
 });

--- a/tests/unit/templates/policyPackages.js
+++ b/tests/unit/templates/policyPackages.js
@@ -7,7 +7,122 @@ export default [
     data:         { 'kubewarden/resources': 'Deployment,Replicaset,Statefulset,Daemonset,Replicationcontroller,Job,Cronjob,Pod' },
     signed:       true,
     signatures:   ['cosign'],
-    repository:   { organization_display_name: 'Kubewarden Developers' }
+    repository:   {
+      organization_name:         'kubewarden',
+      organization_display_name: 'Kubewarden Developers'
+    }
+  },
+  {
+    name:            'deprecated-api-versions',
+    normalized_name: 'deprecated-api-versions',
+    display_name:    'Deprecated API Versions',
+    description:     'Find deprecated and removed Kubernetes resources',
+    keywords:        [
+      'compliance',
+      'deprecated API'
+    ],
+    data:               { 'kubewarden/resources': '*' },
+    version:            '0.1.12-k8sv1.29.0',
+    available_versions: [
+      {
+        version:                   '0.1.12-k8sv1.29.0',
+        contains_security_updates: false,
+        prerelease:                false,
+      }
+    ],
+    prerelease: false,
+    provider:   'kubewarden',
+    repository: {
+      name:                      'deprecated-api-versions-policy',
+      display_name:              'Deprecated API Versions',
+      url:                       'https://github.com/kubewarden/deprecated-api-versions-policy',
+      organization_name:         'kubewarden',
+      organization_display_name: 'Kubewarden Developers'
+    },
+  },
+  {
+    name:            'container-resources',
+    normalized_name: 'container-resources',
+    display_name:    'Container Resources',
+    description:     'Policy is designed to enforce constraints on the resource requirements of Kubernetes containers',
+    keywords:        [
+      'container',
+      'resources'
+    ],
+    home_url: 'https://github.com/kubewarden/container-resources-policy',
+    data:     {
+      'kubewarden/mutation':  'true',
+      'kubewarden/resources': 'Pod, Replicationcontroller, Deployments, Replicaset, Statefulset, Daemonset, Job, Cronjob',
+    },
+    version:            '0.1.0-rc1',
+    available_versions: [
+      {
+        version:                   '0.1.0-rc1',
+        contains_security_updates: false,
+        prerelease:                false,
+      }
+    ],
+    prerelease:        false,
+    signed:            false,
+    containers_images: [
+      {
+        name:        'policy',
+        image:       'ghcr.io/kubewarden/policies/container-resources:v0.1.0',
+        whitelisted: false
+      }
+    ],
+    provider:   'kubewarden',
+    repository: {
+      name:                      'container-resources',
+      display_name:              'Container resources',
+      url:                       'https://github.com/kubewarden/container-resources-policy',
+      organization_name:         'kubewarden',
+      organization_display_name: 'Kubewarden Developers'
+    },
+  },
+  {
+    name:            'psa-label-enforcer',
+    normalized_name: 'psa-label-enforcer',
+    display_name:    'PSA Label Enforcer',
+    description:     'Policy to ensure that namespaces have the required PSA labels configuration for deployment in the cluster.',
+    keywords:        [
+      'namespace',
+      'psa',
+      'kubewarden'
+    ],
+    home_url: 'https://github.com/kubewarden/psa-label-enforcer',
+    data:     {
+      'kubewarden/mutation':  'true',
+      'kubewarden/resources': 'Namespace',
+    },
+    version:            '0.1.3',
+    available_versions: [
+      {
+        version:                   '0.1.3',
+        contains_security_updates: false,
+        prerelease:                false,
+      }
+    ],
+    prerelease: false,
+    signed:     true,
+    signatures: [
+      'cosign'
+    ],
+    containers_images: [
+      {
+        name:        'policy',
+        image:       'ghcr.io/kubewarden/policies/psa-label-enforcer:v0.1.3',
+        whitelisted: false
+      }
+    ],
+    provider:   'kubewarden',
+    repository: {
+      name:                      'psa-label-enforcer',
+      display_name:              'PSA Label Enforcer',
+      url:                       'https://github.com/kubewarden/psa-label-enforcer-policy',
+      organization_name:         'kubewarden',
+      organization_display_name: 'Kubewarden Developers'
+    },
   },
   {
     name:         'signed-test-policy',
@@ -27,6 +142,11 @@ export default [
     description:  'A test policy with less info',
     data:         { 'kubewarden/resources': 'Daemonset' },
     keywords:     ['PSP'],
-    repository:   { user_alias: 'evil' }
+    repository:   {
+      name:                      'test-policy-2',
+      display_name:              'test-policy-2',
+      url:                       'https://github.com/test-org/test-policy-2',
+      user_alias:                'evil'
+    }
   }
 ];

--- a/tests/unit/templates/schemas.js
+++ b/tests/unit/templates/schemas.js
@@ -1,0 +1,40 @@
+export default [
+  {
+    id:    'namespace',
+    type:  'schema',
+    links: {
+      collection: 'https://localhost:8005/v1/namespaces',
+      self:       'https://localhost:8005/v1/schemas/namespace'
+    },
+    description:     'Namespace provides a scope for Names. Use of multiple namespaces is optional.',
+    pluralName:      'namespaces',
+    resourceMethods: [
+      'GET',
+      'DELETE',
+      'PUT',
+      'PATCH'
+    ],
+    collectionMethods: [
+      'GET',
+      'GET',
+      'GET',
+      'POST'
+    ],
+    attributes: {
+      group:      '',
+      kind:       'Namespace',
+      namespaced: false,
+      resource:   'namespaces',
+      verbs:      [
+        'create',
+        'delete',
+        'get',
+        'list',
+        'patch',
+        'update',
+        'watch'
+      ],
+      version: 'v1'
+    }
+  }
+];


### PR DESCRIPTION
Fix #590 

This gives the ability for a user to display or hide pre-release policies within the PolicyGrid component by setting the pre-release user preference. There is a custom condition for the `deprecated-api-policy` as those versions have a [unique naming scheme](https://github.com/kubewarden/deprecated-api-versions-policy/releases).
