### PR TITLE
Replace `catalog/refresh` call with `catalog/load`

### DIFF
--- a/tests/unit/_templates_/policyServerPod.ts
+++ b/tests/unit/_templates_/policyServerPod.ts
@@ -1,4 +1,4 @@
-export default {
+export const policyServerPod: any = {
   id:         'cattle-kubewarden-system/policy-server-default-7f59869c46-wjg4v',
   type:       'pod',
   apiVersion: 'v1',

--- a/tests/unit/components/Dashboard/DashboardView.spec.ts
+++ b/tests/unit/components/Dashboard/DashboardView.spec.ts
@@ -6,7 +6,6 @@ import DefaultsBanner from '@kubewarden/components/DefaultsBanner';
 import ConsumptionGauge from '@shell/components/ConsumptionGauge';
 
 import DEFAULTS_APP from '@tests/unit/_templates_/defaultsApp';
-import PS_POD from '@tests/unit/_templates_/policyServerPod';
 
 describe('component: DashboardView', () => {
   const commonMocks = {
@@ -30,7 +29,6 @@ describe('component: DashboardView', () => {
     controllerChart:    () => null,
     defaultsApp:        () => DEFAULTS_APP,
     hideBannerDefaults: () => false,
-    policyServerPods:   () => [PS_POD],
     globalPolicies:     () => [],
     namespacedPolicies: () => [],
     version:            () => '1.25',
@@ -134,15 +132,13 @@ describe('component: DashboardView', () => {
     ];
 
     const wrapper = createWrapper({
-      data() {
-        return { psPods: pods };
-      },
-      stubs: { DefaultsBanner: { template: '<span />' } }
+      computed: { policyServerPods: () => pods },
+      stubs:    { DefaultsBanner: { template: '<span />' } }
     });
 
     const gauges = wrapper.findAllComponents(ConsumptionGauge);
 
-    expect(gauges.at(0).props().capacity).toStrictEqual([PS_POD].length as Number);
+    expect(gauges.at(0).props().capacity).toStrictEqual(pods.length as Number);
     expect(gauges.at(0).props().used).toStrictEqual(1 as Number);
   });
 


### PR DESCRIPTION
Fix #632 

There is an issue with the `catalog/refresh` store method which causes it to repeatedly load the index of each cluster repository. I've replaced that method with `catalog/load` which will only fetch the index once per repo.

https://github.com/rancher/kubewarden-ui/assets/40806497/f8d73ba2-8861-41d5-a58f-33d59e1f8d44


