### PR TITLE
Kubewarden defaults rc version changed 1.9.5 -> 2.0.0

### DIFF
--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -121,7 +121,7 @@ kubewarden:
   clusterAdmissionPolicy:
     title: Cluster Admission Policies
     description: ClusterAdmissionPolicy is a cluster-wide resource. These policies will process all requests within the cluster where the ClusterAdmissionPolicy is defined.
-    kwDefaultsSettingsCompatibility: ClusterAdmissionPolicies that derive from kubewarden-default Helm Chart will not have editable policy settings since the kubewarden-default Helm Chart version should be greater or equal than 1.9.5
+    kwDefaultsSettingsCompatibility: ClusterAdmissionPolicies that derive from kubewarden-default Helm Chart will not have editable policy settings since the kubewarden-default Helm Chart version should be greater or equal than 2.0.0
     defaultsUpdateBtn: Update
   customPolicy:
     badge: Custom

--- a/pkg/kubewarden/modules/policies.ts
+++ b/pkg/kubewarden/modules/policies.ts
@@ -2,14 +2,14 @@ import semver from 'semver';
 
 /**
  * Determines if the Kubewarden Extension is compatible with kubewarden-defaults version for displaying settings edit
- * for Kubewarden Extension `>= 1.4.2` it requires kubewarden-defaults version of `>= 1.9.5`
+ * for Kubewarden Extension `>= 1.4.2` it requires kubewarden-defaults version of `>= 2.0.0`
  * @param string
  * @param string
  * @returns Object
  */
 export function kwDefaultsHelmChartSettings(kwDefaultsVersion: string, uiPluginVersion: string): Object | void {
   if (semver.gt(uiPluginVersion, '1.4.1')) {
-    return semver.gt(kwDefaultsVersion, '1.9.4');
+    return semver.gt(kwDefaultsVersion, '1.9.9');
   }
 
   return true;


### PR DESCRIPTION
Version 1.9.5-rc does not exist, it was changed to 2.0.0-rc because of breaking change.

Tested manually, PR e2e tests are broken until we merge https://github.com/rancher/kubewarden-ui/pull/697.