### PR TITLE
fix issue with banners

### DIFF
--- a/pkg/kubewarden/components/Dashboard/DashboardView.vue
+++ b/pkg/kubewarden/components/Dashboard/DashboardView.vue
@@ -239,7 +239,7 @@ export default {
     kubewardenExtension() {
       const extensionsInstalled = this.$store.getters['uiplugins/plugins'] || [];
 
-      return extensionsInstalled.find(ext => ext.id === KUBEWARDEN_PRODUCT_NAME);
+      return extensionsInstalled.find(ext => ext.id.includes(KUBEWARDEN_PRODUCT_NAME));
     },
 
     policyReportsCompatible() {


### PR DESCRIPTION
fix issue with banners

the `id` field doesn't yeld `kubewarden` but will be something like `kubewarden-1.3.6`. I'll just check for the existance of `kubewarden` on the string