### PR TITLE
Remove config edit action for policies deployed by fleet

### DIFF
--- a/pkg/kubewarden/components/Policies/PolicyList.vue
+++ b/pkg/kubewarden/components/Policies/PolicyList.vue
@@ -4,7 +4,6 @@ import { sortBy } from '@shell/utils/sort';
 
 import LabeledSelect from '@shell/components/form/LabeledSelect';
 import ResourceTable from '@shell/components/ResourceTable';
-import { KUBEWARDEN } from '../../types';
 
 export default {
   components: { LabeledSelect, ResourceTable },
@@ -37,22 +36,7 @@ export default {
 
   computed: {
     headers() {
-      const headers = this.$store.getters['type-map/headersFor'](this.schema);
-
-      // adding Source col for CAP's
-      // https://github.com/rancher/kubewarden-ui/issues/682
-      if (this.resource === KUBEWARDEN.CLUSTER_ADMISSION_POLICY) {
-        const sourceHeader = {
-          name:  'source',
-          label: 'Source',
-          value: 'source',
-          sort:  ['source'],
-        };
-
-        headers.splice(2, 0, sourceHeader);
-      }
-
-      return headers;
+      return this.$store.getters['type-map/headersFor'](this.schema);
     },
 
     filteredRows() {

--- a/pkg/kubewarden/config/table-headers.ts
+++ b/pkg/kubewarden/config/table-headers.ts
@@ -34,6 +34,13 @@ export const ADMISSION_POLICY_OPERATIONS = {
   formatter: 'PolicyResources'
 };
 
+export const ADMISSION_POLICY_SOURCE = {
+  name:  'source',
+  label: 'Source',
+  value: 'source',
+  sort:  ['source']
+};
+
 export const POLICY_SERVER_STATE = {
   name:      'state',
   sort:      ['stateSort', 'nameSort'],
@@ -66,6 +73,7 @@ export const RELATED_HEADERS = [
   ADMISSION_POLICY_MODE,
   ADMISSION_POLICY_RESOURCES,
   ADMISSION_POLICY_OPERATIONS,
+  ADMISSION_POLICY_SOURCE,
   {
     name:      'age',
     labelKey:  'tableHeaders.age',
@@ -128,6 +136,7 @@ export const POLICY_HEADERS = [
   },
   ADMISSION_POLICY_RESOURCES,
   ADMISSION_POLICY_OPERATIONS,
+  ADMISSION_POLICY_SOURCE,
   {
     name:      'age',
     labelKey:  'tableHeaders.age',

--- a/pkg/kubewarden/list/policies.kubewarden.io.admissionpolicy.vue
+++ b/pkg/kubewarden/list/policies.kubewarden.io.admissionpolicy.vue
@@ -1,6 +1,4 @@
 <script>
-import { mapGetters } from 'vuex';
-
 import { Banner } from '@components/Banner';
 import Loading from '@shell/components/Loading';
 
@@ -27,7 +25,6 @@ export default {
   },
 
   computed: {
-
     rows() {
       return this.$store.getters['cluster/all'](this.resource);
     }

--- a/pkg/kubewarden/list/policies.kubewarden.io.clusteradmissionpolicy.vue
+++ b/pkg/kubewarden/list/policies.kubewarden.io.clusteradmissionpolicy.vue
@@ -58,7 +58,7 @@ export default {
     kubewardenExtension() {
       const extensionsInstalled = this.$store.getters['uiplugins/plugins'] || [];
 
-      return extensionsInstalled.find(ext => ext.id.includes(KUBEWARDEN_PRODUCT_NAME));
+      return extensionsInstalled?.find(ext => ext?.id?.includes(KUBEWARDEN_PRODUCT_NAME));
     },
     kwDefaultsHelmChartSettingsCompatible() {
       const kwDefaultsVersion = this.kubewardenDefaultsApp?.spec?.chart?.metadata?.version;


### PR DESCRIPTION
Fix #702
Fix #701 

When deploying the `kubewarden-defaults` charts from Fleet, the action for editing the policy's settings would not account for Fleet deployments. I have added a method on the model to check for the annotation `objectset.rio.cattle.io/id` as this will be applied to resources when created by Fleet.

As this creates a larger issue with managing resources controlled by Fleet, I decided to simply remove the ability to edit the configuration at the moment, we should revisit this with a more streamlined approach to managing this use case for all resources.

I have also added the "Source" column to the Admission Policy list table and Policy Server detail related policies table.

___Cluster Admission Policies deployed with Fleet___
![cap-list-source-actions](https://github.com/rancher/kubewarden-ui/assets/40806497/1caaea18-3fd0-4ef1-a701-4317e6661aa0)

___Policy Server related policies table___
![ps-detail-source](https://github.com/rancher/kubewarden-ui/assets/40806497/83d0318e-d154-4088-b134-69c92eb8b929)


