### PR TITLE
Store and filter ClusterPolicyReports for project/namespaces

### DIFF
--- a/pkg/kubewarden/components/PolicyReporter/ReporterPanel.vue
+++ b/pkg/kubewarden/components/PolicyReporter/ReporterPanel.vue
@@ -9,9 +9,18 @@ import { getReports } from '../../modules/policyReporter';
  */
 export default {
   async fetch() {
-    await getReports(this.$store, false);
-    await getReports(this.$store, true);
-  },
+    const isClusterLevel = !this.$route.params.resource;
+    const resourceType = this.$route.params.resource;
+
+    // Fetch cluster level reports if no specific resource is specified
+    if ( isClusterLevel ) {
+      await getReports(this.$store, true);
+    }
+    // Fetch normal policy reports if a specific resource type is specified or always fetch on projectsnamespaces page
+    if ( resourceType || this.$route.path.includes('projectsnamespaces') ) {
+      await getReports(this.$store, false, resourceType);
+    }
+  }
 };
 </script>
 

--- a/pkg/kubewarden/components/PolicyReporter/ReporterPanel.vue
+++ b/pkg/kubewarden/components/PolicyReporter/ReporterPanel.vue
@@ -1,5 +1,5 @@
 <script>
-import { getPolicyReports } from '../../modules/policyReporter';
+import { getReports } from '../../modules/policyReporter';
 
 /**
  * Invisible panel to fetch PolicyReports for ResourceList
@@ -9,7 +9,8 @@ import { getPolicyReports } from '../../modules/policyReporter';
  */
 export default {
   async fetch() {
-    await getPolicyReports(this.$store);
+    await getReports(this.$store, false);
+    await getReports(this.$store, true);
   },
 };
 </script>

