### PR TITLE
enforce default as namespace for AP creation

### DIFF
--- a/pkg/kubewarden/chart/kubewarden/admission/General.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/General.vue
@@ -68,6 +68,12 @@ export default {
       policy = this.value || {};
     }
 
+    // fix for https://github.com/rancher/kubewarden-ui/issues/672
+    // enforce `default` as namespace for creation of AP's
+    if ( this.mode === _CREATE && this.chartType === KUBEWARDEN.ADMISSION_POLICY ) {
+      set(policy.metadata, 'namespace', 'default');
+    }
+
     return {
       policy,
       initialPolicyMode: null,


### PR DESCRIPTION
Fixes #672 

enforce `default` as namespace for AP creation