### PR TITLE
Add check for context-aware & mutation labels

### DIFF
--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -156,14 +156,19 @@ test('05 Whitelist Artifact Hub', async({ page, ui, nav }) => {
     await ui.button('Create').click()
     await expect(cap.cards()).toHaveCount(apList.length)
     await expect(cap.cards({ signed: true, official: true })).toHaveCount(apList.length - 1) // -1 for Custom Policy
+
+    // Only Custom Policy is unofficial & unsigned
+    await expect(cap.cards({ signed: false })).toHaveCount(1)
+    await expect(cap.cards({ official: false })).toHaveCount(1)
+    await expect(cap.cards({ name: 'Custom Policy', signed: false, official: false })).toBeVisible()
+    // We have context-aware and mutating policy
+    await expect(cap.cards({ aware: true }).first()).toBeVisible()
+    await expect(cap.cards({ mutation: true }).first()).toBeVisible()
   })
 
   await test.step('Check User policies', async() => {
     await nav.capolicy()
     await ui.button('Create').click()
-    // Custom Policy is unofficial & unsigned
-    await expect(cap.cards({ signed: false })).toHaveCount(1)
-    await expect(cap.cards({ official: false })).toHaveCount(1)
     // Display User policies
     await ui.button('Deselect Kubewarden Developers').click()
     await expect(cap.cards().nth(capList.length)).toBeVisible()

--- a/tests/e2e/pages/policies.page.ts
+++ b/tests/e2e/pages/policies.page.ts
@@ -10,7 +10,7 @@ export const apList = ['Custom Policy', 'Allow Privilege Escalation PSP', 'Allow
   'Safe Annotations', 'Safe Labels', 'Seccomp PSP', 'Selinux PSP', 'Sysctl PSP', 'Trusted Repos', 'User Group PSP', 'Verify Image Signatures', 'volumeMounts', 'Volumes PSP', 'Unique Ingress host',
   'Unique service selector'] as const // WIP: 'CEL Policy'
 
-export const capList = [...apList, 'PSA Label Enforcer']
+export const capList = [...apList, 'PSA Label Enforcer'] as const
 
 export type policyTitle = typeof capList[number]
 export type PolicyKind = 'AdmissionPolicy' | 'ClusterAdmissionPolicy'


### PR DESCRIPTION
Check that:
- only Custom Policy is unsigned and unofficial
- we have at least one context-aware and mutation policy
- fix policyTitle code completion