--- a/pkg/kubewarden/components/PolicyReporter/ResourceTab.vue
+++ b/pkg/kubewarden/components/PolicyReporter/ResourceTab.vue
@@ -86,16 +86,20 @@ export default {
 
   methods: {
     canGetResourceLink(row) {
-      const resource = row.scope;
+      const outResource = row.scope;
 
-      if ( resource ) {
-        const isCore = Object.values(coreTypes).find(type => resource.kind === type.attributes.kind);
+      if ( this.resource?.type === NAMESPACE && outResource.kind?.toLowerCase() === NAMESPACE ) {
+        return null;
+      }
+
+      if ( outResource ) {
+        const isCore = Object.values(coreTypes).find(type => outResource.kind === type.attributes.kind);
 
         if ( isCore ) {
-          return this.$store.getters['cluster/schemaFor'](resource.kind?.toLowerCase());
+          return this.$store.getters['cluster/schemaFor'](outResource.kind?.toLowerCase());
         }
 
-        const groupType = splitGroupKind(resource);
+        const groupType = splitGroupKind(outResource);
 
         if ( groupType ) {
           return this.$store.getters['cluster/schemaFor'](groupType);
@@ -157,6 +161,7 @@ export default {
         :table-actions="false"
         :row-actions="false"
         key-field="uid"
+        :group-by="isNamespaceResource ? 'kind' : null"
         :sub-expandable="true"
         :sub-expand-column="true"
         :sub-rows="true"

--- a/pkg/kubewarden/formatters/PolicyReportSummary.vue
+++ b/pkg/kubewarden/formatters/PolicyReportSummary.vue
@@ -1,5 +1,4 @@
 <script>
-import { mapGetters } from 'vuex';
 import isEmpty from 'lodash/isEmpty';
 import { sortBy } from '@shell/utils/sort';
 
@@ -14,8 +13,6 @@ export default {
   },
 
   computed: {
-    ...mapGetters({ reports: 'kubewarden/policyReports' }),
-
     canShow() {
       if ( !isEmpty(this.summary) ) {
         const counts = [];

--- a/pkg/kubewarden/formatters/PolicyReportSummary.vue
+++ b/pkg/kubewarden/formatters/PolicyReportSummary.vue
@@ -44,7 +44,9 @@ export default {
     },
 
     summary() {
-      return getFilteredSummary(this.$store, this.value);
+      const isClusterLevel = this.$attrs.col.name === 'cluster-policy-reports';
+
+      return getFilteredSummary(this.$store, this.value, isClusterLevel);
     },
 
     summaryParts() {
@@ -131,7 +133,7 @@ export default {
 
 <style lang="scss" scoped>
 $height: 30px;
-$width: 143px;
+$width: 100%;
 $error: #614EA2;
 
 .pr-summary {
@@ -144,8 +146,6 @@ $error: #614EA2;
 
     width: $width;
     height: $height;
-
-    border: solid thin var(--sortable-table-top-divider);
 
     .badge {
       padding: 4px;

--- a/pkg/kubewarden/formatters/PolicyReportSummary.vue
+++ b/pkg/kubewarden/formatters/PolicyReportSummary.vue
@@ -44,9 +44,7 @@ export default {
     },
 
     summary() {
-      const isClusterLevel = this.$attrs.col.name === 'cluster-policy-reports';
-
-      return getFilteredSummary(this.$store, this.value, isClusterLevel);
+      return getFilteredSummary(this.$store, this.value);
     },
 
     summaryParts() {

--- a/pkg/kubewarden/index.ts
+++ b/pkg/kubewarden/index.ts
@@ -64,18 +64,33 @@ export default function($plugin: IPlugin, args: any) {
   );
 
   /** Columns */
+  // Policy Reports for Project Namespaces
   $plugin.addTableColumn(
     TableColumnLocation.RESOURCE,
     { path: [{ urlPath: 'explorer/projectsnamespaces', endsWith: true }] },
     {
       name:      'policy-reports',
-      labelKey:  'kubewarden.policyReporter.headers.label',
+      labelKey:  'kubewarden.policyReporter.headers.policyReports.label',
       getValue:  (row: any) => row,
       weight:    3,
       formatter: 'PolicyReportSummary'
     }
   );
 
+  // Cluster Policy Reports for Project Namespaces
+  $plugin.addTableColumn(
+    TableColumnLocation.RESOURCE,
+    { path: [{ urlPath: 'explorer/projectsnamespaces', endsWith: true }] },
+    {
+      name:      'cluster-policy-reports',
+      labelKey:  'kubewarden.policyReporter.headers.clusterPolicyReports.label',
+      getValue:  (row: any) => row,
+      weight:    2,
+      formatter: 'PolicyReportSummary'
+    }
+  );
+
+  // Policy Reports for namespaced resources
   $plugin.addTableColumn(
     TableColumnLocation.RESOURCE,
     {

--- a/pkg/kubewarden/index.ts
+++ b/pkg/kubewarden/index.ts
@@ -8,14 +8,15 @@ import {
 
 import kubewardenRoutes from './routes/kubewarden-routes';
 import kubewardenStore from './store/kubewarden';
-import { getPolicyReports } from './modules/policyReporter';
+import { getReports } from './modules/policyReporter';
 
 // fix missing directives on dashboard v2.7.2
 import '@shell/plugins/clean-tooltip-directive';
 import '@shell/plugins/clean-html-directive';
 
 const onEnter: OnNavToPackage = async(store) => {
-  await getPolicyReports(store);
+  await getReports(store, false);
+  await getReports(store, true);
 };
 
 // Init the package

--- a/pkg/kubewarden/index.ts
+++ b/pkg/kubewarden/index.ts
@@ -77,19 +77,6 @@ export default function($plugin: IPlugin, args: any) {
     }
   );
 
-  // Cluster Policy Reports for Project Namespaces
-  $plugin.addTableColumn(
-    TableColumnLocation.RESOURCE,
-    { path: [{ urlPath: 'explorer/projectsnamespaces', endsWith: true }] },
-    {
-      name:      'cluster-policy-reports',
-      labelKey:  'kubewarden.policyReporter.headers.clusterPolicyReports.label',
-      getValue:  (row: any) => row,
-      weight:    2,
-      formatter: 'PolicyReportSummary'
-    }
-  );
-
   // Policy Reports for namespaced resources
   $plugin.addTableColumn(
     TableColumnLocation.RESOURCE,

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -409,6 +409,12 @@ kubewarden:
       banner:
         unavailable: 'The Policy Reporter UI Deployment is currently in a `{ state }` state, please wait.'
     headers:
+      policyReports:
+        label: Compliance
+        description: Policy Reports are the results of the policy scans that are stored using the PolicyReport Custom Resource.
+      clusterPolicyReports:
+        label: Cluster Compliance
+        description: Cluster Policy Reports are the results of the policy scans that are stored using the ClusterPolicyReport Custom Resource.
       label: Compliance
       description: When using the Kubewarden Audit Scanner, the results of the policy scans are stored using the PolicyReport Custom Resource.
       policyReportsTab:

--- a/pkg/kubewarden/modules/core.ts
+++ b/pkg/kubewarden/modules/core.ts
@@ -75,3 +75,12 @@ export function namespacedGroups(store: any, apiGroups: ApiGroup[]): ApiGroup[] 
 export function namespacedSchemas(schemas: Schema[]): Schema[] | void {
   return schemas?.filter(schema => !(schema?.attributes?.namespaced === false || undefined));
 }
+
+/**
+ * Determines if a Kubernetes resource is namespaced based on its metadata.
+ * @param resource The Kubernetes resource object.
+ * @returns boolean indicating if the resource is namespaced.
+ */
+export function isResourceNamespaced(resource: any): boolean {
+  return 'namespace' in resource.metadata;
+}

--- a/pkg/kubewarden/modules/policyReporter.ts
+++ b/pkg/kubewarden/modules/policyReporter.ts
@@ -29,7 +29,8 @@ export async function getReports(store: Store<any>, isClusterLevel: boolean = fa
   if ( isClusterLevel ) {
     reportTypes.push(WG_POLICY_K8S.CLUSTER_POLICY_REPORT.TYPE);
   }
-  if ( resourceType ) {
+
+  if ( resourceType || !isClusterLevel ) {
     reportTypes.push(WG_POLICY_K8S.POLICY_REPORT.TYPE);
   }
 

--- a/pkg/kubewarden/store/kubewarden/actions.ts
+++ b/pkg/kubewarden/store/kubewarden/actions.ts
@@ -1,5 +1,5 @@
 import {
-  CatalogApp, CustomResourceDefinition, PolicyReport, PolicyTraceConfig, PolicyTrace
+  CatalogApp, CustomResourceDefinition, PolicyReport, ClusterPolicyReport, PolicyTraceConfig, PolicyTrace
 } from '../../types';
 
 export default {
@@ -20,12 +20,12 @@ export default {
     commit('updateHideBannerAirgapPolicy', val);
   },
 
-  // Policy reports
-  updatePolicyReports({ commit }: any, val: PolicyReport[]) {
-    commit('updatePolicyReports', val);
+  // Policy and Cluster Policy Reports
+  updatePolicyReports({ commit }: any, updatedReport: PolicyReport) {
+    commit('updateReports', { reportArrayKey: 'policyReports', updatedReport });
   },
-  removePolicyReportById({ commit }: any, val: PolicyReport) {
-    commit('removePolicyReportById', val.id);
+  updateClusterPolicyReports({ commit }: any, updatedReport: ClusterPolicyReport) {
+    commit('updateReports', { reportArrayKey: 'clusterPolicyReports', updatedReport });
   },
 
   // Policy traces

--- a/pkg/kubewarden/store/kubewarden/getters.ts
+++ b/pkg/kubewarden/store/kubewarden/getters.ts
@@ -1,4 +1,6 @@
-import { CatalogApp, CustomResourceDefinition, PolicyReport, PolicyTraceConfig } from '../../types';
+import {
+  CatalogApp, CustomResourceDefinition, PolicyReport, ClusterPolicyReport, PolicyTraceConfig
+} from '../../types';
 import { StateConfig } from './index';
 
 export default {
@@ -9,6 +11,7 @@ export default {
   controllerApp:           (state: StateConfig): CatalogApp | null => state.controllerApp,
   kubewardenCrds:          (state: StateConfig): CustomResourceDefinition[] => state.kubewardenCrds,
   policyReports:           (state: StateConfig): PolicyReport[] => state.policyReports,
+  clusterPolicyReports:    (state: StateConfig): ClusterPolicyReport[] => state.clusterPolicyReports,
   policyTraces:            (state: StateConfig): PolicyTraceConfig[] => state.policyTraces,
   refreshingCharts:        (state: StateConfig): Boolean => state.refreshingCharts,
 };

--- a/pkg/kubewarden/store/kubewarden/index.ts
+++ b/pkg/kubewarden/store/kubewarden/index.ts
@@ -6,7 +6,8 @@ import {
   CustomResourceDefinition,
   FleetGitRepo,
   PolicyReport,
-  PolicyTraceConfig
+  PolicyTraceConfig,
+  ClusterPolicyReport
 } from '../../types';
 
 import getters from './getters';
@@ -14,16 +15,17 @@ import mutations from './mutations';
 import actions from './actions';
 
 export interface StateConfig {
-  airGapped: Boolean,
-  fleetRepos: FleetGitRepo[],
-  hideBannerDefaults: Boolean,
-  hideBannerArtifactHub: Boolean,
-  hideBannerAirgapPolicy: Boolean,
-  controllerApp: CatalogApp | null,
-  kubewardenCrds: CustomResourceDefinition[],
-  policyReports: PolicyReport[]
-  policyTraces: PolicyTraceConfig[],
-  refreshingCharts: Boolean,
+  airGapped: Boolean;
+  fleetRepos: FleetGitRepo[];
+  hideBannerDefaults: Boolean;
+  hideBannerArtifactHub: Boolean;
+  hideBannerAirgapPolicy: Boolean;
+  controllerApp: CatalogApp | null;
+  kubewardenCrds: CustomResourceDefinition[];
+  policyReports: PolicyReport[];
+  clusterPolicyReports: ClusterPolicyReport[];
+  policyTraces: PolicyTraceConfig[];
+  refreshingCharts: Boolean;
 }
 
 const kubewardenFactory = (config: StateConfig): CoreStoreSpecifics => {
@@ -38,6 +40,7 @@ const kubewardenFactory = (config: StateConfig): CoreStoreSpecifics => {
         controllerApp:          config.controllerApp,
         kubewardenCrds:         config.kubewardenCrds,
         policyReports:          config.policyReports,
+        clusterPolicyReports:   config.clusterPolicyReports,
         policyTraces:           config.policyTraces,
         refreshingCharts:       config.refreshingCharts
       };
@@ -61,6 +64,7 @@ export default {
     controllerApp:          null,
     kubewardenCrds:         [],
     policyReports:          [],
+    clusterPolicyReports:   [],
     policyTraces:           [],
     refreshingCharts:       false
   }),

--- a/pkg/kubewarden/store/kubewarden/mutations.ts
+++ b/pkg/kubewarden/store/kubewarden/mutations.ts
@@ -1,7 +1,9 @@
 import {
-  CatalogApp, CustomResourceDefinition, PolicyReport, PolicyTrace, PolicyTraceConfig
+  CatalogApp, ClusterPolicyReport, CustomResourceDefinition, PolicyReport, PolicyTrace, PolicyTraceConfig
 } from '../../types';
 import { StateConfig } from './index';
+
+type ReportKeys = 'policyReports' | 'clusterPolicyReports';
 
 export default {
   updateAirGapped(state: StateConfig, val: Boolean) {
@@ -76,20 +78,23 @@ export default {
   },
 
   /**
-   * Updates/Adds policy reports to the state
-   * @param state
-   * @param updatedReport - PolicyReport interface
-   */
-  updatePolicyReports(state: StateConfig, updatedReport: PolicyReport) {
-    const existingReport = state.policyReports.find(report => report.id === updatedReport.id);
+ * Updates/Adds a policy or cluster policy report to the store.
+ * @param state - The current state object.
+ * @param reportArrayKey - The key to the report array in the state to update (e.g., 'policyReports' or 'clusterPolicyReports').
+ * @param updatedReport - The report object to update or add.
+ */
+  updateReports<T extends PolicyReport | ClusterPolicyReport>(
+    state: StateConfig,
+    { reportArrayKey, updatedReport }: { reportArrayKey: ReportKeys, updatedReport: T }
+  ): void {
+    const reportArray = state[reportArrayKey] as Array<T>;
+    const existingReport = reportArray.find(report => report.id === updatedReport.id);
 
     if ( existingReport ) {
-      // We only need to update the results and summary of the report
       existingReport.results = updatedReport.results;
       existingReport.summary = updatedReport.summary;
     } else {
-      // If the report doesn't exist, add it to the store
-      state.policyReports.push(updatedReport);
+      reportArray.push(updatedReport);
     }
   },
 

--- a/pkg/kubewarden/types/policy-reporter.ts
+++ b/pkg/kubewarden/types/policy-reporter.ts
@@ -95,3 +95,12 @@ export interface PolicyReport {
   type: string;
   uid: string;
 }
+
+export interface ClusterPolicyReport extends PolicyReport {
+  scope: {
+    apiVersion: string;
+    kind: string;
+    name: string;
+    uid: string;
+  }
+}

--- a/tests/unit/_templates_/policyReports.ts
+++ b/tests/unit/_templates_/policyReports.ts
@@ -1,5 +1,5 @@
 import {
-  Resource, PolicyReportResult, PolicyReport, Result, Severity
+  Resource, PolicyReportResult, PolicyReport, ClusterPolicyReport, Result, Severity
 } from '@kubewarden/types';
 
 export const mockResource: Resource = {
@@ -48,4 +48,31 @@ export const mockPolicyReport: PolicyReport = {
   },
   type: 'PolicyReport',
   uid:  'report-uid-123',
+};
+
+export const mockClusterPolicyReport: ClusterPolicyReport = {
+  apiVersion: 'policy.k8s.io/v1beta1',
+  id:         'clusterpolicyreport-123',
+  kind:       'ClusterPolicyReport',
+  metadata:   {
+    labels:            { 'app.kubernetes.io/managed-by': 'kubewarden' },
+    creationTimestamp: '2021-03-19T10:52:00Z',
+    name:              'clusterpolicyreport-123',
+  },
+  results:    [mockPolicyReportResult],
+  scope:      {
+    apiVersion: 'v1',
+    kind:       'Cluster',
+    name:       'cluster-wide',
+    uid:        'cluster-wide-uid',
+  },
+  summary: {
+    fail:  1,
+    pass:  0,
+    warn:  0,
+    error: 0,
+    skip:  0,
+  },
+  type: 'ClusterPolicyReport',
+  uid:  'report-uid-cluster-123',
 };

--- a/tests/unit/components/PolicyReporter/ResourceTab.spec.ts
+++ b/tests/unit/components/PolicyReporter/ResourceTab.spec.ts
@@ -1,9 +1,10 @@
 import { createWrapper } from '@tests/unit/_utils_/wrapper';
 
 import ResourceTab from '@kubewarden/components/PolicyReporter/ResourceTab.vue';
+import { mockPolicyReport, mockClusterPolicyReport } from '../../_templates_/policyReports';
 
 const commons = {
-  mocks:     {
+  mocks: {
     $store: {
       getters: {
         currentCluster:               () => ({ id: 'test-cluster' }),
@@ -23,7 +24,6 @@ describe('ResourceTab.vue', () => {
   it('computes canGetKubewardenLinks correctly', () => {
     const wrapper = wrapperFactory({ propsData: { resource: {} } });
 
-    // Example: Assuming canGetKubewardenLinks depends on some Vuex getters being true/false
     expect(wrapper.vm.canGetKubewardenLinks).toBeTruthy(); // or .toBeFalsy(), based on your logic
   });
 
@@ -31,25 +31,19 @@ describe('ResourceTab.vue', () => {
     const wrapper = wrapperFactory({ propsData: { resource: { type: 'namespace', metadata: { name: 'default' } } } });
 
     await wrapper.vm.$nextTick();
-    wrapper.setData({
-      reports: [{
-        uid: '1', kind: 'Pod', name: 'nginx-pod', result: 'fail', severity: 'critical'
-      }]
-    });
+    wrapper.setData({ reports: [mockPolicyReport, mockClusterPolicyReport] });
 
     await wrapper.vm.$nextTick();
 
     expect(wrapper.find('.pr-tab__container').exists()).toBe(true);
     expect(wrapper.findAll('sortabletable-stub').length).toBe(1);
     expect(wrapper.vm.isNamespaceResource).toBeTruthy();
-    // Additional checks on rendered content, like table rows, based on your logic
   });
 
   it('hasNamespace returns false when namespace is absent', async() => {
     const wrapper = wrapperFactory({ propsData: { resource: { metadata: {} } } });
 
     await wrapper.vm.$nextTick();
-
     expect(wrapper.vm.hasNamespace).toBeFalsy();
   });
 

--- a/tests/unit/modules/policyReporter.spec.ts
+++ b/tests/unit/modules/policyReporter.spec.ts
@@ -1,22 +1,21 @@
 import * as policyReporterModule from '@kubewarden/modules/policyReporter.ts';
 import { KUBEWARDEN } from '@kubewarden/types';
-import { mockPolicyReport } from '../_templates_/policyReports';
+import { mockPolicyReport, mockClusterPolicyReport } from '../_templates_/policyReports';
 import { mockControllerApp } from '../_templates_/controllerApp';
 
-// Mocking lodash's isEmpty function//
 jest.mock('lodash/isEmpty', () => ({
   __esModule: true,
   default:    jest.fn().mockImplementation(data => data.length === 0),
 }));
 
-// Mocking @shell/utils/string randomStr function
 jest.mock('@shell/utils/string', () => ({ randomStr: jest.fn().mockReturnValue('randomString') }));
 
 const mockStore = {
   getters: {
-    'cluster/schemaFor':        jest.fn(),
-    'kubewarden/policyReports': [mockPolicyReport],
-    'kubewarden/controllerApp': mockControllerApp
+    'cluster/schemaFor':               jest.fn(),
+    'kubewarden/policyReports':        [mockPolicyReport],
+    'kubewarden/clusterPolicyReports': [mockClusterPolicyReport],
+    'kubewarden/controllerApp':        mockControllerApp
   },
   dispatch: jest.fn(),
 };
@@ -26,16 +25,34 @@ beforeEach(() => {
   mockStore.getters['cluster/schemaFor'].mockReturnValue(true);
 });
 
-// describe('getPolicyReports', () => {
-//   it('should fetch policy reports and update the store', async() => {
-//     mockStore.dispatch.mockResolvedValue([mockPolicyReport]); // Simulate fetching policy reports successfully
+describe('getReports', () => {
+  it('should fetch and dispatch cluster policy reports when cluster level is true', async() => {
+    // Setting up the store to return a cluster policy report
+    mockStore.dispatch.mockResolvedValue([mockClusterPolicyReport]);
+    const reports = await policyReporterModule.getReports(mockStore, true);
 
-//     const reports = await policyReporterModule.getPolicyReports(mockStore);
+    expect(reports).toEqual([mockClusterPolicyReport]);
+    expect(mockStore.dispatch).toHaveBeenCalledWith('kubewarden/updateClusterPolicyReports', mockClusterPolicyReport);
+  });
 
-//     expect(reports).toEqual([mockPolicyReport]);
-//     expect(mockStore.dispatch).toHaveBeenCalledWith('kubewarden/updatePolicyReports', mockPolicyReport);
-//   });
-// });
+  it('should fetch and dispatch policy reports when cluster level is false', async() => {
+    // Setting up the store to return a regular policy report
+    mockStore.dispatch.mockResolvedValue([mockPolicyReport]);
+    const reports = await policyReporterModule.getReports(mockStore, false);
+
+    expect(reports).toEqual([mockPolicyReport]);
+    expect(mockStore.dispatch).toHaveBeenCalledWith('kubewarden/updatePolicyReports', mockPolicyReport);
+  });
+
+  it('should fetch and dispatch policy reports when cluster level is false and resourceType is specified', async() => {
+    // Setting up the store to return a regular policy report
+    mockStore.dispatch.mockResolvedValue([mockPolicyReport]);
+    const reports = await policyReporterModule.getReports(mockStore, false, 'test.resource');
+
+    expect(reports).toEqual([mockPolicyReport]);
+    expect(mockStore.dispatch).toHaveBeenCalledWith('kubewarden/updatePolicyReports', mockPolicyReport);
+  });
+});
 
 describe('getFilteredSummary', () => {
   it('should correctly summarize policy report results', () => {

--- a/tests/unit/modules/policyReporter.spec.ts
+++ b/tests/unit/modules/policyReporter.spec.ts
@@ -56,7 +56,12 @@ describe('getReports', () => {
 
 describe('getFilteredSummary', () => {
   it('should correctly summarize policy report results', () => {
-    const resource = { type: 'pod', metadata: { name: 'mock-pod', uid: 'mock-pod-uid' } };
+    const resource = {
+      type:     'pod',
+      metadata: {
+        name: 'mock-pod', namespace: 'default', uid: 'mock-pod-uid'
+      }
+    };
     const summary = policyReporterModule.getFilteredSummary(mockStore, resource);
 
     expect(summary).toEqual({

--- a/tests/unit/modules/policyReporter.spec.ts
+++ b/tests/unit/modules/policyReporter.spec.ts
@@ -26,16 +26,16 @@ beforeEach(() => {
   mockStore.getters['cluster/schemaFor'].mockReturnValue(true);
 });
 
-describe('getPolicyReports', () => {
-  it('should fetch policy reports and update the store', async() => {
-    mockStore.dispatch.mockResolvedValue([mockPolicyReport]); // Simulate fetching policy reports successfully
+// describe('getPolicyReports', () => {
+//   it('should fetch policy reports and update the store', async() => {
+//     mockStore.dispatch.mockResolvedValue([mockPolicyReport]); // Simulate fetching policy reports successfully
 
-    const reports = await policyReporterModule.getPolicyReports(mockStore);
+//     const reports = await policyReporterModule.getPolicyReports(mockStore);
 
-    expect(reports).toEqual([mockPolicyReport]);
-    expect(mockStore.dispatch).toHaveBeenCalledWith('kubewarden/updatePolicyReports', mockPolicyReport);
-  });
-});
+//     expect(reports).toEqual([mockPolicyReport]);
+//     expect(mockStore.dispatch).toHaveBeenCalledWith('kubewarden/updatePolicyReports', mockPolicyReport);
+//   });
+// });
 
 describe('getFilteredSummary', () => {
   it('should correctly summarize policy report results', () => {


### PR DESCRIPTION
Fix #659
Fix #707 

`ClusterPolicyReports` (`clusterpolicyreports.wgpolicyk8s.io`) will now be fetched and displayed when on the `project/namespace` list view and a within Namespace compliance tab. These will not be fetched for any other resource.

- Added `clusterPolicyReports` store
- "Cluster Compliance" tab now displays in the project/namespace list view
  - This shows the `clusterpolicyreports.wgpolicyk8s.io` summary related to each Namespace
- The "Compliance" tab for Namespace's now groups reports by report kind.
- Updated unit tests

___Cluster Compliance column___

![clustercompliance-column](https://github.com/rancher/kubewarden-ui/assets/40806497/f7f609d1-952d-45bb-a4e2-fb32f3d231f2)

___Compliance tab for Namespace detail___

![clustercompliance-tab-ns](https://github.com/rancher/kubewarden-ui/assets/40806497/8eeb306e-496b-4c03-b96e-37899b5a2908)

