### PR TITLE
recreate PR 616 - refactor policy server based on new data structure

### DIFF
--- a/pkg/kubewarden/components/PolicyReporter/ResourceTab.vue
+++ b/pkg/kubewarden/components/PolicyReporter/ResourceTab.vue
@@ -17,6 +17,8 @@ import {
 import { splitGroupKind } from '../../modules/core';
 import * as coreTypes from '../../core/core-resources';
 
+import PolicyReportSummary from '../../formatters/PolicyReportSummary';
+
 export default {
   props: {
     resource: {
@@ -26,7 +28,7 @@ export default {
   },
 
   components: {
-    BadgeState, Banner, Loading, SortableTable
+    BadgeState, Banner, Loading, SortableTable, PolicyReportSummary
   },
 
   mixins: [ResourceFetch],
@@ -34,11 +36,7 @@ export default {
   async fetch() {
     const fetchedReports = await getFilteredReports(this.$store, this.resource);
 
-    if ( this.isNamespaceResource ) {
-      this.reports = fetchedReports?.results || [];
-    } else {
-      this.reports = fetchedReports || [];
-    }
+    this.reports = fetchedReports || [];
 
     if ( !isEmpty(this.reports) ) {
       const hash = [
@@ -53,15 +51,10 @@ export default {
   data() {
     return {
       colorForResult,
-      headers:      POLICY_REPORTER_HEADERS,
-      reports:      null
+      reports:          [],
+      resourceHeaders:  POLICY_REPORTER_HEADERS.RESOURCE,
+      namespaceHeaders: POLICY_REPORTER_HEADERS.NAMESPACE
     };
-  },
-
-  created() {
-    if ( !this.isNamespaceResource ) {
-      this.headers = this.headers.slice(2);
-    }
   },
 
   computed: {
@@ -80,6 +73,10 @@ export default {
       return this.resource?.metadata?.namespace;
     },
 
+    hasReports() {
+      return !isEmpty(this.reports);
+    },
+
     isNamespaceResource() {
       return this.resource?.type === NAMESPACE;
     }
@@ -87,7 +84,7 @@ export default {
 
   methods: {
     canGetResourceLink(row) {
-      const resource = row?.resources[0];
+      const resource = row.scope;
 
       if ( resource ) {
         const isCore = Object.values(coreTypes).find(type => resource.kind === type.attributes.kind);
@@ -106,9 +103,9 @@ export default {
       return null;
     },
 
-    getResourceValue(row, val, needsResource = false) {
-      if ( this.isNamespaceResource && needsResource && !isEmpty(row.resources) ) {
-        return row.resources[0][val] || '-';
+    getResourceValue(row, val, needScope = false) {
+      if ( this.isNamespaceResource && needScope ) {
+        return row.scope?.[val] || '-';
       }
 
       if ( !isEmpty(row) ) {
@@ -151,95 +148,97 @@ export default {
 <template>
   <Loading v-if="$fetchState.pending" mode="relative" />
   <div v-else class="pr-tab__container">
-    <SortableTable
-      v-if="reports"
-      :rows="reports"
-      :headers="headers"
-      :table-actions="false"
-      :row-actions="false"
-      key-field="uid"
-      :sub-expandable="true"
-      :sub-expand-column="true"
-      :sub-rows="true"
-      :paging="true"
-      :rows-per-page="25"
-      :extra-search-fields="['result']"
-      default-sort-by="status"
-    >
-      <!-- Namespace Resource columns -->
-      <template v-if="isNamespaceResource" #col:kind="{row}">
-        <td>{{ getResourceValue(row, 'kind', true) }}</td>
-      </template>
-      <template v-if="isNamespaceResource" #col:name="{row}">
-        <td>
-          <template v-if="canGetResourceLink(row)">
-            <n-link :to="getResourceLink(row)">
+    <template v-if="isNamespaceResource">
+      <SortableTable
+        :rows="reports"
+        :headers="namespaceHeaders"
+        :table-actions="false"
+        :row-actions="false"
+        key-field="uid"
+        :paging="true"
+        :rows-per-page="25"
+        :extra-search-fields="['summary']"
+        default-sort-by="status"
+      >
+        <template #col:kind="{row}">
+          <td>{{ getResourceValue(row, 'kind', true) }}</td>
+        </template>
+        <template #col:name="{row}">
+          <td>
+            <template v-if="canGetResourceLink(row)">
+              <n-link :to="getResourceLink(row)">
+                <span>{{ getResourceValue(row, 'name', true) }}</span>
+              </n-link>
+            </template>
+            <template v-else>
               <span>{{ getResourceValue(row, 'name', true) }}</span>
-            </n-link>
-          </template>
-          <template v-else>
-            <span>{{ getResourceValue(row, 'name', true) }}</span>
-          </template>
-        </td>
-      </template>
+            </template>
+          </td>
+        </template>
 
-      <template #col:policy="{row}">
-        <td v-if="row.policy && row.rule" :class="{ 'text-bold': isNamespaceResource}">
-          <template v-if="canGetKubewardenLinks">
-            <n-link :to="getPolicyLink(row)">
+        <template #col:summary>
+          <td>
+            <PolicyReportSummary :value="resource" />
+          </td>
+        </template>
+      </SortableTable>
+    </template>
+
+    <template v-else>
+      <SortableTable
+        :rows="reports"
+        :headers="resourceHeaders"
+        :table-actions="false"
+        :row-actions="false"
+        key-field="uid"
+        :sub-expandable="true"
+        :sub-expand-column="true"
+        :sub-rows="true"
+        :paging="true"
+        :rows-per-page="25"
+        :extra-search-fields="['result']"
+        default-sort-by="status"
+      >
+        <template #col:policy="{row}">
+          <td v-if="row.policy && row.rule">
+            <template v-if="canGetKubewardenLinks">
+              <n-link :to="getPolicyLink(row)">
+                <span>{{ row.rule }}</span>
+              </n-link>
+            </template>
+            <template v-else>
               <span>{{ row.rule }}</span>
-            </n-link>
-          </template>
-          <template v-else>
-            <span>{{ row.rule }}</span>
-          </template>
-        </td>
-      </template>
-      <template #col:severity="{row}">
-        <td>
-          <BadgeState
-            :label="getResourceValue(row, 'severity')"
-            :color="severityColor(row)"
-          />
-        </td>
-      </template>
-      <template #col:status="{row}">
-        <td>
-          <BadgeState
-            :label="getResourceValue(row, 'result')"
-            :color="statusColor(row)"
-          />
-        </td>
-      </template>
+            </template>
+          </td>
+        </template>
+        <template #col:severity="{row}">
+          <td>
+            <BadgeState
+              :label="getResourceValue(row, 'severity')"
+              :color="severityColor(row)"
+            />
+          </td>
+        </template>
+        <template #col:status="{row}">
+          <td>
+            <BadgeState
+              :label="getResourceValue(row, 'result')"
+              :color="statusColor(row)"
+            />
+          </td>
+        </template>
 
-      <!-- Sub-rows -->
-      <template #sub-row="{row, fullColspan}">
-        <td :colspan="fullColspan" class="pr-tab__sub-row">
-          <Banner v-if="row.message" color="info" class="message">
-            <span class="text-muted">{{ t('kubewarden.policyReporter.headers.policyReportsTab.message.title') }}:</span>
-            <span>{{ row.message }}</span>
-          </Banner>
-          <div class="details">
-            <section class="col">
-              <div class="title">
-                {{ t('kubewarden.policyReporter.headers.policyReportsTab.properties.mutating') }}
-              </div>
-              <span>
-                {{ row.properties['mutating'] || '-' }}
-              </span>
-            </section>
-            <section class="col">
-              <div class="title">
-                {{ t('kubewarden.policyReporter.headers.policyReportsTab.properties.validating') }}
-              </div>
-              <span>
-                {{ row.properties['validating'] || '-' }}
-              </span>
-            </section>
-          </div>
-        </td>
-      </template>
-    </SortableTable>
+        <!-- Sub-rows -->
+        <template #sub-row="{row, fullColspan}">
+          <td :colspan="fullColspan" class="pr-tab__sub-row">
+            <Banner v-if="row.message" color="info" class="message">
+              <span class="text-muted">{{ t('kubewarden.policyReporter.headers.policyReportsTab.message.title') }}:</span>
+              <span>{{ row.message }}</span>
+            </Banner>
+          </td>
+        </template>
+      </SortableTable>
+    </template>
   </div>
 </template>
 

--- a/pkg/kubewarden/components/PolicyReporter/ResourceTab.vue
+++ b/pkg/kubewarden/components/PolicyReporter/ResourceTab.vue
@@ -188,14 +188,14 @@ export default {
         </template>
 
         <template #col:policy="{row}">
-          <td v-if="row.policy && row.rule">
+          <td v-if="row.policy && row.policyName">
             <template v-if="canGetKubewardenLinks">
               <n-link :to="getPolicyLink(row)">
-                <span>{{ row.rule }}</span>
+                <span>{{ row.policyName }}</span>
               </n-link>
             </template>
             <template v-else>
-              <span>{{ row.rule }}</span>
+              <span>{{ row.policyName }}</span>
             </template>
           </td>
         </template>
@@ -218,14 +218,29 @@ export default {
 
         <!-- Sub-rows -->
         <template #sub-row="{row, fullColspan}">
-          <td
-            :colspan="fullColspan"
-            class="pr-tab__sub-row"
-          >
+          <td :colspan="fullColspan" class="pr-tab__sub-row">
             <Banner v-if="row.message" color="info" class="message">
               <span class="text-muted">{{ t('kubewarden.policyReporter.headers.policyReportsTab.message.title') }}:</span>
               <span>{{ row.message }}</span>
             </Banner>
+            <div class="details">
+              <section class="col">
+                <div class="title">
+                  {{ t('kubewarden.policyReporter.headers.policyReportsTab.properties.mutating') }}
+                </div>
+                <span>
+                  {{ row.properties['mutating'] || '-' }}
+                </span>
+              </section>
+              <section class="col">
+                <div class="title">
+                  {{ t('kubewarden.policyReporter.headers.policyReportsTab.properties.validating') }}
+                </div>
+                <span>
+                  {{ row.properties['validating'] || '-' }}
+                </span>
+              </section>
+            </div>
           </td>
         </template>
       </SortableTable>

--- a/pkg/kubewarden/components/PolicyReporter/index.vue
+++ b/pkg/kubewarden/components/PolicyReporter/index.vue
@@ -13,7 +13,7 @@ import { Banner } from '@components/Banner';
 
 import { handleGrowl } from '../../utils/handle-growl';
 import { rootKubewardenRoute } from '../../utils/custom-routing';
-import { KUBEWARDEN, KUBEWARDEN_APPS, KUBEWARDEN_CHARTS } from '../../types';
+import { KUBEWARDEN, KUBEWARDEN_APPS, KUBEWARDEN_CHARTS, WG_POLICY_K8S } from '../../types';
 
 export default {
   components: { Banner, Loading },
@@ -61,11 +61,11 @@ export default {
     },
 
     hasClusterPolicyReportSchema() {
-      return this.$store.getters['cluster/schemaFor'](KUBEWARDEN.CLUSTER_POLICY_REPORT);
+      return this.$store.getters['cluster/schemaFor'](WG_POLICY_K8S.CLUSTER_POLICY_REPORT.TYPE);
     },
 
     hasPolicyReportSchema() {
-      return this.$store.getters['cluster/schemaFor'](KUBEWARDEN.POLICY_REPORT);
+      return this.$store.getters['cluster/schemaFor'](WG_POLICY_K8S.POLICY_REPORT.TYPE);
     },
 
     reporterCrds() {

--- a/pkg/kubewarden/config/kubewarden.ts
+++ b/pkg/kubewarden/config/kubewarden.ts
@@ -1,5 +1,7 @@
 import { rootKubewardenRoute } from '../utils/custom-routing';
-import { KUBEWARDEN, KUBEWARDEN_DASHBOARD, POLICY_REPORTER_PRODUCT, KUBEWARDEN_PRODUCT_NAME } from '../types';
+import {
+  KUBEWARDEN, KUBEWARDEN_DASHBOARD, POLICY_REPORTER_PRODUCT, KUBEWARDEN_PRODUCT_NAME, WG_POLICY_K8S
+} from '../types';
 import { POLICY_SERVER_HEADERS, POLICY_HEADERS } from './table-headers';
 
 export function init($plugin: any, store: any) {
@@ -38,7 +40,7 @@ export function init($plugin: any, store: any) {
   virtualType({
     label:      store.getters['i18n/t']('kubewarden.policyReporter.title'),
     icon:       'notifier',
-    ifHaveType: KUBEWARDEN.POLICY_REPORT,
+    ifHaveType: WG_POLICY_K8S.POLICY_REPORT.TYPE,
     name:       POLICY_REPORTER_PRODUCT,
     namespaced: false,
     weight:     95,

--- a/pkg/kubewarden/config/table-headers.ts
+++ b/pkg/kubewarden/config/table-headers.ts
@@ -284,10 +284,22 @@ export const POLICY_REPORTER_HEADERS = {
       sort:     'name'
     },
     {
-      name:     'summary',
-      labelKey: 'kubewarden.policyReporter.headers.policyReportsTab.summary.label',
-      value:    'summary',
-      sort:     'summary'
+      name:     'policy',
+      labelKey: 'kubewarden.policyReporter.headers.policyReportsTab.policy.label',
+      value:    'policy',
+      sort:     'policy'
     },
+    {
+      name:     'severity',
+      labelKey: 'kubewarden.policyReporter.headers.policyReportsTab.severity.label',
+      value:    'severity',
+      sort:     'severity'
+    },
+    {
+      name:     'status',
+      labelKey: 'kubewarden.policyReporter.headers.policyReportsTab.status.label',
+      value:    'status',
+      sort:     'result'
+    }
   ]
 };

--- a/pkg/kubewarden/config/table-headers.ts
+++ b/pkg/kubewarden/config/table-headers.ts
@@ -249,35 +249,45 @@ export const RULE_HEADERS = [
   },
 ];
 
-export const POLICY_REPORTER_HEADERS = [
-  {
-    name:     'kind',
-    labelKey: 'tableHeaders.subType',
-    value:    'kind',
-    sort:     'kind'
-  },
-  {
-    name:     'name',
-    labelKey: 'tableHeaders.name',
-    value:    'name',
-    sort:     'name'
-  },
-  {
-    name:     'policy',
-    labelKey: 'kubewarden.policyReporter.headers.policyReportsTab.policy.label',
-    value:    'policy',
-    sort:     'policy'
-  },
-  {
-    name:     'severity',
-    labelKey: 'kubewarden.policyReporter.headers.policyReportsTab.severity.label',
-    value:    'severity',
-    sort:     'severity'
-  },
-  {
-    name:     'status',
-    labelKey: 'kubewarden.policyReporter.headers.policyReportsTab.status.label',
-    value:    'status',
-    sort:     'result'
-  },
-];
+export const POLICY_REPORTER_HEADERS = {
+  RESOURCE: [
+    {
+      name:     'policy',
+      labelKey: 'kubewarden.policyReporter.headers.policyReportsTab.policy.label',
+      value:    'policy',
+      sort:     'policy'
+    },
+    {
+      name:     'severity',
+      labelKey: 'kubewarden.policyReporter.headers.policyReportsTab.severity.label',
+      value:    'severity',
+      sort:     'severity'
+    },
+    {
+      name:     'status',
+      labelKey: 'kubewarden.policyReporter.headers.policyReportsTab.status.label',
+      value:    'status',
+      sort:     'result'
+    },
+  ],
+  NAMESPACE: [
+    {
+      name:     'kind',
+      labelKey: 'tableHeaders.subType',
+      value:    'kind',
+      sort:     'kind'
+    },
+    {
+      name:     'name',
+      labelKey: 'tableHeaders.name',
+      value:    'name',
+      sort:     'name'
+    },
+    {
+      name:     'summary',
+      labelKey: 'kubewarden.policyReporter.headers.policyReportsTab.summary.label',
+      value:    'summary',
+      sort:     'summary'
+    },
+  ]
+};

--- a/pkg/kubewarden/formatters/PolicyReportSummary.vue
+++ b/pkg/kubewarden/formatters/PolicyReportSummary.vue
@@ -93,7 +93,7 @@ export default {
         }
       }
 
-      return this.filteredReports;
+      return getFilteredSummary(this.$store, this.value);
     }
   },
 

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -418,6 +418,8 @@ kubewarden:
           label: Severity
         status:
           label: Status
+        summary:
+          label: Summary
         message:
           title: Message
         properties:

--- a/pkg/kubewarden/modules/policyReporter.ts
+++ b/pkg/kubewarden/modules/policyReporter.ts
@@ -122,7 +122,6 @@ export async function getFilteredReports(store: any, resource: any): Promise<Pol
                 outResults.push({
                   ...result,
                   scope:      report.scope,
-                  namespace:  report.metadata?.namespace,
                   policyName: result.properties?.['policy-name'],
                 });
               });
@@ -133,7 +132,6 @@ export async function getFilteredReports(store: any, resource: any): Promise<Pol
                 report.results?.forEach((result: any) => {
                   outResults.push({
                     ...result,
-                    namespace:  report.metadata?.namespace,
                     policyName: result.properties?.['policy-name'],
                   });
                 });
@@ -167,20 +165,13 @@ export function getLinkForPolicy(store: any, report: PolicyReportResult): Object
   if ( report?.policy ) {
     const apSchema = store.getters['cluster/schemaFor'](KUBEWARDEN.ADMISSION_POLICY);
     const capSchema = store.getters['cluster/schemaFor'](KUBEWARDEN.CLUSTER_ADMISSION_POLICY);
-
-    let policyType: string = '';
-
-    const policyParts: string[] = report.policy?.split('-');
-
-    if (policyParts?.length >= 2 ) {
-      policyType = policyParts[0] === 'clusterwide' ? KUBEWARDEN.CLUSTER_ADMISSION_POLICY : KUBEWARDEN.ADMISSION_POLICY;
-    }
+    const policyType: string = report.properties?.['policy-namespace'] ? KUBEWARDEN.ADMISSION_POLICY : KUBEWARDEN.CLUSTER_ADMISSION_POLICY;
 
     if ( policyType === KUBEWARDEN.ADMISSION_POLICY && apSchema ) {
       return createKubewardenRoute({
         name:   'c-cluster-product-resource-namespace-id',
         params: {
-          resource: policyType, id: report?.policyName, namespace: report.namespace
+          resource: policyType, id: report?.policyName, namespace: report.properties?.['policy-namespace']
         }
       });
     }

--- a/pkg/kubewarden/modules/policyReporter.ts
+++ b/pkg/kubewarden/modules/policyReporter.ts
@@ -58,7 +58,7 @@ export function getFilteredSummary(store: any, resource: any): PolicyReportSumma
       // Find the report that is scoped to the resource name
       if ( Array.isArray(reports) && reports.length ) {
         reports.forEach((report: any) => {
-          if ( report.metadata?.labels?.['app.kubernetes.io/managed-by'] === 'kubewarden' && report.metadata?.name === resource.metadata?.uid ) {
+          if ( report.metadata?.labels?.['app.kubernetes.io/managed-by'] === 'kubewarden' && report.scope?.uid === resource.metadata?.uid ) {
             filtered = report.results;
           }
         });

--- a/pkg/kubewarden/modules/policyReporter.ts
+++ b/pkg/kubewarden/modules/policyReporter.ts
@@ -37,10 +37,7 @@ export async function getPolicyReports(store: any): Promise<PolicyReport[] | voi
  * @returns `PolicyReport[] | void`
  */
 export async function fetchPolicyReports(store: any): Promise<Array<PolicyReport>> {
-  return await store.dispatch('cluster/findMatching', {
-    type:     WG_POLICY_K8S.POLICY_REPORT.TYPE,
-    selector: 'app.kubernetes.io/managed-by=kubewarden'
-  }, { root: true });
+  return await store.dispatch('cluster/findAll', { type: WG_POLICY_K8S.POLICY_REPORT.TYPE }, { root: true });
 }
 
 /**
@@ -61,7 +58,7 @@ export function getFilteredSummary(store: any, resource: any): PolicyReportSumma
       // Find the report that is scoped to the resource name
       if ( Array.isArray(reports) && reports.length ) {
         reports.forEach((report: any) => {
-          if ( report.scope?.name === resource.metadata.name ) {
+          if ( report.metadata?.labels?.['app.kubernetes.io/managed-by'] === 'kubewarden' && report.metadata?.name === resource.metadata?.uid ) {
             filtered = report.results;
           }
         });

--- a/pkg/kubewarden/modules/policyReporter.ts
+++ b/pkg/kubewarden/modules/policyReporter.ts
@@ -98,29 +98,37 @@ export async function getFilteredReports(store: any, resource: any): Promise<Pol
 
   if ( schema ) {
     try {
-      const reports = await getPolicyReports(store);
+      const reports:any = await getPolicyReports(store);
 
       if ( !isEmpty(reports) ) {
+        let outReports: PolicyReport[] = [];
+
         // If the resource is of type `namespace`, return the all reports for the ns
         if ( resource?.type === 'namespace' ) {
-          let outReports: PolicyReport[] = [];
-
           if ( Array.isArray(reports) ) {
             outReports = reports.filter((report: PolicyReport) => report.scope?.namespace === resource?.name);
           }
-
-          return outReports;
+        } else {
+          outReports = reports;
         }
 
         let outResults: PolicyReportResult[] = [];
 
         // Find the report that is scoped to the resource name
-        if ( Array.isArray(reports) ) {
-          reports.forEach((report: any) => {
-            if ( report.scope?.name === resource.metadata.name ) {
-              outResults = report.results;
-            }
-          });
+        if ( Array.isArray(outReports) ) {
+          if ( resource?.type === 'namespace' ) {
+            outReports.forEach((report: any) => {
+              report.results?.forEach((result: any) => {
+                outResults.push({ ...result, scope: report.scope });
+              });
+            });
+          } else {
+            outReports.forEach((report: any) => {
+              if ( report.scope?.name === resource.metadata.name ) {
+                outResults = report.results;
+              }
+            });
+          }
 
           if ( !isEmpty(outResults) ) {
             // Assign uid for SortableTable sub-row

--- a/pkg/kubewarden/modules/policyReporter.ts
+++ b/pkg/kubewarden/modules/policyReporter.ts
@@ -2,7 +2,7 @@ import isEmpty from 'lodash/isEmpty';
 import semver from 'semver';
 import { randomStr } from '@shell/utils/string';
 import {
-  KUBEWARDEN, Resource, Severity, Result, PolicyReport, PolicyReportResult, PolicyReportSummary
+  KUBEWARDEN, Severity, Result, PolicyReport, PolicyReportResult, PolicyReportSummary, WG_POLICY_K8S
 } from '../types';
 import * as coreTypes from '../core/core-resources';
 import { createKubewardenRoute } from '../utils/custom-routing';
@@ -14,7 +14,7 @@ import { splitGroupKind } from './core';
  * @returns `PolicyReport[] | void` - Scaffolded value of a PolicyReport accomplished by scaffoldPolicyReport()
  */
 export async function getPolicyReports(store: any): Promise<PolicyReport[] | void> {
-  const schema = store.getters['cluster/schemaFor'](KUBEWARDEN.POLICY_REPORT);
+  const schema = store.getters['cluster/schemaFor'](WG_POLICY_K8S.POLICY_REPORT.TYPE);
 
   if ( schema ) {
     try {
@@ -37,11 +37,14 @@ export async function getPolicyReports(store: any): Promise<PolicyReport[] | voi
  * @returns `PolicyReport[] | void`
  */
 export async function fetchPolicyReports(store: any): Promise<Array<PolicyReport>> {
-  return await store.dispatch('cluster/findAll', { type: KUBEWARDEN.POLICY_REPORT }, { root: true });
+  return await store.dispatch('cluster/findMatching', {
+    type:     WG_POLICY_K8S.POLICY_REPORT.TYPE,
+    selector: 'app.kubernetes.io/managed-by=kubewarden'
+  }, { root: true });
 }
 
 /**
- * Filters PolicyReports to return a summary of the results per namespace
+ * Filters PolicyReports to return a summary of the report determined by the scope.
  * @param store
  * @param resource
  * @returns `PolicyReportSummary | null | void`
@@ -53,58 +56,35 @@ export function getFilteredSummary(store: any, resource: any): PolicyReportSumma
     const reports = store.getters['kubewarden/policyReports'];
 
     if ( !isEmpty(reports) ) {
-      const hasNamespace = resource?.metadata?.namespace;
+      let filtered: PolicyReportResult[] | undefined;
 
-      if ( hasNamespace ) {
-        let filtered: PolicyReportResult[] | undefined;
+      // Find the report that is scoped to the resource name
+      if ( Array.isArray(reports) && reports.length ) {
+        reports.forEach((report: any) => {
+          if ( report.scope?.name === resource.metadata.name ) {
+            filtered = report.results;
+          }
+        });
+      }
 
-        // Find the report that is scoped to the resource namespace
-        if ( Array.isArray(reports) ) {
-          reports.forEach((report: any) => {
-            if ( report.scope?.name === resource.metadata.namespace ) {
-              const filteredResult = report.results?.filter((result: PolicyReportResult) => {
-                const filteredResource = result?.resources?.find((r: Resource) => {
-                  const { kind, name, namespace } = r;
+      if ( !isEmpty(filtered) ) {
+        const out: PolicyReportSummary = {
+          pass:  0,
+          fail:  0,
+          warn:  0,
+          error: 0,
+          skip:  0
+        };
 
-                  if ( kind === resource.kind && name === resource.metadata.name && namespace === resource.metadata.namespace ) {
-                    return r;
-                  }
-                });
+        filtered?.forEach((r: PolicyReportResult) => {
+          const resultVal = r.result;
 
-                if ( !isEmpty(filteredResource) ) {
-                  // Assign uid for SortableTable sub-row
-                  Object.assign(result, { uid: randomStr() });
+          if ( resultVal ) {
+            (out as any)[resultVal]++;
+          }
+        });
 
-                  return result;
-                }
-              });
-
-              if ( !isEmpty(filteredResult) ) {
-                filtered = filteredResult;
-              }
-            }
-          });
-        }
-
-        if ( !isEmpty(filtered) ) {
-          const out: PolicyReportSummary = {
-            pass:  0,
-            fail:  0,
-            warn:  0,
-            error: 0,
-            skip:  0
-          };
-
-          filtered?.forEach((r: PolicyReportResult) => {
-            const resultVal = r.result;
-
-            if ( resultVal ) {
-              (out as any)[resultVal]++;
-            }
-          });
-
-          return out;
-        }
+        return out;
       }
     }
   }
@@ -116,66 +96,43 @@ export function getFilteredSummary(store: any, resource: any): PolicyReportSumma
  * @param resource
  * @returns `PolicyReport | PolicyReportResult[] | null | void`
  */
-export async function getFilteredReports(store: any, resource: any): Promise<PolicyReport | PolicyReportResult[] | null | void> {
-  const schema = store.getters['cluster/schemaFor'](resource.type);
+export async function getFilteredReports(store: any, resource: any): Promise<PolicyReport[] | PolicyReportResult[] | null | void> {
+  const schema = store.getters['cluster/schemaFor'](resource?.type);
 
   if ( schema ) {
     try {
       const reports = await getPolicyReports(store);
 
       if ( !isEmpty(reports) ) {
-        const hasNamespace = resource?.metadata?.namespace;
-
-        // If the resource is a namespace, return the all reports for the ns
+        // If the resource is of type `namespace`, return the all reports for the ns
         if ( resource?.type === 'namespace' ) {
-          let out: PolicyReport | undefined | null = null;
+          let outReports: PolicyReport[] = [];
 
           if ( Array.isArray(reports) ) {
-            out = reports.find((report: PolicyReport) => report.scope?.name === resource?.name);
+            outReports = reports.filter((report: PolicyReport) => report.scope?.namespace === resource?.name);
           }
 
-          if ( !isEmpty(out) ) {
-            // Assign uid for SortableTable sub-row
-            out.results?.forEach((result: any) => {
-              Object.assign(result, { uid: randomStr() });
-            });
-
-            return out;
-          }
+          return outReports;
         }
 
-        if ( hasNamespace ) {
-          let out: PolicyReportResult[] | null = null;
+        let outResults: PolicyReportResult[] = [];
 
-          // Find the report that is scoped to the resource namespace
-          if ( Array.isArray(reports) ) {
-            reports.forEach((report: any) => {
-              if ( report.scope?.name === resource.metadata.namespace ) {
-                const filteredResult = report.results?.filter((result: PolicyReportResult) => {
-                  const filteredResource = result?.resources?.find((r: Resource) => {
-                    const { kind, name, namespace } = r;
+        // Find the report that is scoped to the resource name
+        if ( Array.isArray(reports) ) {
+          reports.forEach((report: any) => {
+            if ( report.scope?.name === resource.metadata.name ) {
+              outResults = report.results;
+            }
+          });
 
-                    if ( kind === resource.kind && name === resource.metadata.name && namespace === resource.metadata.namespace ) {
-                      return r;
-                    }
-                  });
-
-                  if ( !isEmpty(filteredResource) ) {
-                    // Assign uid for SortableTable sub-row
-                    Object.assign(result, { uid: randomStr() });
-
-                    return result;
-                  }
-                });
-
-                if ( !isEmpty(filteredResult) ) {
-                  out = filteredResult;
-                }
-              }
+          if ( !isEmpty(outResults) ) {
+            // Assign uid for SortableTable sub-row
+            outResults?.forEach((report: any) => {
+              Object.assign(report, { uid: randomStr() });
             });
-          }
 
-          return out;
+            return outResults;
+          }
         }
       }
     } catch (e) {
@@ -242,12 +199,12 @@ export function getLinkForPolicy(store: any, report: PolicyReportResult): Object
  * not passed in from the report, it needs to be determined by the `kind` of the resource. For core
  * resources this works as is, but for non-core resources (e.g. `apps.deployments`), this is extrapolated
  * by the `apiVersion` combined with the `kind`.
- * @param report: `PolicyReportResult
+ * @param report: `PolicyReport
  * @returns `Route | void`
  */
-export function getLinkForResource(report: PolicyReportResult): Object | void {
-  if ( !isEmpty(report.resources?.[0]) ) {
-    const resource = report.resources?.[0];
+export function getLinkForResource(report: PolicyReport): Object | void {
+  if ( !isEmpty(report.scope) ) {
+    const resource = report.scope;
 
     if ( resource ) {
       const isCore = Object.values(coreTypes).find(type => resource.kind === type.attributes.kind);

--- a/pkg/kubewarden/types.ts
+++ b/pkg/kubewarden/types.ts
@@ -11,3 +11,4 @@ export * from './types/policy';
 export * from './types/policy-reporter';
 export * from './types/rancher';
 export * from './types/service';
+export * from './types/wgpolicyk8s.io';

--- a/pkg/kubewarden/types/kubewarden.ts
+++ b/pkg/kubewarden/types/kubewarden.ts
@@ -25,18 +25,14 @@ export const KUBEWARDEN_LABELS = { POLICY_SERVER: 'kubewarden/policy-server' };
 export const KUBEWARDEN = {
   ADMISSION_POLICY:         'policies.kubewarden.io.admissionpolicy',
   CLUSTER_ADMISSION_POLICY: 'policies.kubewarden.io.clusteradmissionpolicy',
-  POLICY_SERVER:            'policies.kubewarden.io.policyserver',
-  POLICY_REPORT:            'wgpolicyk8s.io.policyreport',
-  CLUSTER_POLICY_REPORT:    'wgpolicyk8s.io.clusterpolicyreport'
+  POLICY_SERVER:            'policies.kubewarden.io.policyserver'
 };
 
 /* eslint-disable no-unused-vars */
 export enum KUBEWARDEN_CRD {
   ADMISSION_POLICY = 'admissionpolicies.policies.kubewarden.io',
   CLUSTER_ADMISSION_POLICY = 'clusteradmissionpolicies.policies.kubewarden.io',
-  POLICY_SERVER = 'policyservers.policies.kubewarden.io',
-  POLICY_REPORT = 'policyreports.wgpolicyk8s.io',
-  CLUSTER_POLICY_REPORT = 'clusterpolicyreports.wgpolicyk8s.io'
+  POLICY_SERVER = 'policyservers.policies.kubewarden.io'
 }
 /* eslint-enable no-unused-vars */
 

--- a/pkg/kubewarden/types/policy-reporter.ts
+++ b/pkg/kubewarden/types/policy-reporter.ts
@@ -47,7 +47,9 @@ export interface PolicyReportSummary {
 export interface PolicyReportResult {
   category?: string;
   message?: string;
+  namespace?: string;
   policy: string;
+  policyName?: string;
   properties?: {[key: string]: string};
   resourceSelector?: {
     matchExpressions?: {

--- a/pkg/kubewarden/types/policy-reporter.ts
+++ b/pkg/kubewarden/types/policy-reporter.ts
@@ -47,7 +47,6 @@ export interface PolicyReportSummary {
 export interface PolicyReportResult {
   category?: string;
   message?: string;
-  namespace?: string;
   policy: string;
   policyName?: string;
   properties?: {[key: string]: string};

--- a/pkg/kubewarden/types/policy-reporter.ts
+++ b/pkg/kubewarden/types/policy-reporter.ts
@@ -60,6 +60,13 @@ export interface PolicyReportResult {
   resources?: Resource[];
   result?: Result;
   rule?: string;
+  scope?: {
+    apiVersion: string;
+    kind: string;
+    name: string;
+    namespace?: string;
+    uid?: string;
+  },
   scored?: boolean;
   severity?: Severity;
   source?: string;

--- a/pkg/kubewarden/types/policy-reporter.ts
+++ b/pkg/kubewarden/types/policy-reporter.ts
@@ -8,11 +8,13 @@ export const POLICY_REPORTER_CHART = 'policy-reporter';
 
 export const POLICY_REPORTER_REPO = 'https://kyverno.github.io/policy-reporter';
 
-export type Resource = {
+export interface Resource {
   apiVersion: string;
+  fieldPath?: string;
   kind: string;
   name: string;
   namespace?: string;
+  resourceVersion: string;
   uid: string;
 }
 
@@ -34,7 +36,7 @@ export enum Result {
 }
 /* eslint-enable no-unused-vars */
 
-export type PolicyReportSummary = {
+export interface PolicyReportSummary {
   pass?: number;
   fail?: number;
   warn?: number;
@@ -42,23 +44,32 @@ export type PolicyReportSummary = {
   skip?: number;
 }
 
-export type PolicyReportResult = {
-  message: string;
-  policy: string;
-  rule: string;
-  priority?: string;
-  status?: string;
-  source?: string;
-  severity?: string;
+export interface PolicyReportResult {
   category?: string;
+  message?: string;
+  policy: string;
   properties?: {[key: string]: string};
-  scored: boolean;
-  result?: string;
+  resourceSelector?: {
+    matchExpressions?: {
+      key: string;
+      operator: string;
+      values?: string[];
+    };
+    matchLabels?: {[key: string]: string};
+  };
   resources?: Resource[];
-  uid?: string;
+  result?: Result;
+  rule?: string;
+  scored?: boolean;
+  severity?: Severity;
+  source?: string;
+  timestamp?: {
+    nanos: number;
+    seconds: number;
+  }
 }
 
-export type PolicyReport = {
+export interface PolicyReport {
   apiVersion: string;
   id: string;
   kind: string;
@@ -66,7 +77,10 @@ export type PolicyReport = {
   metadata: V1ObjectMeta;
   results?: Array<PolicyReportResult>
   scope?: {
-    name?: string;
+    apiVersion: string;
+    kind: string;
+    name: string;
+    namespace?: string;
     uid?: string;
   }
   summary?: PolicyReportSummary

--- a/pkg/kubewarden/types/wgpolicyk8s.io.ts
+++ b/pkg/kubewarden/types/wgpolicyk8s.io.ts
@@ -1,0 +1,12 @@
+export const WG_POLICY_K8S = {
+  POLICY_REPORT: {
+    KIND: 'PolicyReport',
+    NAME: 'policyreports.wgpolicyk8s.io',
+    TYPE: 'wgpolicyk8s.io.policyreport',
+  },
+  CLUSTER_POLICY_REPORT: {
+    KIND: 'ClusterPolicyReport',
+    NAME: 'clusterpolicyreports.wgpolicyk8s.io',
+    TYPE: 'wgpolicyk8s.io.clusterpolicyreport'
+  }
+};

--- a/tests/unit/_templates_/policyReports.ts
+++ b/tests/unit/_templates_/policyReports.ts
@@ -8,7 +8,7 @@ export const mockResource: Resource = {
   name:            'example-pod',
   namespace:       'default',
   resourceVersion: '12345',
-  uid:             'uid123',
+  metadata:        { uid: 'mock-pod-uid' }
 };
 
 export const mockPolicyReportResult: PolicyReportResult = {
@@ -27,7 +27,10 @@ export const mockPolicyReport: PolicyReport = {
   id:         'policyreport-123',
   kind:       'PolicyReport',
   metadata:   {
-    creationTimestamp: '2021-03-19T10:52:00Z', name: 'policyreport-123', namespace: 'default'
+    labels:            { 'app.kubernetes.io/managed-by': 'kubewarden' },
+    creationTimestamp: '2021-03-19T10:52:00Z',
+    name:              'policyreport-123',
+    namespace:         'default',
   },
   results:    [mockPolicyReportResult],
   scope:      {

--- a/tests/unit/_templates_/policyReports.ts
+++ b/tests/unit/_templates_/policyReports.ts
@@ -1,0 +1,48 @@
+import {
+  Resource, PolicyReportResult, PolicyReport, Result, Severity
+} from '@kubewarden/types';
+
+export const mockResource: Resource = {
+  apiVersion:      'v1',
+  kind:            'Pod',
+  name:            'example-pod',
+  namespace:       'default',
+  resourceVersion: '12345',
+  uid:             'uid123',
+};
+
+export const mockPolicyReportResult: PolicyReportResult = {
+  category:  'security',
+  message:   'Pod lacks a security policy',
+  policy:    'require-pod-security-policy',
+  result:    Result.FAIL,
+  severity:  Severity.HIGH,
+  source:    'Kubewarden',
+  timestamp: { nanos: 0, seconds: 1616141520 },
+  resources: [mockResource],
+};
+
+export const mockPolicyReport: PolicyReport = {
+  apiVersion: 'policy.k8s.io/v1beta1',
+  id:         'policyreport-123',
+  kind:       'PolicyReport',
+  metadata:   {
+    creationTimestamp: '2021-03-19T10:52:00Z', name: 'policyreport-123', namespace: 'default'
+  },
+  results:    [mockPolicyReportResult],
+  scope:      {
+    apiVersion: 'v1',
+    kind:       'pod',
+    name:       'mock-pod',
+    uid:        'mock-pod-uid',
+  },
+  summary: {
+    fail:  1,
+    pass:  0,
+    warn:  0,
+    error: 0,
+    skip:  0,
+  },
+  type: 'PolicyReport',
+  uid:  'report-uid-123',
+};

--- a/tests/unit/components/PolicyReporter/ResourceTab.spec.ts
+++ b/tests/unit/components/PolicyReporter/ResourceTab.spec.ts
@@ -1,4 +1,4 @@
-import { createWrapper } from '@tests/unit/utils/wrapper';
+import { createWrapper } from '@tests/unit/_utils_/wrapper';
 
 import ResourceTab from '@kubewarden/components/PolicyReporter/ResourceTab.vue';
 

--- a/tests/unit/components/PolicyReporter/ResourceTab.spec.ts
+++ b/tests/unit/components/PolicyReporter/ResourceTab.spec.ts
@@ -1,0 +1,79 @@
+import { createWrapper } from '@tests/unit/utils/wrapper';
+
+import ResourceTab from '@kubewarden/components/PolicyReporter/ResourceTab.vue';
+
+const commons = {
+  mocks:     {
+    $store: {
+      getters: {
+        currentCluster:               () => ({ id: 'test-cluster' }),
+        'resource-fetch/refreshFlag': () => jest.fn(),
+        'management/byId':            () => jest.fn(),
+        'i18n/t':                     () => jest.fn(),
+        'cluster/schemaFor':          () => jest.fn()
+      },
+    },
+    $fetchState: { pending: false }
+  },
+};
+
+const wrapperFactory = createWrapper(ResourceTab, commons);
+
+describe('ResourceTab.vue', () => {
+  it('computes canGetKubewardenLinks correctly', () => {
+    const wrapper = wrapperFactory({ propsData: { resource: {} } });
+
+    // Example: Assuming canGetKubewardenLinks depends on some Vuex getters being true/false
+    expect(wrapper.vm.canGetKubewardenLinks).toBeTruthy(); // or .toBeFalsy(), based on your logic
+  });
+
+  it('renders reports for namespace resources', async() => {
+    const wrapper = wrapperFactory({ propsData: { resource: { type: 'namespace', metadata: { name: 'default' } } } });
+
+    await wrapper.vm.$nextTick();
+    wrapper.setData({
+      reports: [{
+        uid: '1', kind: 'Pod', name: 'nginx-pod', result: 'fail', severity: 'critical'
+      }]
+    });
+
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('.pr-tab__container').exists()).toBe(true);
+    expect(wrapper.findAll('sortabletable-stub').length).toBe(1);
+    expect(wrapper.vm.isNamespaceResource).toBeTruthy();
+    // Additional checks on rendered content, like table rows, based on your logic
+  });
+
+  it('hasNamespace returns false when namespace is absent', async() => {
+    const wrapper = wrapperFactory({ propsData: { resource: { metadata: {} } } });
+
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.hasNamespace).toBeFalsy();
+  });
+
+  it('hasReports returns true when reports are present', async() => {
+    const wrapper = wrapperFactory({ propsData: { resource: { metadata: {} } } });
+
+    await wrapper.vm.$nextTick();
+    wrapper.setData({
+      reports: [{
+        id: '1', result: 'fail', severity: 'critical'
+      }]
+    });
+
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.hasReports).toBeTruthy();
+  });
+
+  it('hasReports returns false when reports are empty', async() => {
+    const wrapper = wrapperFactory({ propsData: { resource: {} } });
+
+    await wrapper.vm.$nextTick();
+    wrapper.setData({ reports: [] });
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.hasReports).toBeFalsy();
+  });
+});

--- a/tests/unit/modules/policyReporter.spec.ts
+++ b/tests/unit/modules/policyReporter.spec.ts
@@ -37,7 +37,7 @@ describe('getPolicyReports', () => {
 
 describe('getFilteredSummary', () => {
   it('should correctly summarize policy report results', () => {
-    const resource = { type: 'pod', metadata: { name: 'mock-pod' } };
+    const resource = { type: 'pod', metadata: { name: 'mock-pod', uid: 'mock-pod-uid' } };
     const summary = policyReporterModule.getFilteredSummary(mockStore, resource);
 
     expect(summary).toEqual({

--- a/tests/unit/modules/policyReporter.spec.ts
+++ b/tests/unit/modules/policyReporter.spec.ts
@@ -2,7 +2,7 @@ import * as policyReporterModule from '@kubewarden/modules/policyReporter.ts';
 import { KUBEWARDEN } from '@kubewarden/types';
 import { mockPolicyReport } from '../_templates_/policyReports';
 
-// Mocking lodash's isEmpty function
+// Mocking lodash's isEmpty function//
 jest.mock('lodash/isEmpty', () => ({
   __esModule: true,
   default:    jest.fn().mockImplementation(data => data.length === 0),
@@ -65,13 +65,15 @@ describe('getLinkForPolicy', () => {
     });
 
     const report2 = {
-      policy: 'namespaced-something-example-policy', policyName: 'example-policy', namespace: 'something'
+      policy: 'namespaced-something-example-policy', policyName: 'example-policy', properties: { 'policy-namespace': 'something' }
     };
     const route2 = policyReporterModule.getLinkForPolicy(mockStore, report2);
 
     expect(route2).toMatchObject({
       name:   expect.any(String),
-      params: expect.objectContaining({ id: 'example-policy', resource: 'policies.kubewarden.io.admissionpolicy' })
+      params: expect.objectContaining({
+        id: 'example-policy', resource: 'policies.kubewarden.io.admissionpolicy', namespace: 'something'
+      })
     });
   });
 });

--- a/tests/unit/modules/policyReporter.spec.ts
+++ b/tests/unit/modules/policyReporter.spec.ts
@@ -1,0 +1,67 @@
+import * as policyReporterModule from '@kubewarden/modules/policyReporter.ts';
+import { KUBEWARDEN } from '@kubewarden/types';
+import { mockPolicyReport } from '../_templates_/policyReports';
+
+// Mocking lodash's isEmpty function
+jest.mock('lodash/isEmpty', () => ({
+  __esModule: true,
+  default:    jest.fn().mockImplementation(data => data.length === 0),
+}));
+
+// Mocking @shell/utils/string randomStr function
+jest.mock('@shell/utils/string', () => ({ randomStr: jest.fn().mockReturnValue('randomString') }));
+
+const mockStore = {
+  getters: {
+    'cluster/schemaFor':        jest.fn(),
+    'kubewarden/policyReports': [mockPolicyReport],
+  },
+  dispatch: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockStore.getters['cluster/schemaFor'].mockReturnValue(true);
+});
+
+describe('getPolicyReports', () => {
+  it('should fetch policy reports and update the store', async() => {
+    mockStore.dispatch.mockResolvedValue([mockPolicyReport]); // Simulate fetching policy reports successfully
+
+    const reports = await policyReporterModule.getPolicyReports(mockStore);
+
+    expect(reports).toEqual([mockPolicyReport]);
+    expect(mockStore.dispatch).toHaveBeenCalledWith('kubewarden/updatePolicyReports', mockPolicyReport);
+  });
+});
+
+describe('getFilteredSummary', () => {
+  it('should correctly summarize policy report results', () => {
+    const resource = { type: 'pod', metadata: { name: 'mock-pod' } };
+    const summary = policyReporterModule.getFilteredSummary(mockStore, resource);
+
+    expect(summary).toEqual({
+      pass:  0,
+      fail:  1,
+      warn:  0,
+      error: 0,
+      skip:  0,
+    });
+  });
+});
+
+describe('getLinkForPolicy', () => {
+  it('should return a route for a given policy report result', () => {
+    mockStore.getters['cluster/schemaFor'].mockImplementation((type) => {
+      return type === KUBEWARDEN.CLUSTER_ADMISSION_POLICY || type === KUBEWARDEN.ADMISSION_POLICY;
+    });
+
+    const report = { policy: 'cap-example-policy' };
+    const route = policyReporterModule.getLinkForPolicy(mockStore, report);
+
+    expect(route).toMatchObject({
+      name:   expect.any(String),
+      params: expect.objectContaining({ id: 'example-policy' })
+    });
+  });
+});

--- a/tests/unit/modules/policyReporter.spec.ts
+++ b/tests/unit/modules/policyReporter.spec.ts
@@ -56,12 +56,22 @@ describe('getLinkForPolicy', () => {
       return type === KUBEWARDEN.CLUSTER_ADMISSION_POLICY || type === KUBEWARDEN.ADMISSION_POLICY;
     });
 
-    const report = { policy: 'cap-example-policy' };
-    const route = policyReporterModule.getLinkForPolicy(mockStore, report);
+    const report1 = { policy: 'clusterwide-example-policy', policyName: 'example-policy' };
+    const route1 = policyReporterModule.getLinkForPolicy(mockStore, report1);
 
-    expect(route).toMatchObject({
+    expect(route1).toMatchObject({
       name:   expect.any(String),
-      params: expect.objectContaining({ id: 'example-policy' })
+      params: expect.objectContaining({ id: 'example-policy', resource: 'policies.kubewarden.io.clusteradmissionpolicy' })
+    });
+
+    const report2 = {
+      policy: 'namespaced-something-example-policy', policyName: 'example-policy', namespace: 'something'
+    };
+    const route2 = policyReporterModule.getLinkForPolicy(mockStore, report2);
+
+    expect(route2).toMatchObject({
+      name:   expect.any(String),
+      params: expect.objectContaining({ id: 'example-policy', resource: 'policies.kubewarden.io.admissionpolicy' })
     });
   });
 });


### PR DESCRIPTION
Recreation of PR https://github.com/rancher/kubewarden-ui/pull/616
Fix #609 

This restructures the policy reports for the PolicySummary column and PolicyReportsTab to match the new schema.