### PR TITLE
fix issue with semver assertion for banners

### DIFF
--- a/pkg/kubewarden/components/Dashboard/DashboardView.vue
+++ b/pkg/kubewarden/components/Dashboard/DashboardView.vue
@@ -251,7 +251,7 @@ export default {
       }
 
       return {
-        oldSPolicyReports: true,
+        oldPolicyReports: true,
         newPolicyReports:  true
       };
     }
@@ -380,7 +380,7 @@ export default {
       data-testid="kw-dashboard-pr-incompatible-banner-new-policy-structure"
     />
     <Banner
-      v-else-if="controllerApp && kubewardenExtension && !policyReportsCompatible.oldSPolicyReports"
+      v-else-if="controllerApp && kubewardenExtension && !policyReportsCompatible.oldPolicyReports"
       :label="t('kubewarden.dashboard.policyReports.oldPolicyReportsIncompatible', { version: controllerApp.spec?.chart?.metadata?.appVersion }, true)"
       color="warning"
       class="mb-40"

--- a/pkg/kubewarden/modules/policyReporter.ts
+++ b/pkg/kubewarden/modules/policyReporter.ts
@@ -333,20 +333,20 @@ export function colorForSeverity(severity: Severity): string {
 export function newPolicyReportCompatible(controllerAppVersion: string, uiPluginVersion: string): Object | void {
   if (semver.gte(uiPluginVersion, '1.4.0')) {
     return {
-      oldSPolicyReports: semver.gte(controllerAppVersion, '1.11.0'),
+      oldPolicyReports: semver.gt(controllerAppVersion, '1.10.100'),
       newPolicyReports:  true
     };
   }
 
   if (semver.lt(uiPluginVersion, '1.4.0')) {
     return {
-      oldSPolicyReports: true,
-      newPolicyReports:  semver.lte(controllerAppVersion, '1.10.0')
+      oldPolicyReports: true,
+      newPolicyReports:  semver.lte(controllerAppVersion, '1.10.100')
     };
   }
 
   return {
-    oldSPolicyReports: true,
+    oldPolicyReports: true,
     newPolicyReports:  true
   };
 }


### PR DESCRIPTION
- fix issue with semver assertion for banners (rc version is considered lower than the "released" version `v1.11.0-rc1` < `v1.11.0`)
- fix typo in variable name