### PR TITLE
fix: remove Rancher version from extension description

### DIFF
--- a/pkg/kubewarden/README.md
+++ b/pkg/kubewarden/README.md
@@ -1,6 +1,6 @@
 # Kubewarden Extension for Rancher Manager
 
-An extension for Rancher Manager (v2.7.0) which allows you to interact with Kubewarden.
+An extension for Rancher Manager which allows you to interact with Kubewarden.
 
 After installation, go to a cluster and you will see a new side navigation entry 'Kubewarden'. This will allow you to install Kubewarden into the cluster and manage Kubewarden resources and configuration.
 


### PR DESCRIPTION
feel free to close if not appropriate

I noticed from a fresh Rancher 2.8.2 installation that the extension mention Rancher 2.7.0

![image](https://github.com/rancher/kubewarden-ui/assets/2360224/b5a2e393-76e8-43a1-ba6d-84abc9237dcd)

I am assuming that if the user can see the extension then it means it's compatible with its Rancher version
