### PR TITLE
Remove calls to `currentProduct`

### DIFF
--- a/pkg/kubewarden/chart/kubewarden/admission/ContextAware/Resource.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/ContextAware/Resource.vue
@@ -40,10 +40,9 @@ export default {
   watch: { 'value.apiVersion': 'clearKind' },
 
   computed: {
-    ...mapGetters(['currentProduct']),
 
     allSchemas() {
-      return this.$store.getters[`${ this.currentProduct.inStore }/all`](SCHEMA);
+      return this.$store.getters['cluster/all'](SCHEMA);
     },
 
     isCreate() {

--- a/pkg/kubewarden/chart/kubewarden/admission/ContextAware/index.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/ContextAware/index.vue
@@ -29,7 +29,7 @@ export default {
   },
 
   async fetch() {
-    await this.$store.dispatch(`${ this.currentProduct.inStore }/findAll`, { type: 'apigroup' });
+    await this.$store.dispatch('cluster/findAll', { type: 'apigroup' });
 
     this.contextAwareResources = [];
 
@@ -43,10 +43,8 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['currentProduct']),
-
     apiGroups() {
-      return this.$store.getters[`${ this.currentProduct.inStore }/all`]('apigroup');
+      return this.$store.getters['cluster/all']('apigroup');
     },
 
     /** Return the group ID and groupVersion for each apiGroup */

--- a/pkg/kubewarden/chart/kubewarden/admission/General.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/General.vue
@@ -44,7 +44,7 @@ export default {
   },
 
   async fetch() {
-    await this.$store.dispatch(`${ this.currentProduct.inStore }/findAll`, { type: KUBEWARDEN.POLICY_SERVER });
+    await this.$store.dispatch('cluster/findAll', { type: KUBEWARDEN.POLICY_SERVER });
 
     if ( this.isCreate && !isEmpty(this.policy.spec) ) {
       set(this.policy.spec, 'mode', 'protect');
@@ -88,8 +88,6 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['currentProduct']),
-
     isCreate() {
       return this.mode === _CREATE;
     },
@@ -112,7 +110,7 @@ export default {
     },
 
     policyServers() {
-      return this.$store.getters[`${ this.currentProduct.inStore }/all`](KUBEWARDEN.POLICY_SERVER);
+      return this.$store.getters['cluster/all'](KUBEWARDEN.POLICY_SERVER);
     },
 
     policyServerOptions() {

--- a/pkg/kubewarden/chart/kubewarden/admission/Rules/Rule.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/Rules/Rule.vue
@@ -94,7 +94,6 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['currentProduct']),
 
     filteredGroups() {
       return this.chartType === KUBEWARDEN.ADMISSION_POLICY ? this.namespacedGroups : this.apiGroups;

--- a/pkg/kubewarden/components/Dashboard/DashboardView.vue
+++ b/pkg/kubewarden/components/Dashboard/DashboardView.vue
@@ -28,7 +28,6 @@ export default {
   mixins: [ResourceManager],
 
   async fetch() {
-    const inStore = this.currentProduct.inStore;
     const hash = {};
     const types = [
       KUBEWARDEN.ADMISSION_POLICY,
@@ -39,8 +38,8 @@ export default {
     ];
 
     for ( const type of types ) {
-      if ( this.$store.getters[`${ inStore }/canList`](type) ) {
-        hash[type] = this.$store.dispatch(`${ inStore }/findAll`, { type });
+      if ( this.$store.getters['cluster/canList'](type) ) {
+        hash[type] = this.$store.dispatch('cluster/findAll', { type });
       }
     }
 
@@ -68,7 +67,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['currentCluster', 'currentProduct']),
+    ...mapGetters(['currentCluster']),
     ...mapGetters({ charts: 'catalog/charts' }),
 
     allApps() {

--- a/pkg/kubewarden/components/Dashboard/InstallView.vue
+++ b/pkg/kubewarden/components/Dashboard/InstallView.vue
@@ -49,12 +49,11 @@ export default {
     this.reloadReady = false;
 
     if ( !this.hasSchema ) {
-      const inStore = this.currentProduct.inStore;
       const hash = [];
       const listTypes = [SERVICE, CATALOG.CLUSTER_REPO];
 
       listTypes.forEach((type) => {
-        if ( this.$store.getters[`${ inStore }/canList`](type) ) {
+        if ( this.$store.getters['cluster/canList'](type) ) {
           hash.push(this.$fetchType(type));
         }
       });
@@ -119,7 +118,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['currentCluster', 'currentProduct']),
+    ...mapGetters(['currentCluster']),
     ...mapGetters({
       charts: 'catalog/charts', repos: 'catalog/repos', t: 'i18n/t'
     }),
@@ -129,7 +128,7 @@ export default {
     },
 
     certService() {
-      return this.$store.getters[`${ this.currentProduct.inStore }/all`](SERVICE).find(s => s.metadata?.labels?.['app'] === 'cert-manager');
+      return this.$store.getters['cluster/all'](SERVICE).find(s => s.metadata?.labels?.['app'] === 'cert-manager');
     },
 
     controllerChart() {

--- a/pkg/kubewarden/components/Policies/Values.vue
+++ b/pkg/kubewarden/components/Policies/Values.vue
@@ -126,8 +126,7 @@ export default {
 
   methods: {
     generateYaml() {
-      const inStore = this.$store.getters['currentStore'](this.value);
-      const schemas = this.$store.getters[`${ inStore }/all`](SCHEMA);
+      const schemas = this.$store.getters['cluster/all'](SCHEMA);
       const cloned = this.chartValues?.policy ? structuredClone(this.chartValues.policy) : this.value;
 
       if ( this.yamlValues?.length ) {

--- a/pkg/kubewarden/detail/policies.kubewarden.io.policyserver.vue
+++ b/pkg/kubewarden/detail/policies.kubewarden.io.policyserver.vue
@@ -68,7 +68,7 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['currentCluster', 'currentProduct']),
+    ...mapGetters(['currentCluster']),
     ...mapGetters({ policyTraces: 'kubewarden/policyTraces' }),
     _group: mapPref(GROUP_RESOURCES),
 

--- a/pkg/kubewarden/formatters/PolicyServerStatus.vue
+++ b/pkg/kubewarden/formatters/PolicyServerStatus.vue
@@ -18,14 +18,13 @@ export default {
   },
 
   async fetch() {
-    await this.$store.dispatch(`${ this.currentProduct.inStore }/findAll`, { type: WORKLOAD_TYPES.DEPLOYMENT });
+    await this.$store.dispatch('cluster/findAll', { type: WORKLOAD_TYPES.DEPLOYMENT });
   },
 
   computed: {
-    ...mapGetters(['currentProduct']),
 
     allDeployments() {
-      return this.$store.getters[`${ this.currentProduct.inStore }/all`](WORKLOAD_TYPES.DEPLOYMENT);
+      return this.$store.getters['cluster/all'](WORKLOAD_TYPES.DEPLOYMENT);
     },
 
     deployment() {

--- a/pkg/kubewarden/list/policies.kubewarden.io.admissionpolicy.vue
+++ b/pkg/kubewarden/list/policies.kubewarden.io.admissionpolicy.vue
@@ -23,14 +23,13 @@ export default {
   },
 
   async fetch() {
-    await this.$store.dispatch(`${ this.currentProduct.inStore }/findAll`, { type: this.resource });
+    await this.$store.dispatch('cluster/findAll', { type: this.resource });
   },
 
   computed: {
-    ...mapGetters(['currentProduct']),
 
     rows() {
-      return this.$store.getters[`${ this.currentProduct.inStore }/all`](this.resource);
+      return this.$store.getters['cluster/all'](this.resource);
     }
   }
 };

--- a/pkg/kubewarden/list/policies.kubewarden.io.clusteradmissionpolicy.vue
+++ b/pkg/kubewarden/list/policies.kubewarden.io.clusteradmissionpolicy.vue
@@ -23,14 +23,13 @@ export default {
   },
 
   async fetch() {
-    await this.$store.dispatch(`${ this.currentProduct.inStore }/findAll`, { type: this.resource });
+    await this.$store.dispatch('cluster/findAll', { type: this.resource });
   },
 
   computed: {
-    ...mapGetters(['currentProduct']),
 
     rows() {
-      return this.$store.getters[`${ this.currentProduct.inStore }/all`](this.resource);
+      return this.$store.getters['cluster/all'](this.resource);
     }
   }
 };

--- a/pkg/kubewarden/list/policies.kubewarden.io.policyserver.vue
+++ b/pkg/kubewarden/list/policies.kubewarden.io.policyserver.vue
@@ -28,11 +28,11 @@ export default {
   },
 
   async fetch() {
-    await this.$store.dispatch(`${ this.currentProduct.inStore }/findAll`, { type: this.resource });
+    await this.$store.dispatch('cluster/findAll', { type: this.resource });
     await this.$store.dispatch('catalog/load');
 
     if ( !this.hideBannerDefaults ) {
-      this.apps = await this.$store.dispatch(`${ this.currentProduct.inStore }/findAll`, { type: CATALOG.APP });
+      this.apps = await this.$store.dispatch('cluster/findAll', { type: CATALOG.APP });
     }
   },
 
@@ -41,7 +41,6 @@ export default {
   },
 
   computed: {
-    ...mapGetters(['currentProduct']),
 
     defaultsApp() {
       return this.apps?.find((a) => {
@@ -54,7 +53,7 @@ export default {
     },
 
     rows() {
-      return this.$store.getters[`${ this.currentProduct.inStore }/all`](this.resource);
+      return this.$store.getters['cluster/all'](this.resource);
     }
   }
 };

--- a/pkg/kubewarden/plugins/kubewarden-class.js
+++ b/pkg/kubewarden/plugins/kubewarden-class.js
@@ -19,15 +19,14 @@ import {
 
 export default class KubewardenModel extends SteveModel {
   async allServices() {
-    const inStore = this.$rootGetters['currentProduct'].inStore;
-    const services = this.$rootGetters[`${ inStore }/all`](SERVICE);
+    const services = this.$rootGetters['cluster/all'](SERVICE);
 
     if ( !isEmpty(services) ) {
       return services;
     }
 
     return await this.$dispatch(
-      `${ inStore }/findAll`,
+      'cluster/findAll',
       { type: SERVICE },
       { root: true }
     );

--- a/pkg/kubewarden/plugins/policy-server-class.js
+++ b/pkg/kubewarden/plugins/policy-server-class.js
@@ -23,9 +23,8 @@ export default class PolicyServerModel extends KubewardenModel {
 
   get allRelatedPolicies() {
     return async() => {
-      const inStore = this.$rootGetters['currentProduct'].inStore;
       const types = [KUBEWARDEN.ADMISSION_POLICY, KUBEWARDEN.CLUSTER_ADMISSION_POLICY];
-      const promises = types.map(type => this.$dispatch(`${ inStore }/findAll`, { type, opt: { force: true } }, { root: true }));
+      const promises = types.map(type => this.$dispatch('cluster/findAll', { type, opt: { force: true } }, { root: true }));
 
       try {
         const out = await Promise.all(promises);
@@ -111,9 +110,7 @@ export default class PolicyServerModel extends KubewardenModel {
   get matchingDeployment() {
     return async() => {
       try {
-        const inStore = this.$rootGetters['currentProduct'].inStore;
-
-        return await this.$dispatch(`${ inStore }/findMatching`, {
+        return await this.$dispatch('cluster/findMatching', {
           type:     WORKLOAD_TYPES.DEPLOYMENT,
           selector: `kubewarden/policy-server=${ this.metadata?.name }`
         }, { root: true });
@@ -126,9 +123,7 @@ export default class PolicyServerModel extends KubewardenModel {
   get matchingPods() {
     return async() => {
       try {
-        const inStore = this.$rootGetters['currentProduct'].inStore;
-
-        return await this.$dispatch(`${ inStore }/findMatching`, {
+        return await this.$dispatch('cluster/findMatching', {
           type:     POD,
           selector: `app=kubewarden-policy-server-${ this.metadata?.name }` // kubewarden-policy-server is hardcoded from the kubewarden-controller
         }, { root: true });

--- a/tests/unit/charts/admission/Rules.spec.ts
+++ b/tests/unit/charts/admission/Rules.spec.ts
@@ -18,12 +18,7 @@ describe('component: Rules', () => {
       },
       propsData: { value: { policy: policyConfig } },
       provide:   { chartType: KUBEWARDEN.CLUSTER_ADMISSION_POLICY },
-      computed:  {
-        currentProduct: () => {
-          return { inStore: 'cluster' };
-        },
-        apiGroups: () => []
-      },
+      computed:  { apiGroups: () => [] },
       mocks:     {
         $fetchState: { pending: false },
         $store:      {

--- a/tests/unit/components/Dashboard/DashboardView.spec.ts
+++ b/tests/unit/components/Dashboard/DashboardView.spec.ts
@@ -14,7 +14,6 @@ describe('component: DashboardView', () => {
     $store:      {
       getters: {
         currentCluster:                  () => 'current_cluster',
-        currentProduct:                  () => 'current_product',
         'kubewarden/hideBannerDefaults': jest.fn(),
         'i18n/t':                        jest.fn(),
         'catalog/chart':                 jest.fn(),

--- a/tests/unit/detail/PolicyServer.spec.ts
+++ b/tests/unit/detail/PolicyServer.spec.ts
@@ -47,7 +47,6 @@ describe('component: PolicyServer', () => {
         $store:      {
           getters: {
             currentCluster:                  () => 'current_cluster',
-            currentProduct:                  () => 'current_product',
             'current_product/all':           jest.fn(),
             'i18n/t':                        jest.fn(),
             'kubewarden/policyTraces':       () => TraceTestData
@@ -108,7 +107,6 @@ describe('component: PolicyServer', () => {
         $store:      {
           getters: {
             currentCluster:                  () => 'current_cluster',
-            currentProduct:                  () => 'current_product',
             'current_product/all':           jest.fn(),
             'i18n/t':                        jest.fn(),
             'kubewarden/policyTraces':       () => TraceTestData


### PR DESCRIPTION
Fix #626 

This will remove all of the calls to the getter `currentProduct` as it adds unnecessary overhead when we will only ever be in the `cluster` context.