### PR TITLE
Add defaults chart upgrade button to dashboard

### DIFF
--- a/pkg/kubewarden/components/Dashboard/DashboardView.vue
+++ b/pkg/kubewarden/components/Dashboard/DashboardView.vue
@@ -204,7 +204,14 @@ export default {
 
     defaultsUpgradeAvailable() {
       if ( this.defaultsApp && this.controllerChart ) {
-        return this.checkUpgradeAvailable(this.defaultsApp, this.defaultsChart);
+        const defaultsAppVersion = this.defaultsApp.spec?.chart?.metadata?.appVersion;
+        const appVersionSatisfies = semver.satisfies(this.appVersion, `>${ defaultsAppVersion }`);
+
+        if ( appVersionSatisfies ) {
+          return this.checkUpgradeAvailable(this.defaultsApp, this.defaultsChart);
+        }
+
+        return null;
       }
 
       return null;
@@ -430,8 +437,9 @@ export default {
             @click.prevent="getChartRoute(controllerUpgradeAvailable)"
           >
             <i class="icon icon-upload" />
-            <span>{{ t('kubewarden.dashboard.upgrade.appUpgrade') }}: {{ controllerUpgradeAvailable.appVersion }} &nbsp;-&nbsp;</span>
-            <span>{{ t('kubewarden.dashboard.upgrade.chart') }}: {{ controllerUpgradeAvailable.version }}</span>
+            <span>{{ t('kubewarden.dashboard.upgrade.appUpgrade') }}: {{ controllerUpgradeAvailable.appVersion }}</span>
+            <span class="p-0">-</span>
+            <span>{{ t('kubewarden.dashboard.upgrade.controllerChart') }}: {{ controllerUpgradeAvailable.version }}</span>
           </div>
           <!-- Defaults upgrade -->
           <div
@@ -442,8 +450,9 @@ export default {
             @click.prevent="getChartRoute(defaultsUpgradeAvailable)"
           >
             <i class="icon icon-upload" />
-            <span>{{ t('kubewarden.dashboard.upgrade.defaultsUpgrade') }}: {{ defaultsUpgradeAvailable.appVersion }} &nbsp;-&nbsp;</span>
-            <span>{{ t('kubewarden.dashboard.upgrade.chart') }}: {{ defaultsUpgradeAvailable.version }}</span>
+            <span>{{ t('kubewarden.dashboard.upgrade.appUpgrade') }}: {{ defaultsUpgradeAvailable.appVersion }}</span>
+            <span class="p-0">-</span>
+            <span>{{ t('kubewarden.dashboard.upgrade.defaultsChart') }}: {{ defaultsUpgradeAvailable.version }}</span>
           </div>
         </div>
       </div>

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -12,10 +12,10 @@ kubewarden:
     getStarted: Get Started
     issues: Issues
     upgrade:
-      chart: Chart
       appVersion: App Version
       appUpgrade: App Upgrade
-      defaultsUpgrade: Defaults Upgrade
+      controllerChart: Controller
+      defaultsChart: Defaults
     policyReports:
       oldPolicyReportsIncompatible: 'Policy Reports are not compatible with the current version of the Kubewarden App. Please update to version v1.11.0 or newer.'
       newPolicyReportsIncompatible: 'Policy Reports are not compatible with the current version of the Kubewarden extension. Please update to version 1.4.0 or newer.'

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -15,6 +15,7 @@ kubewarden:
       chart: Chart
       appVersion: App Version
       appUpgrade: App Upgrade
+      defaultsUpgrade: Defaults Upgrade
     policyReports:
       oldPolicyReportsIncompatible: 'Policy Reports are not compatible with the current version of the Kubewarden App. Please update to version v1.11.0 or newer.'
       newPolicyReportsIncompatible: 'Policy Reports are not compatible with the current version of the Kubewarden extension. Please update to version 1.4.0 or newer.'

--- a/tests/unit/_templates_/defaultsApp.ts
+++ b/tests/unit/_templates_/defaultsApp.ts
@@ -1,4 +1,6 @@
-export default {
+import { CatalogApp } from '@kubewarden/types';
+
+export const mockDefaultsApp: CatalogApp = {
   id:         'cattle-kubewarden-system/rancher-kubewarden-defaults',
   type:       'catalog.cattle.io.app',
   apiVersion: 'catalog.cattle.io/v1',

--- a/tests/unit/components/Dashboard/DashboardView.spec.ts
+++ b/tests/unit/components/Dashboard/DashboardView.spec.ts
@@ -195,7 +195,7 @@ describe('component: DashboardView', () => {
 
     expect(upgradeButton.exists()).toBe(true);
     expect(upgradeButton.text()).toContain(
-      '%kubewarden.dashboard.upgrade.chart%: 2.0.5'
+      '%kubewarden.dashboard.upgrade.appUpgrade%: v1.9.0 - %kubewarden.dashboard.upgrade.controllerChart%: 2.0.5'
     );
   });
 
@@ -214,7 +214,8 @@ describe('component: DashboardView', () => {
 
     expect(upgradeButton.exists()).toBe(true);
     expect(upgradeButton.text()).toContain(
-      '%kubewarden.dashboard.upgrade.chart%: 1.0.0'
+      '%kubewarden.dashboard.upgrade.appUpgrade%: v1.0.0 - %kubewarden.dashboard.upgrade.controllerChart%: 1.0.0'
+
     );
   });
 
@@ -233,7 +234,7 @@ describe('component: DashboardView', () => {
 
     expect(upgradeButton.exists()).toBe(true);
     expect(upgradeButton.text()).toContain(
-      '%kubewarden.dashboard.upgrade.chart%: 1.2.3'
+      '%kubewarden.dashboard.upgrade.appUpgrade%: v1.1.1 - %kubewarden.dashboard.upgrade.controllerChart%: 1.2.3'
     );
   });
 
@@ -252,7 +253,7 @@ describe('component: DashboardView', () => {
 
     expect(upgradeButton.exists()).toBe(true);
     expect(upgradeButton.text()).toContain(
-      '%kubewarden.dashboard.upgrade.chart%: 2.0.5'
+      '%kubewarden.dashboard.upgrade.appUpgrade%: v1.9.0 - %kubewarden.dashboard.upgrade.controllerChart%: 2.0.5'
     );
     expect(wrapper.vm.controllerUpgradeAvailable).toBe(controllerCharts.versions[1]);
   });
@@ -272,7 +273,7 @@ describe('component: DashboardView', () => {
 
     expect(upgradeButton.exists()).toBe(true);
     expect(upgradeButton.text()).toContain(
-      '%kubewarden.dashboard.upgrade.chart%: 2.0.2'
+      '%kubewarden.dashboard.upgrade.appUpgrade%: v1.8.0 - %kubewarden.dashboard.upgrade.controllerChart%: 2.0.2'
     );
   });
 
@@ -291,7 +292,7 @@ describe('component: DashboardView', () => {
 
     expect(upgradeButton.exists()).toBe(true);
     expect(upgradeButton.text()).toContain(
-      '%kubewarden.dashboard.upgrade.chart%: 1.5.3'
+      '%kubewarden.dashboard.upgrade.appUpgrade%: v1.6.0 - %kubewarden.dashboard.upgrade.controllerChart%: 1.5.3'
     );
   });
 
@@ -311,7 +312,7 @@ describe('component: DashboardView', () => {
 
     expect(upgradeButton.exists()).toBe(true);
     expect(upgradeButton.text()).toContain(
-      '%kubewarden.dashboard.upgrade.chart%: 2.0.6-rc1'
+      '%kubewarden.dashboard.upgrade.appUpgrade%: v1.10.0-rc1 - %kubewarden.dashboard.upgrade.controllerChart%: 2.0.6-rc1'
     );
   });
 

--- a/tests/unit/components/Dashboard/DashboardView.spec.ts
+++ b/tests/unit/components/Dashboard/DashboardView.spec.ts
@@ -191,7 +191,7 @@ describe('component: DashboardView', () => {
       },
     });
 
-    const upgradeButton = wrapper.find('[data-testid="kw-app-upgrade-button"]');
+    const upgradeButton = wrapper.find('[data-testid="kw-app-controller-upgrade-button"]');
 
     expect(upgradeButton.exists()).toBe(true);
     expect(upgradeButton.text()).toContain(
@@ -210,7 +210,7 @@ describe('component: DashboardView', () => {
       },
     });
 
-    const upgradeButton = wrapper.find('[data-testid="kw-app-upgrade-button"]');
+    const upgradeButton = wrapper.find('[data-testid="kw-app-controller-upgrade-button"]');
 
     expect(upgradeButton.exists()).toBe(true);
     expect(upgradeButton.text()).toContain(
@@ -229,7 +229,7 @@ describe('component: DashboardView', () => {
       },
     });
 
-    const upgradeButton = wrapper.find('[data-testid="kw-app-upgrade-button"]');
+    const upgradeButton = wrapper.find('[data-testid="kw-app-controller-upgrade-button"]');
 
     expect(upgradeButton.exists()).toBe(true);
     expect(upgradeButton.text()).toContain(
@@ -248,13 +248,13 @@ describe('component: DashboardView', () => {
       },
     });
 
-    const upgradeButton = wrapper.find('[data-testid="kw-app-upgrade-button"]');
+    const upgradeButton = wrapper.find('[data-testid="kw-app-controller-upgrade-button"]');
 
     expect(upgradeButton.exists()).toBe(true);
     expect(upgradeButton.text()).toContain(
       '%kubewarden.dashboard.upgrade.chart%: 2.0.5'
     );
-    expect(wrapper.vm.upgradeAvailable).toBe(controllerCharts.versions[1]);
+    expect(wrapper.vm.controllerUpgradeAvailable).toBe(controllerCharts.versions[1]);
   });
 
   it('calculates the correct chart for multiple appVersions with chart PATCH available', () => {
@@ -268,7 +268,7 @@ describe('component: DashboardView', () => {
       },
     });
 
-    const upgradeButton = wrapper.find('[data-testid="kw-app-upgrade-button"]');
+    const upgradeButton = wrapper.find('[data-testid="kw-app-controller-upgrade-button"]');
 
     expect(upgradeButton.exists()).toBe(true);
     expect(upgradeButton.text()).toContain(
@@ -287,7 +287,7 @@ describe('component: DashboardView', () => {
       },
     });
 
-    const upgradeButton = wrapper.find('[data-testid="kw-app-upgrade-button"]');
+    const upgradeButton = wrapper.find('[data-testid="kw-app-controller-upgrade-button"]');
 
     expect(upgradeButton.exists()).toBe(true);
     expect(upgradeButton.text()).toContain(
@@ -307,7 +307,7 @@ describe('component: DashboardView', () => {
       },
     });
 
-    const upgradeButton = wrapper.find('[data-testid="kw-app-upgrade-button"]');
+    const upgradeButton = wrapper.find('[data-testid="kw-app-controller-upgrade-button"]');
 
     expect(upgradeButton.exists()).toBe(true);
     expect(upgradeButton.text()).toContain(
@@ -327,7 +327,7 @@ describe('component: DashboardView', () => {
       },
     });
 
-    const upgradeButton = wrapper.find('[data-testid="kw-app-upgrade-button"]');
+    const upgradeButton = wrapper.find('[data-testid="kw-app-controller-upgrade-button"]');
 
     expect(upgradeButton.exists()).toBe(false);
   });


### PR DESCRIPTION
Fix #655 
Fix #700 

This adds a upgrade button for the `kubewarden-defaults` chart on the Dashboard view. Refactored a few things to reuse the functions used to determine if an upgrade is available for the controller for a more agnostic approach. Also fixed the alignment of the badges.

__With upgradable controller and defaults chart__

![kw-dashboard-upgrades](https://github.com/rancher/kubewarden-ui/assets/40806497/9763a407-2ead-480f-81b7-b944df56ba56)

__With only upgradable defaults__

![kw-defaults-upgrades](https://github.com/rancher/kubewarden-ui/assets/40806497/dc971c40-b09e-44ed-a150-43c9ac43ebcb)
