### PR TITLE
Fix missing semver package

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -7,8 +7,10 @@
     "@playwright/test": "^1.41.2",
     "@types/js-yaml": "^4.0.5",
     "@types/lodash": "^4.14.201",
+    "@types/semver": "^7.5.8",
     "js-yaml": "^4.1.0",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "semver": "^7.6.0"
   },
   "scripts": {}
 }

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -19,6 +19,11 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.201.tgz#76f47cb63124e806824b6c18463daf3e1d480239"
   integrity sha512-y9euML0cim1JrykNxADLfaG0FgD1g/yTHwUs/Jg9ZIU7WKj2/4IW9Lbb1WZbvck78W/lfGXFfe+u2EGfIJXdLQ==
 
+"@types/semver@^7.5.8":
+  version "7.5.8"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.8.tgz#8268a8c57a3e4abd25c165ecd36237db7948a55e"
+  integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
+
 argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
@@ -41,6 +46,13 @@ lodash@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 playwright-core@1.41.2:
   version "1.41.2"
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.41.2.tgz#db22372c708926c697acc261f0ef8406606802d9"
@@ -54,3 +66,15 @@ playwright@1.41.2:
     playwright-core "1.41.2"
   optionalDependencies:
     fsevents "2.3.2"
+
+semver@^7.6.0:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
+  integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
+  dependencies:
+    lru-cache "^6.0.0"
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==


### PR DESCRIPTION
Fix missing package: https://github.com/rancher/kubewarden-ui/actions/runs/8275356367/job/22642173560
```
Error: Cannot find module 'semver'
Require stack:
- /home/opensuse/actions-runner/_work/kubewarden-ui/kubewarden-ui/tests/e2e/30-policyservers.spec.ts
- /home/opensuse/actions-runner/_work/kubewarden-ui/kubewarden-ui/tests/node_modules/playwright/lib/transform/transform.js
- /home/opensuse/actions-runner/_work/kubewarden-ui/kubewarden-ui/tests/node_modules/playwright/lib/common/config.js
- /home/opensuse/actions-runner/_work/kubewarden-ui/kubewarden-ui/tests/node_modules/playwright/lib/reporters/json.js
- /home/opensuse/actions-runner/_work/kubewarden-ui/kubewarden-ui/tests/node_modules/playwright/lib/reporters/html.js
- /home/opensuse/actions-runner/_work/kubewarden-ui/kubewarden-ui/tests/node_modules/playwright/lib/runner/reporters.js
- /home/opensuse/actions-runner/_work/kubewarden-ui/kubewarden-ui/tests/node_modules/playwright/lib/runner/runner.js
- /home/opensuse/actions-runner/_work/kubewarden-ui/kubewarden-ui/tests/node_modules/playwright/lib/cli.js
- /home/opensuse/actions-runner/_work/kubewarden-ui/kubewarden-ui/tests/node_modules/playwright/cli.js
- /home/opensuse/actions-runner/_work/kubewarden-ui/kubewarden-ui/tests/node_modules/@playwright/test/cli.js

   at 30-policyservers.spec.ts:1

> 1 | import semver from 'semver'
```