### PR TITLE
Disable editing in UI for KW default policies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "1.4.2-rc.1",
+  "version": "1.4.2-rc.2",
   "private": false,
   "scripts": {
     "build-pkg": "./node_modules/@rancher/shell/scripts/build-pkg.sh",

--- a/pkg/kubewarden/components/DefaultsBanner.vue
+++ b/pkg/kubewarden/components/DefaultsBanner.vue
@@ -15,6 +15,13 @@ import { refreshCharts } from '../utils/chart';
 export default {
   components: { Banner },
 
+  props: {
+    mode: {
+      type:    String,
+      default: 'install'
+    },
+  },
+
   fetch() {
     this.debouncedRefreshCharts = debounce((init = false) => {
       refreshCharts({
@@ -50,6 +57,22 @@ export default {
     kubewardenRepo() {
       return this.charts?.find(chart => chart.chartName === KUBEWARDEN_CHARTS.DEFAULTS);
     },
+
+    bannerCopy() {
+      return this.mode === 'upgrade' ? this.t('kubewarden.clusterAdmissionPolicy.kwDefaultsSettingsCompatibility', {}, true) : this.t('kubewarden.policyServer.noDefaultsInstalled.description', {}, true);
+    },
+
+    btnText() {
+      return this.mode === 'upgrade' ? this.t('kubewarden.clusterAdmissionPolicy.defaultsUpdateBtn') : this.t('kubewarden.policyServer.noDefaultsInstalled.button');
+    },
+
+    isClosable() {
+      return !this.mode === 'upgrade';
+    },
+
+    colorMode() {
+      return this.mode === 'upgrade' ? 'warning' : 'info';
+    }
   },
 
   methods: {
@@ -120,18 +143,18 @@ export default {
   <Banner
     data-testid="kw-defaults-banner"
     class="mb-20 mt-0"
-    color="info"
-    :closable="true"
+    :color="colorMode"
+    :closable="isClosable"
     @close="closeDefaultsBanner()"
   >
-    <span v-clean-html="t('kubewarden.policyServer.noDefaultsInstalled.description', {}, true)" />
+    <span v-clean-html="bannerCopy" />
     <button
       v-if="defaultsChart"
       data-testid="kw-defaults-banner-button"
       class="btn role-primary ml-10"
       @click.prevent="chartRoute"
     >
-      {{ t("kubewarden.policyServer.noDefaultsInstalled.button") }}
+      {{ btnText }}
     </button>
   </Banner>
 </template>

--- a/pkg/kubewarden/components/Policies/PolicyList.vue
+++ b/pkg/kubewarden/components/Policies/PolicyList.vue
@@ -4,6 +4,7 @@ import { sortBy } from '@shell/utils/sort';
 
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import ResourceTable from '@shell/components/ResourceTable';
+import { KUBEWARDEN } from '../../types';
 
 export default {
   components: { LabeledSelect, ResourceTable },
@@ -36,7 +37,22 @@ export default {
 
   computed: {
     headers() {
-      return this.$store.getters['type-map/headersFor'](this.schema);
+      const headers = this.$store.getters['type-map/headersFor'](this.schema);
+
+      // adding Source col for CAP's
+      // https://github.com/rancher/kubewarden-ui/issues/682
+      if (this.resource === KUBEWARDEN.CLUSTER_ADMISSION_POLICY) {
+        const sourceHeader = {
+          name:  'source',
+          label: 'Source',
+          value: 'source',
+          sort:  ['source'],
+        };
+
+        headers.splice(2, 0, sourceHeader);
+      }
+
+      return headers;
     },
 
     filteredRows() {

--- a/pkg/kubewarden/edit/policies.kubewarden.io.clusteradmissionpolicy.vue
+++ b/pkg/kubewarden/edit/policies.kubewarden.io.clusteradmissionpolicy.vue
@@ -1,6 +1,6 @@
 <script>
 import jsyaml from 'js-yaml';
-import { _CREATE, _EDIT } from '@shell/config/query-params';
+import { _CREATE, _EDIT, _CLONE } from '@shell/config/query-params';
 import CreateEditView from '@shell/mixins/create-edit-view';
 
 import CruResource from '@shell/components/CruResource';
@@ -44,12 +44,22 @@ export default {
     isCreate() {
       return this.realMode === _CREATE;
     },
+
+    isClone() {
+      return this.realMode === _CLONE;
+    }
   },
 
   methods: {
     async finish(event) {
       try {
         removeEmptyAttrs(this.value);
+
+        // remove metadata that identifies a CAP as a default policy, so that we can edit it later on the UI
+        // https://github.com/rancher/kubewarden-ui/issues/682
+        if (this.isClone && this.value.isKubewardenDefaultPolicy && this.value?.metadata?.labels?.['app.kubernetes.io/name'] === 'kubewarden-defaults') {
+          delete this.value?.metadata?.labels?.['app.kubernetes.io/name'];
+        }
 
         await this.save(event);
       } catch (e) {

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -121,6 +121,8 @@ kubewarden:
   clusterAdmissionPolicy:
     title: Cluster Admission Policies
     description: ClusterAdmissionPolicy is a cluster-wide resource. These policies will process all requests within the cluster where the ClusterAdmissionPolicy is defined.
+    kwDefaultsSettingsCompatibility: ClusterAdmissionPolicies that derive from kubewarden-default Helm Chart will not have editable policy settings since the kubewarden-default Helm Chart version should be greater or equal than 1.9.5
+    defaultsUpdateBtn: Update
   customPolicy:
     badge: Custom
     title: Custom Policy

--- a/pkg/kubewarden/list/policies.kubewarden.io.clusteradmissionpolicy.vue
+++ b/pkg/kubewarden/list/policies.kubewarden.io.clusteradmissionpolicy.vue
@@ -1,14 +1,17 @@
 <script>
-import { mapGetters } from 'vuex';
-
+import { CATALOG, UI_PLUGIN } from '@shell/config/types';
 import { Banner } from '@components/Banner';
 import Loading from '@shell/components/Loading';
+import { CATALOG as CATALOG_ANNOTATIONS } from '@shell/config/labels-annotations';
+import { KUBEWARDEN_APPS, KUBEWARDEN_CHARTS, KUBEWARDEN_PRODUCT_NAME } from '../types';
+import { kwDefaultsHelmChartSettings } from '../modules/policies';
 
 import PolicyList from '../components/Policies/PolicyList';
+import DefaultsBanner from '../components/DefaultsBanner';
 
 export default {
   components: {
-    Banner, Loading, PolicyList
+    Banner, Loading, PolicyList, DefaultsBanner
   },
 
   props: {
@@ -23,13 +26,49 @@ export default {
   },
 
   async fetch() {
+    // needed to populate banner for edit settings compatibility for kubewarden-default CAP's
+    if ( this.$store.getters['cluster/canList'](CATALOG.APP) ) {
+      this.$store.dispatch('cluster/findAll', { type: CATALOG.APP });
+    }
+    if ( this.$store.getters['cluster/canList'](UI_PLUGIN) ) {
+      this.$store.dispatch('cluster/findAll', { type: UI_PLUGIN });
+    }
     await this.$store.dispatch('cluster/findAll', { type: this.resource });
   },
 
   computed: {
-
     rows() {
       return this.$store.getters['cluster/all'](this.resource);
+    },
+    allApps() {
+      return this.$store.getters['cluster/all'](CATALOG.APP);
+    },
+    kubewardenDefaultsApp() {
+      if ( this.allApps ) {
+        return this.allApps?.find((a) => {
+          return (
+            a.spec?.chart?.metadata?.annotations?.[CATALOG_ANNOTATIONS.RELEASE_NAME] === KUBEWARDEN_APPS.RANCHER_DEFAULTS ||
+            a.spec?.chart?.metadata?.name === KUBEWARDEN_CHARTS.DEFAULTS
+          );
+        });
+      }
+
+      return null;
+    },
+    kubewardenExtension() {
+      const extensionsInstalled = this.$store.getters['uiplugins/plugins'] || [];
+
+      return extensionsInstalled.find(ext => ext.id.includes(KUBEWARDEN_PRODUCT_NAME));
+    },
+    kwDefaultsHelmChartSettingsCompatible() {
+      const kwDefaultsVersion = this.kubewardenDefaultsApp?.spec?.chart?.metadata?.version;
+      const uiPluginVersion = this.kubewardenExtension?.version;
+
+      if ( kwDefaultsVersion && uiPluginVersion) {
+        return kwDefaultsHelmChartSettings(kwDefaultsVersion, uiPluginVersion);
+      }
+
+      return true;
     }
   }
 };
@@ -43,6 +82,10 @@ export default {
       class="type-banner mb-20 mt-0"
       color="info"
       :label="t('kubewarden.clusterAdmissionPolicy.description')"
+    />
+    <DefaultsBanner
+      v-if="!kwDefaultsHelmChartSettingsCompatible"
+      mode="upgrade"
     />
 
     <PolicyList data-testid="kw-cap-policy-list" :resource="resource" :rows="rows" :schema="schema" />

--- a/pkg/kubewarden/models/policies.kubewarden.io.clusteradmissionpolicy.js
+++ b/pkg/kubewarden/models/policies.kubewarden.io.clusteradmissionpolicy.js
@@ -13,6 +13,7 @@ export default class ClusterAdmissionPolicy extends PolicyModel {
       return act;
     });
 
+    // add Edit Policy Settings
     if (this.isKubewardenDefaultPolicy) {
       const defaultPolicySettings = {
         action:  'editPolicySettings',
@@ -26,13 +27,17 @@ export default class ClusterAdmissionPolicy extends PolicyModel {
     return filteredActions;
   }
 
+  set _availableActions(actions) {
+    this._availableActions = actions;
+  }
+
   editPolicySettings() {
     this.currentRouter().push(this.kubewardenDefaultsRoute);
   }
 
   get source() {
     if (this.isKubewardenDefaultPolicy) {
-      return 'Default Policy';
+      return 'kubewarden-default';
     }
 
     // right now we are adding 'artifacthub/pkg' anontation
@@ -40,9 +45,9 @@ export default class ClusterAdmissionPolicy extends PolicyModel {
     // that only happens for template based CAP's
     // https://github.com/rancher/kubewarden-ui/issues/682
     if (this.metadata?.annotations?.['artifacthub/pkg']) {
-      return 'Template';
+      return 'template';
     }
 
-    return 'Custom';
+    return 'custom';
   }
 }

--- a/pkg/kubewarden/models/policies.kubewarden.io.clusteradmissionpolicy.js
+++ b/pkg/kubewarden/models/policies.kubewarden.io.clusteradmissionpolicy.js
@@ -1,3 +1,48 @@
 import PolicyModel from '../plugins/policy-class';
 
-export default class ClusterAdmissionPolicy extends PolicyModel {}
+export default class ClusterAdmissionPolicy extends PolicyModel {
+  get _availableActions() {
+    const out = super._availableActions;
+
+    // remove edit actions for KW default policies
+    const filteredActions = out.filter((act) => {
+      if (this.isKubewardenDefaultPolicy) {
+        return act.action !== 'goToEdit' && act.action !== 'goToEditYaml';
+      }
+
+      return act;
+    });
+
+    if (this.isKubewardenDefaultPolicy) {
+      const defaultPolicySettings = {
+        action:  'editPolicySettings',
+        icon:    'icon icon-edit',
+        label:   'Edit Policy Settings',
+      };
+
+      filteredActions.unshift(defaultPolicySettings);
+    }
+
+    return filteredActions;
+  }
+
+  editPolicySettings() {
+    this.currentRouter().push(this.kubewardenDefaultsRoute);
+  }
+
+  get source() {
+    if (this.isKubewardenDefaultPolicy) {
+      return 'Default Policy';
+    }
+
+    // right now we are adding 'artifacthub/pkg' anontation
+    // so that we can fetch the questions info from there
+    // that only happens for template based CAP's
+    // https://github.com/rancher/kubewarden-ui/issues/682
+    if (this.metadata?.annotations?.['artifacthub/pkg']) {
+      return 'Template';
+    }
+
+    return 'Custom';
+  }
+}

--- a/pkg/kubewarden/models/policies.kubewarden.io.clusteradmissionpolicy.js
+++ b/pkg/kubewarden/models/policies.kubewarden.io.clusteradmissionpolicy.js
@@ -5,6 +5,7 @@ export default class ClusterAdmissionPolicy extends PolicyModel {
     const out = super._availableActions;
 
     // remove edit actions for KW default policies
+    // https://github.com/rancher/kubewarden-ui/issues/682
     const filteredActions = out.filter((act) => {
       if (this.isKubewardenDefaultPolicy) {
         return act.action !== 'goToEdit' && act.action !== 'goToEditYaml';
@@ -13,7 +14,8 @@ export default class ClusterAdmissionPolicy extends PolicyModel {
       return act;
     });
 
-    // add Edit Policy Settings
+    // add Edit Policy Settings for default policies
+    // https://github.com/rancher/kubewarden-ui/issues/682
     if (this.isKubewardenDefaultPolicy) {
       const defaultPolicySettings = {
         action:  'editPolicySettings',

--- a/pkg/kubewarden/modules/policies.ts
+++ b/pkg/kubewarden/modules/policies.ts
@@ -1,0 +1,16 @@
+import semver from 'semver';
+
+/**
+ * Determines if the Kubewarden Extension is compatible with kubewarden-defaults version for displaying settings edit
+ * for Kubewarden Extension `>= 1.4.2` it requires kubewarden-defaults version of `>= 1.9.5`
+ * @param string
+ * @param string
+ * @returns Object
+ */
+export function kwDefaultsHelmChartSettings(kwDefaultsVersion: string, uiPluginVersion: string): Object | void {
+  if (semver.gt(uiPluginVersion, '1.4.1')) {
+    return semver.gt(kwDefaultsVersion, '1.9.4');
+  }
+
+  return true;
+}

--- a/pkg/kubewarden/package.json
+++ b/pkg/kubewarden/package.json
@@ -2,7 +2,7 @@
   "name": "kubewarden",
   "description": "Kubewarden extension for Rancher Manager",
   "icon": "https://raw.githubusercontent.com/kubewarden/ui/main/pkg/kubewarden/assets/icon-kubewarden.svg",
-  "version": "1.4.2-rc.1",
+  "version": "1.4.2-rc.2",
   "private": false,
   "rancher": {
     "annotations": {

--- a/pkg/kubewarden/plugins/policy-class.js
+++ b/pkg/kubewarden/plugins/policy-class.js
@@ -35,7 +35,11 @@ export default class PolicyModel extends KubewardenModel {
     if (helmChart && helmChart.includes('-')) {
       const arr = helmChart.split('-');
 
-      version = arr[arr.length - 1];
+      if (arr[arr.length - 1].includes('rc')) {
+        version = `${ arr[arr.length - 2] }-${ arr[arr.length - 1] }`;
+      } else {
+        version = arr[arr.length - 1];
+      }
     }
 
     const query = {

--- a/pkg/kubewarden/plugins/policy-class.js
+++ b/pkg/kubewarden/plugins/policy-class.js
@@ -12,7 +12,7 @@ export default class PolicyModel extends KubewardenModel {
     const out = super._availableActions;
 
     const policyMode = {
-      action:  this.isKubewardenDefaultPolicy ? 'kwDefaultEditPolicyMode' : 'toggleUpdateMode',
+      action:  'toggleUpdateMode',
       enabled: this.spec.mode === 'monitor',
       icon:    'icon icon-fw icon-notifier',
       label:   'Update Mode',
@@ -21,10 +21,6 @@ export default class PolicyModel extends KubewardenModel {
     out.unshift(policyMode);
 
     return out;
-  }
-
-  kwDefaultEditPolicyMode() {
-    this.currentRouter().push(this.kubewardenDefaultsRoute);
   }
 
   get kubewardenDefaultsRoute() {


### PR DESCRIPTION
Fixes #682 

- Remove `"Edit Config"` and `"Edit YAML"` in UI for KW default policies
- Add `"Edit policy settings"` in UI as table action for KW default policies, which will take the user to the `kubewarden-defaults` chart installation screen
- `Update mode` on KW default policies should take the user to the `kubewarden-defaults` chart installation screen
- Add a table column to CAP's list view called `Source`, so that we can distinguish KW default policies from the rest
- Change the `clone`  table action on default KW policies to **NOT** copy annotations that make them a default policy (went with `his.metadata?.labels?.['app.kubernetes.io/name']` which is a default KW policy equals `kubewarden-defaults`)

<img width="1738" alt="Screenshot 2024-04-18 at 16 22 58" src="https://github.com/rancher/kubewarden-ui/assets/97888974/5cd36928-dc27-4eef-8d5e-db8f948e1887">
<img width="1738" alt="Screenshot 2024-04-18 at 16 23 03" src="https://github.com/rancher/kubewarden-ui/assets/97888974/9449850d-6903-4d1d-897b-3f2e73e69937">

https://github.com/rancher/kubewarden-ui/assets/97888974/d311af80-2729-42e2-86bc-b844e83349e0

