### PR TITLE
Official extensions are available on prime only

### DIFF
--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -51,7 +51,7 @@ test('01 Install UI extension', async({ page, ui }) => {
   const extensions = new RancherExtensionsPage(page)
 
   await test.step('Enable extension support', async() => {
-    await extensions.enable(ORIGIN === 'released')
+    await extensions.enable({ rancherRepo: ORIGIN === 'released' ? true : undefined })
     // Wait for default list of extensions
     if (ORIGIN === 'released') {
       await ui.withReload(async() => {
@@ -125,8 +125,7 @@ test('03b Install Kubewarden by Fleet', async({ page, ui }) => {
     branch     : 'main',
     selfHealing: true,
     paths      : ['tests/e2e/fleet/'],
-    workspace  : 'fleet-local',
-    yamlPatch  : (y) => { y.spec.correctDrift.force = true }
+    workspace  : 'fleet-local'
   })
 
   await ui.withReload(async() => {

--- a/tests/e2e/rancher/rancher-extensions.page.ts
+++ b/tests/e2e/rancher/rancher-extensions.page.ts
@@ -18,7 +18,7 @@ export class RancherExtensionsPage extends BasePage {
       await this.tabs.getByRole('tab', { name, exact: true }).click()
     }
 
-    async enable(rancherRepo = true, partnersRepo = true) {
+    async enable(options?: { rancherRepo?: boolean, partnersRepo?: boolean }) {
       await this.goto()
       await expect(this.page.getByRole('heading', { name: 'Extension support is not enabled' })).toBeVisible()
 
@@ -26,11 +26,13 @@ export class RancherExtensionsPage extends BasePage {
       await this.ui.button('Enable').click()
       await expect(this.page.getByRole('heading', { name: 'Enable Extension Support?' })).toBeVisible()
 
-      // Add repositories
-      await this.ui.checkbox('Rancher Extension').setChecked(rancherRepo)
-      // New option in rancher 2.7.7
-      if (await this.ui.checkbox('Partners Extension').isVisible()) {
-        await this.ui.checkbox('Partners Extension').setChecked(partnersRepo)
+      // Available only on Rancher Prime since 2.8.3
+      if (options?.rancherRepo !== undefined) {
+        await this.ui.checkbox('Rancher Extension').setChecked(options.rancherRepo)
+      }
+      // New option in rancher 2.7.7, checked by default
+      if (options?.partnersRepo !== undefined) {
+        await this.ui.checkbox('Partners Extension').setChecked(options.partnersRepo)
       }
 
       // Confirm and wait for extensions to be enabled

--- a/tests/e2e/rancher/rancher-fleet.page.ts
+++ b/tests/e2e/rancher/rancher-fleet.page.ts
@@ -9,7 +9,7 @@ export interface GitRepo {
   branch: string
   selfHealing?: boolean
   keepResources?: boolean
-  paths: string[]
+  paths?: string[]
   yamlPatch?: YAMLPatch
   workspace?: string
 }


### PR DESCRIPTION
- remove `correctDrift` yaml patch that is duplicit to UI option `selfHealing`
- official extensions repository is available only on prime, make parameter optional