### PR TITLE
Fix bug Projects/Namespaces show only last policyreport

### DIFF
--- a/pkg/kubewarden/formatters/PolicyReportSummary.vue
+++ b/pkg/kubewarden/formatters/PolicyReportSummary.vue
@@ -2,7 +2,6 @@
 import { mapGetters } from 'vuex';
 import isEmpty from 'lodash/isEmpty';
 import { sortBy } from '@shell/utils/sort';
-import { NAMESPACE } from '@shell/config/query-params';
 
 import { colorForResult, getFilteredSummary } from '../modules/policyReporter';
 
@@ -11,16 +10,6 @@ export default {
     value: {
       type:     Object,
       default:  () => {}
-    }
-  },
-
-  data() {
-    return { expanded: false, filteredReports: null };
-  },
-
-  created() {
-    if ( !this.isNamespaceResource ) {
-      this.filteredReports = getFilteredSummary(this.$store, this.value);
     }
   },
 
@@ -43,8 +32,22 @@ export default {
       return false;
     },
 
-    isNamespaceResource() {
-      return this.value?.type === NAMESPACE;
+    colorParts() {
+      const out = {};
+
+      for ( const p of this.summaryParts ) {
+        out[p.color] = {
+          color: p.color,
+          label: p.label,
+          value: p.value
+        };
+      }
+
+      return sortBy(Object.values(out), 'sort:desc').reverse();
+    },
+
+    summary() {
+      return getFilteredSummary(this.$store, this.value);
     },
 
     summaryParts() {
@@ -69,32 +72,6 @@ export default {
 
       return sortBy(Object.values(out), 'sort:desc').reverse();
     },
-
-    colorParts() {
-      const out = {};
-
-      for ( const p of this.summaryParts ) {
-        out[p.color] = {
-          color: p.color,
-          label: p.label,
-          value: p.value
-        };
-      }
-
-      return sortBy(Object.values(out), 'sort:desc').reverse();
-    },
-
-    summary() {
-      if ( this.isNamespaceResource ) {
-        const connectedReport = this.reports?.find(r => r.metadata?.namespace === this.value?.id);
-
-        if ( connectedReport ) {
-          return connectedReport.summary;
-        }
-      }
-
-      return getFilteredSummary(this.$store, this.value);
-    }
   },
 
   methods: {


### PR DESCRIPTION
Fixes #656 

- fix bug with table col in namespaces showing only aggregates for one policy report result 
- improve formatter code (table col code)
- improve filtering conditions for the policy report results (created a helper function to give the same output for filtering policy report results)


https://github.com/rancher/kubewarden-ui/assets/97888974/cad3dba3-61bc-479e-bc9c-cf991f4f0c22

