### PR TITLE
Remove outdated yq dependency

### DIFF
--- a/.github/workflows/build-extension-charts.yml
+++ b/.github/workflows/build-extension-charts.yml
@@ -38,11 +38,6 @@ jobs:
         with:
           version: v3.8.0
 
-      - name: Setup yq
-        uses: chrisdickinson/setup-yq@v1.0.1
-        with:
-          yq-version: v4.34.2
-
       - name: Setup Nodejs and npm
         uses: actions/setup-node@v4
         with:
@@ -78,7 +73,7 @@ jobs:
           if [[ -n "${{ github.ref_name }}" ]]; then
             publish="$publish -t ${{ github.ref_name }}"
           fi
-          
+
           $publish
 
       - name: Upload charts artifact


### PR DESCRIPTION
Yq is part of ubuntu github runner preinstalled packages.
https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md

Action is also outdated and outputs warning on release job:
https://github.com/rancher/kubewarden-ui/actions/runs/8628654143

Tested on fork release: https://github.com/kravciak/kubewarden-ui/actions/runs/8753200281