### PR TITLE
UI test fixes

### DIFF
--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -20,7 +20,7 @@ const upMap: AppVersion[] = [
   { app: 'v1.8.0', controller: '2.0.0', crds: '1.4.2', defaults: '1.8.0' },
   { app: 'v1.9.0', controller: '2.0.5', crds: '1.4.4' }, // defaults: '1.9.2'
   { app: 'v1.10.0', controller: '2.0.8', crds: '1.4.5' }, // defaults: '1.9.3'
-  // { app: 'v1.11.0', controller: '2.0.9', crds: '1.4.5?' }, // defaults: '1.9.4'
+  { app: 'v1.11.0', controller: '2.0.9', crds: '1.4.6' }, // defaults: '1.9.4'
 ]
 
 test('00 Initial rancher setup', async({ page, ui, nav }) => {
@@ -51,7 +51,7 @@ test('01 Install UI extension', async({ page, ui }) => {
   const extensions = new RancherExtensionsPage(page)
 
   await test.step('Enable extension support', async() => {
-    await extensions.enable({ rancherRepo: ORIGIN === 'released' ? true : undefined })
+    await extensions.enable({ rancherRepo: ORIGIN === 'released' })
     // Wait for default list of extensions
     if (ORIGIN === 'released') {
       await ui.withReload(async() => {
@@ -214,20 +214,6 @@ test('06 Upgrade Kubewarden', async({ page, nav }) => {
     await nav.explorer('Apps', 'Installed Apps')
     await apps.checkChart('rancher-kubewarden-defaults', last.defaults)
   })
-})
-
-// Extra test to validate audit scanner UI PRs
-test('06a Upgrade KW 1.10.0 to 1.11.0-rc', async({ page }) => {
-  test.skip(UPGRADE || FLEET)
-
-  const apps = new RancherAppsPage(page)
-  const kwPage = new KubewardenPage(page)
-
-  const current = (await kwPage.getCurrentVersion()).app
-  if (current === 'v1.10.0') {
-    await apps.updateApp('rancher-kubewarden-controller', { version: 0 })
-    await apps.updateApp('rancher-kubewarden-defaults', { version: 0 })
-  }
 })
 
 test('09 Check resources are active', async({ page, nav, shell }) => {

--- a/tests/e2e/60-telemetry.spec.ts
+++ b/tests/e2e/60-telemetry.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from './rancher/rancher-test'
 import { Chart, RancherAppsPage } from './rancher/rancher-apps.page'
 import { TelemetryPage } from './pages/telemetry.page'
 
-const otelChart: Chart = { title: 'opentelemetry-operator', name: 'opentelemetry-operator', namespace: 'open-telemetry', check: 'opentelemetry-operator' }
+const otelChart: Chart = { title: 'opentelemetry-operator', name: 'opentelemetry-operator', namespace: 'open-telemetry', check: 'opentelemetry-operator', version: '0.49.1' }
 const jaegerChart: Chart = { title: 'Jaeger Operator', namespace: 'jaeger', check: 'jaeger-operator' }
 const monitoringChart: Chart = { title: 'Monitoring', check: 'rancher-monitoring' }
 

--- a/tests/e2e/rancher/rancher-extensions.page.ts
+++ b/tests/e2e/rancher/rancher-extensions.page.ts
@@ -19,6 +19,9 @@ export class RancherExtensionsPage extends BasePage {
     }
 
     async enable(options?: { rancherRepo?: boolean, partnersRepo?: boolean }) {
+      const rancherRepo = this.ui.checkbox('Rancher Extension')
+      const partnersRepo = this.ui.checkbox('Partners Extension')
+
       await this.goto()
       await expect(this.page.getByRole('heading', { name: 'Extension support is not enabled' })).toBeVisible()
 
@@ -27,12 +30,12 @@ export class RancherExtensionsPage extends BasePage {
       await expect(this.page.getByRole('heading', { name: 'Enable Extension Support?' })).toBeVisible()
 
       // Available only on Rancher Prime since 2.8.3
-      if (options?.rancherRepo !== undefined) {
-        await this.ui.checkbox('Rancher Extension').setChecked(options.rancherRepo)
+      if (options?.rancherRepo !== undefined && await rancherRepo.isVisible()) {
+        await rancherRepo.setChecked(options.rancherRepo)
       }
       // New option in rancher 2.7.7, checked by default
       if (options?.partnersRepo !== undefined) {
-        await this.ui.checkbox('Partners Extension').setChecked(options.partnersRepo)
+        await partnersRepo.setChecked(options.partnersRepo)
       }
 
       // Confirm and wait for extensions to be enabled


### PR DESCRIPTION
- Fix nightly jobs failing on broken opentelemetry 0.50.0 (install previous 0.49.1)
- Add upgrade path for kubewarden 1.11.0
- Remove temporary upgrade test to 1.11.0-rc
- rancher 2.8.3-rc6 removed official extensions repository, call setChecked only if it's visible to support both prime and community