### PR TITLE
Fix artifacthub package parsing by repository url

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -27,4 +27,5 @@ module.exports = {
   coverageDirectory: '<rootDir>/coverage/unit',
   coverageReporters: ['json', 'text-summary'],
   preset:            '@vue/cli-plugin-unit-jest/presets/typescript-and-babel',
+  testEnvironment:   './tests/unit/FixJSDOMEnvironment.ts',
 };

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "typescript": "4.5.5"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "resolutions": {
     "**/webpack": "4"

--- a/pkg/kubewarden/components/Policies/Create.vue
+++ b/pkg/kubewarden/components/Policies/Create.vue
@@ -176,10 +176,8 @@ export default ({
     },
 
     packageValues() {
-      if ( this.type?.name ) {
-        const pkg = this.packages?.find(p => p.name === this.type.name);
-
-        return pkg;
+      if ( this.type?.repository?.url ) {
+        return this.packages?.find(p => p.repository?.url === this.type.repository.url);
       }
 
       return null;
@@ -357,7 +355,7 @@ export default ({
         return;
       }
 
-      const policyDetails = this.packages.find(pkg => pkg.name === this.type?.name);
+      const policyDetails = this.packages.find(pkg => pkg.repository?.url === this.type?.repository?.url);
       const packageQuestions = this.value.parsePackageMetadata(policyDetails?.data?.['kubewarden/questions-ui']);
       const packageAnnotation = `${ policyDetails.repository.name }/${ policyDetails.name }/${ policyDetails.version }`;
       /** Return spec from package if annotation exists */

--- a/pkg/kubewarden/package.json
+++ b/pkg/kubewarden/package.json
@@ -15,7 +15,7 @@
     "nuxt": "./node_modules/.bin/nuxt"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=16"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "5.0.8",

--- a/tests/unit/FixJSDOMEnvironment.ts
+++ b/tests/unit/FixJSDOMEnvironment.ts
@@ -1,0 +1,13 @@
+import JSDOMEnvironment from 'jest-environment-jsdom';
+
+// https://github.com/facebook/jest/blob/v29.4.3/website/versioned_docs/version-29.4/Configuration.md#testenvironment-string
+export default class FixJSDOMEnvironment extends JSDOMEnvironment {
+  constructor(...args: ConstructorParameters<typeof JSDOMEnvironment>) {
+    super(...args);
+
+    // FIXME https://github.com/jsdom/jsdom/issues/3363
+    this.global.structuredClone = (val) => {
+      return JSON.parse(JSON.stringify(val));
+    };
+  }
+}

--- a/tests/unit/components/MetricsChecklist.spec.ts
+++ b/tests/unit/components/MetricsChecklist.spec.ts
@@ -2,47 +2,47 @@ import { createWrapper } from '@tests/unit/utils/wrapper';
 
 import MetricsChecklist from '@kubewarden/components/MetricsChecklist.vue';
 
-const commonMocks = {
-  $store: {
-    getters: {
-      currentCluster: () => ({ id: 'test-cluster' }),
-      'i18n/t':       () => jest.fn(),
-    }
+const commons = {
+  propsData: {},
+  computed:  { hasKubewardenDashboards: () => false },
+  mocks:     {
+    $store: {
+      getters: {
+        currentCluster: () => ({ id: 'test-cluster' }),
+        'i18n/t':       () => jest.fn(),
+      },
+    },
+    $router: jest.fn(),
+    $route:  jest.fn(),
   },
-  $router: jest.fn(),
-  $route:  jest.fn(),
 };
 
-const commonComputed = { hasKubewardenDashboards: () => false };
-
-const defaultPropsData = {};
-
-const createMetricChecklistWrapper = createWrapper(MetricsChecklist, commonMocks, commonComputed, defaultPropsData);
+const wrapperFactory = createWrapper(MetricsChecklist, commons);
 
 describe('MetricChecklist.vue', () => {
   it('shows the conflicting dashboards banner when there are conflicting dashboards and no Kubewarden dashboards', () => {
     const conflictingGrafanaDashboards = [{ metadata: { name: 'Dashboard1' } }];
 
-    const wrapper = createMetricChecklistWrapper({
+    const wrapper = wrapperFactory({
       propsData: { conflictingGrafanaDashboards },
       computed:  { hasKubewardenDashboards: () => false },
       stubs:     {
         'n-link': { template: '<span />' },
         Banner:   { template: '<span />' },
-      }
+      },
     });
 
     expect(wrapper.vm.showConflictingDashboardsBanner).toBe(true);
   });
 
   it('does not show the conflicting dashboards banner when there are no conflicting dashboards', () => {
-    const wrapper = createMetricChecklistWrapper({
+    const wrapper = wrapperFactory({
       propsData: { conflictingGrafanaDashboards: [] },
       computed:  { hasKubewardenDashboards: () => false },
       stubs:     {
         'n-link': { template: '<span />' },
         Banner:   { template: '<span />' },
-      }
+      },
     });
 
     expect(wrapper.vm.showConflictingDashboardsBanner).toBe(false);
@@ -51,20 +51,20 @@ describe('MetricChecklist.vue', () => {
   it('does not show the conflicting dashboards banner when there are Kubewarden dashboards, even if there are conflicting dashboards', () => {
     const conflictingGrafanaDashboards = [{ metadata: { name: 'Dashboard1' } }];
 
-    const wrapper = createMetricChecklistWrapper({
+    const wrapper = wrapperFactory({
       propsData: { conflictingGrafanaDashboards },
       computed:  { hasKubewardenDashboards: () => true }, // Simulate presence of KubeWarden dashboards
       stubs:     {
         'n-link': { template: '<span />' },
         Banner:   { template: '<span />' },
-      }
+      },
     });
 
     expect(wrapper.vm.showConflictingDashboardsBanner).toBe(false);
   });
 
   it('disables the dashboard button when there is no monitoring app', () => {
-    const wrapper = createMetricChecklistWrapper({
+    const wrapper = wrapperFactory({
       propsData: {
         monitoringApp:                null,
         cattleDashboardNs:            {},
@@ -73,14 +73,14 @@ describe('MetricChecklist.vue', () => {
       stubs: {
         'n-link': { template: '<span />' },
         Banner:   { template: '<span />' },
-      }
+      },
     });
 
     expect(wrapper.vm.dashboardButtonDisabled).toBe(true);
   });
 
   it('disables the dashboard button when the cattleDashboardNs is empty', () => {
-    const wrapper = createMetricChecklistWrapper({
+    const wrapper = wrapperFactory({
       propsData: {
         monitoringApp:                {},
         cattleDashboardNs:            null,
@@ -89,14 +89,14 @@ describe('MetricChecklist.vue', () => {
       stubs: {
         'n-link': { template: '<span />' },
         Banner:   { template: '<span />' },
-      }
+      },
     });
 
     expect(wrapper.vm.dashboardButtonDisabled).toBe(true);
   });
 
   it('disables the dashboard button when there are conflicting Grafana dashboards', () => {
-    const wrapper = createMetricChecklistWrapper({
+    const wrapper = wrapperFactory({
       propsData: {
         monitoringApp:                {},
         cattleDashboardNs:            {},
@@ -105,14 +105,14 @@ describe('MetricChecklist.vue', () => {
       stubs: {
         'n-link': { template: '<span />' },
         Banner:   { template: '<span />' },
-      }
+      },
     });
 
     expect(wrapper.vm.dashboardButtonDisabled).toBe(true);
   });
 
   it('enables the dashboard button when monitoring app is present, cattleDashboardNs is not empty, and there are no conflicting Grafana dashboards', () => {
-    const wrapper = createMetricChecklistWrapper({
+    const wrapper = wrapperFactory({
       propsData: {
         monitoringApp:                {},
         cattleDashboardNs:            { someKey: 'someValue' },
@@ -121,7 +121,7 @@ describe('MetricChecklist.vue', () => {
       stubs: {
         'n-link': { template: '<span />' },
         Banner:   { template: '<span />' },
-      }
+      },
     });
 
     expect(wrapper.vm.dashboardButtonDisabled).toBe(false);
@@ -130,17 +130,17 @@ describe('MetricChecklist.vue', () => {
   it('enables the dashboard button when monitoring app is present, cattleDashboardNs is not empty, kubewarden dashboards exists and there are conflicting Grafana dashboards', () => {
     const conflictingGrafanaDashboards = [{ metadata: { name: 'Dashboard1' } }];
 
-    const wrapper = createMetricChecklistWrapper({
+    const wrapper = wrapperFactory({
       propsData: {
-        monitoringApp:                {},
-        cattleDashboardNs:            { someKey: 'someValue' },
+        monitoringApp:     {},
+        cattleDashboardNs: { someKey: 'someValue' },
         conflictingGrafanaDashboards,
       },
-      computed:  { hasKubewardenDashboards: () => true },
+      computed: { hasKubewardenDashboards: () => true },
       stubs:    {
         'n-link': { template: '<span />' },
         Banner:   { template: '<span />' },
-      }
+      },
     });
 
     expect(wrapper.vm.dashboardButtonDisabled).toBe(false);

--- a/tests/unit/components/Policies/Create.spec.ts
+++ b/tests/unit/components/Policies/Create.spec.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from '@jest/globals';
+import jsyaml from 'js-yaml';
+
+import { KUBEWARDEN } from '@kubewarden/types';
+import { createWrapper } from '@tests/unit/utils/wrapper';
+
+import Create from '@kubewarden/components/Policies/Create.vue';
+
+import policyPackages from '@tests/unit/templates/policyPackages';
+
+function mockParsePackageMetadata(data) {
+  if (data) {
+    const parsed = JSON.parse(JSON.stringify(data));
+
+    return jsyaml.load(parsed);
+  }
+
+  return null;
+}
+
+const commons = {
+  propsData: { value: { parsePackageMetadata: mockParsePackageMetadata } },
+  computed:  {
+    isAirgap:              () => false,
+    isCreate:              () => true,
+    canFinish:             () => true,
+    hasArtifactHub:        () => true,
+    hasRequired:           () => true,
+    hideArtifactHubBanner: () => true,
+    hideAirgapBanner:      () => true,
+  },
+  provide: { chartType: KUBEWARDEN.CLUSTER_ADMISSION_POLICY },
+  mocks:   {
+    $fetchState: { pending: false },
+    $store:      {
+      getters: {
+        'i18n/t':                            jest.fn(),
+        'kubewarden/airGapped':              jest.fn(),
+        'kubewarden/hideBannerArtifactHub':  jest.fn(),
+        'kubewarden/hideBannerAirgapPolicy': jest.fn(),
+        'cluster/all':                       jest.fn(),
+      },
+    },
+  },
+};
+
+const wrapperFactory = createWrapper(Create, commons);
+
+describe('component: PoliciesCreate', () => {
+  const duplicatePolicy1 = policyPackages[7];
+  const duplicatePolicy2 = policyPackages[8];
+
+  const WizardMock = {
+    render(h) {
+      return h('div');
+    },
+    methods: { next: jest.fn() },
+  };
+
+  it('parses correct artifacthub package details depending on the repository package selected', async() => {
+    const wrapper = wrapperFactory({
+      stubs: {
+        Banner:      { template: '<span />' },
+        Markdown:    { template: '<span />' },
+        AsyncButton: { template: '<span />' },
+        Wizard:      WizardMock,
+      },
+    });
+
+    await wrapper.vm.$nextTick();
+    wrapper.setData({ packages: policyPackages });
+
+    wrapper.vm.selectType(duplicatePolicy1);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.chartValues.policy.spec.module).toStrictEqual(
+      duplicatePolicy1.containers_images[0].image
+    );
+    expect(wrapper.vm.packageValues.readme).toStrictEqual(
+      duplicatePolicy1.readme
+    );
+
+    wrapper.vm.reset({ step: { name: 'policies' } });
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.selectType(duplicatePolicy2);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.chartValues.policy.spec.module).toStrictEqual(
+      duplicatePolicy2.containers_images[0].image
+    );
+    expect(wrapper.vm.packageValues.readme).toStrictEqual(
+      duplicatePolicy2.readme
+    );
+  });
+});

--- a/tests/unit/components/Policies/PolicyGrid.spec.ts
+++ b/tests/unit/components/Policies/PolicyGrid.spec.ts
@@ -16,9 +16,9 @@ const defaultMocks = {
   $store: {
     getters: {
       'i18n/t':    jest.fn(),
-      'prefs/get': () => false
-    }
-  }
+      'prefs/get': () => false,
+    },
+  },
 };
 const defaultProvide = { chartType: KUBEWARDEN.CLUSTER_ADMISSION_POLICY };
 
@@ -27,13 +27,16 @@ describe('component: PolicyGrid', () => {
     const packages: Array<any> = [];
     const customSubtype = `<div>Custom Policy</div>`;
 
-    const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
-      propsData: { targetNamespace: 'default', value: packages },
-      mocks:     defaultMocks,
-      provide:   defaultProvide,
-      computed:  defaultComputed,
-      slots:     { customSubtype }
-    });
+    const wrapper = shallowMount(
+      PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>,
+      {
+        propsData: { targetNamespace: 'default', value: packages },
+        mocks:     defaultMocks,
+        provide:   defaultProvide,
+        computed:  defaultComputed,
+        slots:     { customSubtype },
+      }
+    );
 
     expect(wrapper.html()).toContain('Custom Policy');
   });
@@ -41,41 +44,55 @@ describe('component: PolicyGrid', () => {
   it('should render provided packages', () => {
     const customSubtype = `<div>Custom Policy</div>`;
 
-    const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
-      propsData:  { targetNamespace: 'default', value: policyPackages },
-      directives: { tooltip: jest.fn() },
-      mocks:      defaultMocks,
-      provide:    defaultProvide,
-      computed:   defaultComputed,
-      slots:      { customSubtype }
-    });
+    const wrapper = shallowMount(
+      PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>,
+      {
+        propsData:  { targetNamespace: 'default', value: policyPackages },
+        directives: { tooltip: jest.fn() },
+        mocks:      defaultMocks,
+        provide:    defaultProvide,
+        computed:   defaultComputed,
+        slots:      { customSubtype },
+      }
+    );
 
     expect(wrapper.html()).toContain('Custom Policy');
     expect(wrapper.html()).toContain('Allow Privilege Escalation PSP');
   });
 
   it('should render correct organization options in LabeledSelect', () => {
-    const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
-      propsData:  { targetNamespace: 'default', value: policyPackages },
-      directives: { tooltip: jest.fn() },
-      mocks:      defaultMocks,
-      provide:    defaultProvide,
-      computed:   defaultComputed
-    });
+    const wrapper = shallowMount(
+      PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>,
+      {
+        propsData:  { targetNamespace: 'default', value: policyPackages },
+        directives: { tooltip: jest.fn() },
+        mocks:      defaultMocks,
+        provide:    defaultProvide,
+        computed:   defaultComputed,
+      }
+    );
 
     const selects = wrapper.findAllComponents(LabeledSelect);
 
-    expect(selects.at(0).props().options).toStrictEqual(['Kubewarden Developers', 'evil'] as String[]);
+    expect(selects.at(0).props().options).toStrictEqual([
+      'Kubewarden Developers',
+      'honorable',
+      'dishonorable',
+      'evil',
+    ] as String[]);
   });
 
   it('filters shown cards by organization when selected', async() => {
-    const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
-      propsData:  { targetNamespace: 'default', value: policyPackages },
-      directives: { tooltip: jest.fn() },
-      mocks:      defaultMocks,
-      provide:    defaultProvide,
-      computed:   defaultComputed
-    });
+    const wrapper = shallowMount(
+      PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>,
+      {
+        propsData:  { targetNamespace: 'default', value: policyPackages },
+        directives: { tooltip: jest.fn() },
+        mocks:      defaultMocks,
+        provide:    defaultProvide,
+        computed:   defaultComputed,
+      }
+    );
 
     expect(wrapper.html()).toContain('Allow Privilege Escalation PSP');
     expect(wrapper.html()).toContain('Signed Test Policy');
@@ -89,27 +106,41 @@ describe('component: PolicyGrid', () => {
   });
 
   it('should render correct keyword options in LabeledSelect', () => {
-    const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
-      propsData:  { targetNamespace: 'default', value: policyPackages },
-      directives: { tooltip: jest.fn() },
-      mocks:      defaultMocks,
-      provide:    defaultProvide,
-      computed:   defaultComputed,
-    });
+    const wrapper = shallowMount(
+      PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>,
+      {
+        propsData:  { targetNamespace: 'default', value: policyPackages },
+        directives: { tooltip: jest.fn() },
+        mocks:      defaultMocks,
+        provide:    defaultProvide,
+        computed:   defaultComputed,
+      }
+    );
 
     const selects = wrapper.findAllComponents(LabeledSelect);
 
-    expect(selects.at(1).props().options).toStrictEqual(['PSP', 'privilege escalation', 'compliance', 'deprecated API', 'namespace', 'psa', 'kubewarden'] as String[]);
+    expect(selects.at(1).props().options).toStrictEqual([
+      'PSP',
+      'privilege escalation',
+      'compliance',
+      'deprecated API',
+      'namespace',
+      'psa',
+      'kubewarden',
+    ] as String[]);
   });
 
   it('filters shown cards by keywords when selected', async() => {
-    const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
-      propsData:  { targetNamespace: 'default', value: policyPackages },
-      directives: { tooltip: jest.fn() },
-      mocks:      defaultMocks,
-      provide:    defaultProvide,
-      computed:   defaultComputed
-    });
+    const wrapper = shallowMount(
+      PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>,
+      {
+        propsData:  { targetNamespace: 'default', value: policyPackages },
+        directives: { tooltip: jest.fn() },
+        mocks:      defaultMocks,
+        provide:    defaultProvide,
+        computed:   defaultComputed,
+      }
+    );
 
     expect(wrapper.html()).toContain('Allow Privilege Escalation PSP');
     expect(wrapper.html()).toContain('Signed Test Policy');
@@ -123,15 +154,29 @@ describe('component: PolicyGrid', () => {
   });
 
   it('should render correct resource options in LabeledSelect', () => {
-    const options: String[] = ['Deployment', 'Replicaset', 'Statefulset', 'Daemonset', 'Replicationcontroller', 'Job', 'Cronjob', 'Pod', '*', 'Namespace'];
+    const options: String[] = [
+      'Deployment',
+      'Replicaset',
+      'Statefulset',
+      'Daemonset',
+      'Replicationcontroller',
+      'Job',
+      'Cronjob',
+      'Pod',
+      '*',
+      'Namespace',
+    ];
 
-    const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
-      propsData:  { targetNamespace: 'default', value: policyPackages },
-      directives: { tooltip: jest.fn() },
-      mocks:      defaultMocks,
-      provide:    defaultProvide,
-      computed:   defaultComputed
-    });
+    const wrapper = shallowMount(
+      PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>,
+      {
+        propsData:  { targetNamespace: 'default', value: policyPackages },
+        directives: { tooltip: jest.fn() },
+        mocks:      defaultMocks,
+        provide:    defaultProvide,
+        computed:   defaultComputed,
+      }
+    );
 
     const selects = wrapper.findAllComponents(LabeledSelect);
 
@@ -139,13 +184,16 @@ describe('component: PolicyGrid', () => {
   });
 
   it('filters shown cards by resources when selected', async() => {
-    const wrapper = shallowMount(PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
-      propsData:  { targetNamespace: 'default', value: policyPackages },
-      directives: { tooltip: jest.fn() },
-      mocks:      defaultMocks,
-      provide:    defaultProvide,
-      computed:   defaultComputed
-    });
+    const wrapper = shallowMount(
+      PolicyGrid as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>,
+      {
+        propsData:  { targetNamespace: 'default', value: policyPackages },
+        directives: { tooltip: jest.fn() },
+        mocks:      defaultMocks,
+        provide:    defaultProvide,
+        computed:   defaultComputed,
+      }
+    );
 
     expect(wrapper.html()).toContain('Allow Privilege Escalation PSP');
     expect(wrapper.html()).toContain('Signed Test Policy');
@@ -170,7 +218,9 @@ describe('component: PolicyGrid', () => {
 
     const filteredPackages = wrapper.vm.filteredPackages;
 
-    const containsRc = filteredPackages.some(pkg => pkg.name === 'container-resources');
+    const containsRc = filteredPackages.some(
+      pkg => pkg.name === 'container-resources'
+    );
 
     expect(containsRc).toBe(false);
   });
@@ -183,16 +233,18 @@ describe('component: PolicyGrid', () => {
         $store: {
           getters: {
             'i18n/t':    jest.fn(),
-            'prefs/get': () => true
-          }
-        }
+            'prefs/get': () => true,
+          },
+        },
       },
-      provide:    defaultProvide,
-      computed:   defaultComputed,
+      provide:  defaultProvide,
+      computed: defaultComputed,
     });
 
     const filteredPackages = wrapper.vm.filteredPackages;
-    const containsRc = filteredPackages.some(pkg => pkg.name === 'container-resources');
+    const containsRc = filteredPackages.some(
+      pkg => pkg.name === 'container-resources'
+    );
 
     expect(containsRc).toBe(true);
   });
@@ -205,16 +257,18 @@ describe('component: PolicyGrid', () => {
         $store: {
           getters: {
             'i18n/t':    jest.fn(),
-            'prefs/get': () => false
-          }
-        }
+            'prefs/get': () => false,
+          },
+        },
       },
-      provide:    defaultProvide,
-      computed:   defaultComputed,
+      provide:  defaultProvide,
+      computed: defaultComputed,
     });
 
     const filteredPackages = wrapper.vm.filteredPackages;
-    const containsRc = filteredPackages.some(pkg => pkg.name === 'deprecated-api-versions');
+    const containsRc = filteredPackages.some(
+      pkg => pkg.name === 'deprecated-api-versions'
+    );
 
     expect(containsRc).toBe(true);
   });
@@ -229,7 +283,9 @@ describe('component: PolicyGrid', () => {
     });
 
     const filteredPackages = wrapper.vm.filteredPackages;
-    const containsCap = filteredPackages.some(pkg => pkg.name === 'psa-label-enforcer');
+    const containsCap = filteredPackages.some(
+      pkg => pkg.name === 'psa-label-enforcer'
+    );
 
     expect(containsCap).toBe(false);
   });

--- a/tests/unit/templates/policyPackages.js
+++ b/tests/unit/templates/policyPackages.js
@@ -148,5 +148,49 @@ export default [
       url:                       'https://github.com/test-org/test-policy-2',
       user_alias:                'evil'
     }
-  }
+  },
+  {
+    name:              'duplicate-test-policy',
+    display_name:      'Duplicate Test Policy',
+    description:       'A duplicate test policy with different repositories',
+    data:              { 'kubewarden/resources': 'Daemonset' },
+    home_url:          'https://github.com/duplicate-policy-org-1/duplicate-test-policy',
+    keywords:          ['PSP'],
+    containers_images: [
+      {
+        name:        'policy',
+        image:       'ghcr.io/duplicate-policy-org-1/policies/duplicate-test-policy:v0.1.0',
+        whitelisted: false
+      }
+    ],
+    readme:     'duplicate test policy org 1 readme',
+    repository:   {
+      name:                      'duplicate-test-policy',
+      display_name:              'duplicate-test-policy',
+      url:                       'https://github.com/duplicate-policy-org-1/duplicate-test-policy',
+      user_alias:                'honorable'
+    }
+  },
+  {
+    name:              'duplicate-test-policy',
+    display_name:      'Duplicate Test Policy',
+    description:       'A duplicate test policy with different repositories',
+    data:              { 'kubewarden/resources': 'Daemonset' },
+    home_url:          'https://github.com/duplicate-policy-org-2/duplicate-test-policy',
+    keywords:          ['PSP'],
+    containers_images: [
+      {
+        name:        'policy',
+        image:       'ghcr.io/duplicate-policy-org-2/policies/duplicate-test-policy:v0.1.0',
+        whitelisted: false
+      }
+    ],
+    readme:     'duplicate test policy org 2 readme',
+    repository:   {
+      name:                      'duplicate-test-policy',
+      display_name:              'duplicate-test-policy',
+      url:                       'https://github.com/duplicate-policy-org-2/duplicate-test-policy',
+      user_alias:                'dishonorable'
+    }
+  },
 ];

--- a/tests/unit/utils/wrapper.ts
+++ b/tests/unit/utils/wrapper.ts
@@ -1,37 +1,51 @@
 import Vue from 'vue';
-import { shallowMount, createLocalVue } from '@vue/test-utils';
+import {
+  shallowMount,
+  createLocalVue,
+  ThisTypedShallowMountOptions,
+} from '@vue/test-utils';
 import Vuex from 'vuex';
 
-interface WrapperOptions {
-  propsData?: { [key: string]: any };
-  computed?: { [key: string]: any };
-  mocks?: { [key: string]: any };
-  stubs?: { [key: string]: any };
+type VueComponent = typeof Vue | Vue.VueConstructor;
+
+interface ExtendedMountOptions<V extends Vue>
+  extends ThisTypedShallowMountOptions<V> {
+  [key: string]: any;
 }
 
-export const createWrapper = (Component: typeof Vue, commonMocks: any, commonComputed: any, defaultPropsData = {}) => {
+/**
+ * Creates a wrapper factory function for a given component and common options.
+ *
+ * @param Component - The Vue component to be mounted. This can be a Vue component object or a constructor.
+ * @param commons - A set of default options to be applied to the component during mounting. These can include
+ *                  propsData, computed properties, methods, stubs, mocks, and any other Vue Test Utils options.
+ *                  Custom properties specific to your component can also be included.
+ * @returns A function that takes an object of type `ExtendedMountOptions<Vue>` as an optional parameter
+ *          for providing overrides or additional options to the shallowMount call. This function returns
+ *          a Wrapper<Vue> instance, which is the mounted component wrapper that can be used for testing.
+ *
+ * Usage example:
+ * const defaultOptions = {
+ *   propsData: { propA: 'value1' },
+ *   computed: { computedB: () => 'value2' }
+ * };
+ * const wrapperFactory = createWrapper(MyComponent, defaultOptions);
+ * const wrapper = wrapperFactory({ propsData: { propA: 'overrideValue' } });
+ */
+export const createWrapper = (
+  Component: VueComponent,
+  commons: ExtendedMountOptions<Vue> = {}
+) => {
   const localVue = createLocalVue();
 
   localVue.use(Vuex);
 
-  return (overrides: WrapperOptions = {}) => {
-    const mergedPropsData = {
-      ...defaultPropsData,
-      ...overrides.propsData,
-    };
-
-    const mountOptions = {
+  return (overrides: ExtendedMountOptions<Vue> = {}) => {
+    // Merge the common options with any overrides provided at the call time.
+    const mountOptions: ExtendedMountOptions<Vue> = {
       localVue,
-      ...overrides,
-      propsData: mergedPropsData,
-      computed:  {
-        ...commonComputed,
-        ...overrides.computed,
-      },
-      mocks: {
-        ...commonMocks,
-        ...overrides.mocks,
-      },
+      ...commons, // Apply common/default settings.
+      ...overrides, // Allow specific test cases to override or extend the settings.
     };
 
     return shallowMount(Component, mountOptions);


### PR DESCRIPTION
Fix #611 

The original parsing of the ArtifactHub package when selecting a type was only based on the package's root `name` property. Naturally this will cause errors when there are duplicate packages with the same name but created within different repositories.

Now when a package is selected we are parsing the correct package details based on the package's `repository.url` property. I added a unit test for this case as well.

Other fixes:
- Updated the `createWrapper` utility to accept any override properties
- Updated the node engine resolution to `>= 16`
- Added a polyfill on jest tests for the `structuredClone` method which is only available on node version `>= 17`