### PR TITLE
improve namespace selector controls

### DIFF
--- a/pkg/kubewarden/chart/kubewarden/admission/NamespaceSelector/index.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/NamespaceSelector/index.vue
@@ -48,6 +48,16 @@ export default {
   },
 
   watch: {
+    value: {
+      deep: true,
+      handler(neu) {
+        const matchExpressions = neu?.matchExpressions || [];
+        const matchLabels = neu?.matchLabels || {};
+
+        this.$set(this, 'matchExpressions', matchExpressions);
+        this.$set(this, 'matchLabels', matchLabels);
+      }
+    },
     matchExpressions(neu) {
       this.$set(this.namespaceSelector, 'matchExpressions', neu);
       this.$emit('input', this.namespaceSelector);

--- a/pkg/kubewarden/chart/kubewarden/admission/NamespaceSelector/index.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/NamespaceSelector/index.vue
@@ -1,14 +1,10 @@
 <script>
-import isEmpty from 'lodash/isEmpty';
-
 import { _CREATE } from '@shell/config/query-params';
-import { set } from '@shell/utils/object';
 import { POD } from '@shell/config/types';
 
 import KeyValue from '@shell/components/form/KeyValue';
 import MatchExpressions from '@shell/components/form/MatchExpressions';
 import InfoBox from '@shell/components/InfoBox';
-import Checkbox from '@components/Form/Checkbox/Checkbox.vue';
 
 import { RANCHER_NS_MATCH_EXPRESSION } from '../../../../types';
 
@@ -25,55 +21,41 @@ export default {
   },
 
   components: {
-    KeyValue, MatchExpressions, InfoBox, Checkbox
+    KeyValue, MatchExpressions, InfoBox
   },
 
   data() {
     const parsedRancherNs = JSON.stringify(RANCHER_NS_MATCH_EXPRESSION);
+    const namespaceSelector = Object.assign({}, this.value) || {};
     const matchExpressions = this.value?.matchExpressions || [];
     const matchLabels = this.value?.matchLabels || {};
 
     return {
       POD,
       parsedRancherNs,
+      namespaceSelector,
       matchExpressions,
-      matchLabels,
-      ignoreRancherNamespaces: false,
-      addSelector:             false
+      matchLabels
     };
   },
 
-  created() {
-    set(this, 'ignoreRancherNamespaces', this.hasNamespaceSelector);
-  },
-
-  watch: { ignoreRancherNamespaces: 'updateNamespaceSelector' },
-
-  computed: {
-    hasNamespaceSelector() {
-      if ( !this.isCreate ) {
-        return !isEmpty(this.value);
-      }
-
-      return true;
+  mounted() {
+    // by default, every clusterAdmissionPolicy created will ignore Rancher system namespaces
+    // so that policies in PROTECT mode don't crash the system
+    if (this.mode === _CREATE) {
+      this.$set(this.namespaceSelector, 'matchExpressions', [RANCHER_NS_MATCH_EXPRESSION]);
     }
   },
 
-  methods: {
-    updateNamespaceSelector(ignore) {
-      if ( this.value ) {
-        const expressions = this.value.matchExpressions || [];
-        const exists = expressions?.some(exp => JSON.stringify(exp) === this.parsedRancherNs);
-
-        if ( ignore ) {
-          if ( !exists ) {
-            this.$set(this.value, 'matchExpressions', [...expressions, RANCHER_NS_MATCH_EXPRESSION]);
-          }
-        } else if ( exists ) {
-          this.$set(this.value, 'matchExpressions', expressions.filter(exp => JSON.stringify(exp) !== this.parsedRancherNs));
-        }
-      }
-    }
+  watch: {
+    matchExpressions(neu) {
+      this.$set(this.namespaceSelector, 'matchExpressions', neu);
+      this.$emit('input', this.namespaceSelector);
+    },
+    matchLabels(neu) {
+      this.$set(this.namespaceSelector, 'matchLabels', neu);
+      this.$emit('input', this.namespaceSelector);
+    },
   }
 };
 </script>
@@ -83,24 +65,7 @@ export default {
     <p class="col span-12 mb-20">
       {{ t('kubewarden.policyConfig.namespaceSelector.description') }}
     </p>
-    <div class="col span-6 mb-20">
-      <Checkbox
-        v-model="ignoreRancherNamespaces"
-        :mode="mode"
-        :label="t('kubewarden.policyConfig.ignoreRancherNamespaces.label')"
-        :tooltip="t('kubewarden.policyConfig.ignoreRancherNamespaces.tooltip')"
-      />
-    </div>
-
-    <div class="col span-6 mb-20">
-      <Checkbox
-        v-model="addSelector"
-        :mode="mode"
-        :label="t('kubewarden.policyConfig.namespaceSelector.addSelector')"
-      />
-    </div>
-
-    <template v-if="addSelector">
+    <template>
       <InfoBox ref="infobox">
         <div class="row mb-20">
           <div class="col span-12">
@@ -114,7 +79,7 @@ export default {
             <span v-clean-tooltip="t('kubewarden.policyConfig.namespaceSelector.matchExpressions.tooltip')"></span>
             <MatchExpressions
               ref="matchexp"
-              v-model="value.matchExpressions"
+              v-model="matchExpressions"
               :mode="mode"
               :show-remove="false"
               :type="POD"
@@ -131,7 +96,7 @@ export default {
         <div class="row mb-20">
           <div class="col span-12">
             <KeyValue
-              v-model="value.matchLabels"
+              v-model="matchLabels"
               :mode="mode"
             />
           </div>

--- a/pkg/kubewarden/chart/kubewarden/admission/NamespaceSelector/index.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/NamespaceSelector/index.vue
@@ -25,26 +25,16 @@ export default {
   },
 
   data() {
-    const parsedRancherNs = JSON.stringify(RANCHER_NS_MATCH_EXPRESSION);
     const namespaceSelector = Object.assign({}, this.value) || {};
     const matchExpressions = this.value?.matchExpressions || [];
     const matchLabels = this.value?.matchLabels || {};
 
     return {
       POD,
-      parsedRancherNs,
       namespaceSelector,
       matchExpressions,
       matchLabels
     };
-  },
-
-  mounted() {
-    // by default, every clusterAdmissionPolicy created will ignore Rancher system namespaces
-    // so that policies in PROTECT mode don't crash the system
-    if (this.mode === _CREATE) {
-      this.$set(this.namespaceSelector, 'matchExpressions', [RANCHER_NS_MATCH_EXPRESSION]);
-    }
   },
 
   watch: {

--- a/pkg/kubewarden/components/Policies/Config.vue
+++ b/pkg/kubewarden/components/Policies/Config.vue
@@ -72,5 +72,12 @@ export default {
 
 <template>
   <Loading v-if="$fetchState.pending" />
-  <Values v-else :value="value" :chart-values="chartValues" :yaml-values="yamlValues" :mode="mode" />
+  <Values
+    v-else
+    :value="value"
+    :chart-values="chartValues"
+    :yaml-values="yamlValues"
+    :mode="mode"
+    @updateYamlValues="$emit('updateYamlValues', $event)"
+  />
 </template>

--- a/pkg/kubewarden/components/Policies/Values.vue
+++ b/pkg/kubewarden/components/Policies/Values.vue
@@ -12,7 +12,7 @@ import ResourceCancelModal from '@shell/components/ResourceCancelModal';
 import Tabbed from '@shell/components/Tabbed';
 import YamlEditor, { EDITOR_MODES } from '@shell/components/YamlEditor';
 
-import { KUBEWARDEN_CHARTS, VALUES_STATE, YAML_OPTIONS } from '../../types';
+import { KUBEWARDEN_CHARTS, VALUES_STATE, YAML_OPTIONS, RANCHER_NS_MATCH_EXPRESSION } from '../../types';
 
 export default {
   name: 'Values',
@@ -86,6 +86,19 @@ export default {
       preYamlOption:       VALUES_STATE.FORM,
       yamlOption:          VALUES_STATE.FORM
     };
+  },
+
+  mounted() {
+    // by default, every clusterAdmissionPolicy created will ignore Rancher system namespaces
+    // so that policies in PROTECT mode don't crash the system
+    // needs to be in this component because MatchExpression component is not automatically updated
+    if (this.mode === _CREATE && this.chartValues?.policy?.kind === 'ClusterAdmissionPolicy') {
+      if (!this.chartValues?.policy?.spec?.namespaceSelector) {
+        this.chartValues.policy.spec.namespaceSelector = {};
+      }
+
+      this.chartValues.policy.spec.namespaceSelector.matchExpressions = [RANCHER_NS_MATCH_EXPRESSION];
+    }
   },
 
   watch: {

--- a/pkg/kubewarden/edit/policies.kubewarden.io.admissionpolicy.vue
+++ b/pkg/kubewarden/edit/policies.kubewarden.io.admissionpolicy.vue
@@ -1,4 +1,5 @@
 <script>
+import jsyaml from 'js-yaml';
 import { _CREATE, _EDIT } from '@shell/config/query-params';
 import CreateEditView from '@shell/mixins/create-edit-view';
 
@@ -55,6 +56,14 @@ export default {
         handleGrowl({ error: e, store: this.$store });
       }
     },
+    // this updates the "value" obj for CAP's
+    // with the updated values that came from the "edit YAML" scenario
+    updateYamlValuesFromEdit(val) {
+      const parsed = jsyaml.load(val);
+
+      removeEmptyAttrs(parsed);
+      Object.assign(this.value, parsed);
+    }
   }
 };
 </script>
@@ -68,6 +77,10 @@ export default {
     :can-yaml="false"
     @finish="finish"
   >
-    <Config :value="value" :mode="realMode" />
+    <Config
+      :value="value"
+      :mode="realMode"
+      @updateYamlValues="updateYamlValuesFromEdit"
+    />
   </CruResource>
 </template>

--- a/pkg/kubewarden/edit/policies.kubewarden.io.clusteradmissionpolicy.vue
+++ b/pkg/kubewarden/edit/policies.kubewarden.io.clusteradmissionpolicy.vue
@@ -1,4 +1,5 @@
 <script>
+import jsyaml from 'js-yaml';
 import { _CREATE, _EDIT } from '@shell/config/query-params';
 import CreateEditView from '@shell/mixins/create-edit-view';
 
@@ -55,6 +56,14 @@ export default {
         handleGrowl({ error: e, store: this.$store });
       }
     },
+    // this updates the "value" obj for CAP's
+    // with the updated values that came from the "edit YAML" scenario
+    updateYamlValuesFromEdit(val) {
+      const parsed = jsyaml.load(val);
+
+      removeEmptyAttrs(parsed);
+      Object.assign(this.value, parsed);
+    }
   }
 };
 </script>
@@ -68,6 +77,10 @@ export default {
     :can-yaml="false"
     @finish="finish"
   >
-    <Config :value="value" :mode="realMode" />
+    <Config
+      :value="value"
+      :mode="realMode"
+      @updateYamlValues="updateYamlValuesFromEdit"
+    />
   </CruResource>
 </template>

--- a/tests/unit/charts/admission/NamespaceSelector.spec.ts
+++ b/tests/unit/charts/admission/NamespaceSelector.spec.ts
@@ -20,10 +20,8 @@ describe('component: NamespaceSelector', () => {
     const wrapper = shallowMount(NamespaceSelector as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
       propsData: { value: userGroupPolicy.spec.namespaceSelector },
       provide:   { chartType: KUBEWARDEN.CLUSTER_ADMISSION_POLICY },
-      stubs:     { Checkbox: { template: '<span />' } }
     });
 
-    await wrapper.setData({ addSelector: true });
     const matchExp = wrapper.findComponent(MatchExpressions);
 
     expect(matchExp.props().value).toStrictEqual(userGroupPolicy.spec.namespaceSelector.matchExpressions);
@@ -39,10 +37,7 @@ describe('component: NamespaceSelector', () => {
     const wrapper = shallowMount(NamespaceSelector as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
       propsData: { value: userGroupPolicy.spec.namespaceSelector },
       provide:   { chartType: KUBEWARDEN.CLUSTER_ADMISSION_POLICY },
-      stubs:     { Checkbox: { template: '<span />' } }
     });
-
-    await wrapper.setData({ addSelector: true });
 
     const matchExp = wrapper.findComponent(MatchExpressions);
 
@@ -58,10 +53,7 @@ describe('component: NamespaceSelector', () => {
     const wrapper = shallowMount(NamespaceSelector as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
       propsData: { value: userGroupPolicy.spec.namespaceSelector },
       provide:   { chartType: KUBEWARDEN.CLUSTER_ADMISSION_POLICY },
-      stubs:     { Checkbox: { template: '<span />' } }
     });
-
-    await wrapper.setData({ addSelector: true });
 
     const keyValue = wrapper.findComponent(KeyValue);
 


### PR DESCRIPTION
Fixes #638 
Fixes #665 

- improve namespace selector controls

![Screenshot 2024-03-21 at 16 55 02](https://github.com/rancher/kubewarden-ui/assets/97888974/95692188-b9ed-464d-a0ed-f04a2bdd0a18)

**NOTE:** In regards to the question about switching between YAML and UI, or just editing YAML has some issues, but I think it needs a major refactor which I won't be tackling in this PR. Nevertheless I believe this PR it's an improvement in terms of UX in this particular area of Cluster Admission Policy.

We can discuss this in a KW sync if you want.