### PR TITLE
Fix github e2e run name

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,5 +1,5 @@
 name: Playwright Tests
-run-name: ${{ github.workflow }}${{ github.event.schedule == '0 4 * * *' || inputs.upgrade && ' - Upgrade' ||''}}${{ github.event.schedule == '0 3 * * *' || inputs.fleet && ' - Fleet' || ''}}
+run-name: ${{ github.workflow }}${{ (github.event.schedule == '0 4 * * *' || inputs.upgrade) && ' - Upgrade' || '' }}${{ (github.event.schedule == '0 3 * * *' || inputs.fleet) && ' - Fleet' || '' }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Condition requires brackets, otherwise it outputs [Playwright Teststrue](https://github.com/rancher/kubewarden-ui/actions/workflows/playwright.yml) when triggered by schedule.