### PR TITLE
Install tags and releases on rancher prime

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,16 +5,18 @@ on:
   workflow_dispatch:
     inputs:
       rancher:
-        # helm search repo rancher-latest --version '> 2.8.0-0 < 2.8.1-0'
         description: Rancher version
         type: choice
         default: 'released'
         options:
-        - 'released'
-        - '= 2.7.8'
-        - '= 2.7.9'
-        - '= 2.8.1'
-        - '> 2.8.1-0'
+        - 'released' # released versions
+        - '~ 2.7'
+        - '~ 2.8'
+        - '~ 2.9'
+        - 'rc'       # rc versions
+        - '~ 2.7-0'
+        - '~ 2.8-0'
+        - '~ 2.9-0'
       kubewarden:
         description: Kubewarden version
         type: choice
@@ -50,12 +52,12 @@ on:
       k3s:
         description: Kubernetes
         type: choice
-        default: 'v1.27.10-k3s2'
+        default: 'v1.27.12-k3s1'
         required: true
         options:
-        - v1.26.13-k3s2
-        - v1.27.10-k3s2
-        - v1.28.6-k3s2
+        - v1.26.15-k3s1
+        - v1.27.12-k3s1
+        - v1.28.8-k3s1
 
   pull_request:
     branches: main
@@ -73,7 +75,7 @@ on:
 env:
   # Github -> Secrets and variables -> Actions -> New repository variable
   RANCHER: ${{ vars.RANCHER || 'released' }}
-  K3S_VERSION: ${{ inputs.k3s || 'v1.27.10-k3s2' }}
+  K3S_VERSION: ${{ inputs.k3s || 'v1.27.12-k3s1' }}
   K3D_CLUSTER_NAME: ${{ github.repository_owner }}-${{ github.event.repository.name }}-runner
 
 jobs:
@@ -119,7 +121,11 @@ jobs:
             TESTSUITE='install + all'
         esac
 
+        # KW extension is prime since 2.8.3
+        [[ "$KUBEWARDEN" =~ ^(released|rc)$ ]] && REPO=rancher-prime || REPO=rancher-latest
+
         echo "Event: ${{github.event_name}}"
+        echo REPO="$REPO" | tee -a $GITHUB_ENV
         echo RANCHER="$RANCHER" | tee -a $GITHUB_ENV
         echo KUBEWARDEN="$KUBEWARDEN" | tee -a $GITHUB_ENV
         echo TESTSUITE="$TESTSUITE" | tee -a $GITHUB_ENV
@@ -148,6 +154,7 @@ jobs:
         kubectl wait --for=condition=Available deployment --timeout=2m -n cert-manager --all
 
         # Translate to sematic version
+        [ "$RANCHER" == "rc" ] && RANCHER='*-0'
         [ "$RANCHER" == "released" ] && RANCHER='*'
 
         # Rancher PSP is based on kubernetes version
@@ -155,8 +162,8 @@ jobs:
 
         helm repo add --force-update rancher-latest https://releases.rancher.com/server-charts/latest
         helm repo add --force-update rancher-prime https://charts.rancher.com/server-charts/prime
-        helm search repo rancher-latest/rancher ${RANCHER:+--version "$RANCHER"}
-        helm upgrade --install rancher rancher-latest/rancher --wait \
+        helm search repo $REPO/rancher ${RANCHER:+--version "$RANCHER"}
+        helm upgrade --install rancher $REPO/rancher --wait \
             --namespace cattle-system --create-namespace \
             --set hostname=$RANCHER_FQDN \
             --set bootstrapPassword=sa \

--- a/tests/e2e/fleet/kubewarden/controller/fleet.yaml
+++ b/tests/e2e/fleet/kubewarden/controller/fleet.yaml
@@ -3,7 +3,7 @@ defaultNamespace: cattle-kubewarden-system
 
 helm:
   version: '*-0'  # 2.0.5
-  releaseName: kubewarden-controller
+  releaseName: rancher-kubewarden-controller
   chart: kubewarden-controller
   repo: https://charts.kubewarden.io
   # valuesFiles:
@@ -15,9 +15,9 @@ helm:
         schedule: "*/1 * * * *" # every minute
 
 labels:
-  app: kubewarden-controller
+  app: rancher-kubewarden-controller
 
 dependsOn:
   - selector:
       matchLabels:
-        app: kubewarden-crds
+        app: rancher-kubewarden-crds

--- a/tests/e2e/fleet/kubewarden/crds/fleet.yaml
+++ b/tests/e2e/fleet/kubewarden/crds/fleet.yaml
@@ -3,11 +3,11 @@ defaultNamespace: cattle-kubewarden-system
 
 helm:
   version: '*-0' # 1.4.4
-  releaseName: kubewarden-crds
+  releaseName: rancher-kubewarden-crds
   chart: kubewarden-crds
   repo: https://charts.kubewarden.io
   # valuesFiles:
   #   - values.yaml
 
 labels:
-  app: kubewarden-crds
+  app: rancher-kubewarden-crds

--- a/tests/e2e/fleet/kubewarden/servers/default/fleet.yaml
+++ b/tests/e2e/fleet/kubewarden/servers/default/fleet.yaml
@@ -3,7 +3,7 @@ defaultNamespace: cattle-kubewarden-system
 
 helm:
   version: '*-0'
-  releaseName: kubewarden-defaults
+  releaseName: rancher-kubewarden-defaults
   chart: kubewarden-defaults
   repo: https://charts.kubewarden.io
   # valuesFiles:
@@ -18,4 +18,4 @@ helm:
 dependsOn:
   - selector:
       matchLabels:
-        app: kubewarden-controller
+        app: rancher-kubewarden-controller

--- a/tests/e2e/fleet/kubewarden/servers/ps-fleet/fleet.yaml
+++ b/tests/e2e/fleet/kubewarden/servers/ps-fleet/fleet.yaml
@@ -4,7 +4,7 @@ defaultNamespace: cattle-kubewarden-system
 dependsOn:
   - selector:
       matchLabels:
-        app: kubewarden-controller
+        app: rancher-kubewarden-controller
 
 targetCustomizations:
 - clusterName: local

--- a/tests/e2e/rancher/rancher-apps.page.ts
+++ b/tests/e2e/rancher/rancher-apps.page.ts
@@ -102,7 +102,7 @@ export class RancherAppsPage extends BasePage {
     }
 
     @step
-    async checkChart(name: string, version?: string) {
+    async checkChart(name: string|RegExp, version?: string) {
       const row = this.ui.tableRow(name)
       await row.toHaveState('Deployed')
       if (version) {


### PR DESCRIPTION
- Fix [fleet test](https://github.com/rancher/kubewarden-ui/actions/runs/8430271999/job/23090642124)
- Since rancher 2.8.3 official extension repository will be only available in prime