### PR TITLE
Remove rejected github actions

### DIFF
--- a/.github/workflows/build-extension-charts.yml
+++ b/.github/workflows/build-extension-charts.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Helm
         uses: azure/setup-helm@v4
         with:
-          version: v3.8.0
+          version: v3.14.4
 
       - name: Setup Nodejs and npm
         uses: actions/setup-node@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -70,6 +70,7 @@ on:
 env:
   # Github -> Secrets and variables -> Actions -> New repository variable
   KUBEWARDEN: ${{ inputs.kubewarden || 'rc' }}
+  K3D_VERSION: # 'v5.6.3' - optionally pin version
   K3S_VERSION: ${{ inputs.k3s || 'v1.27.12-k3s1' }}
   K3D_CLUSTER_NAME: ${{ github.repository_owner }}-${{ github.event.repository.name }}-runner
   # First value after the && must be truthy. Otherwise, the value after the || will always be returned
@@ -145,10 +146,9 @@ jobs:
     # ==================================================================================================
     # Create k3d cluster and install rancher
     - name: "Create kubernetes cluster"
-      uses: AbsaOSS/k3d-action@v2.4.0
-      with:
-        cluster-name: ${{ env.K3D_CLUSTER_NAME }}
-        args: "--agents 1 --image rancher/k3s:${{ env.K3S_VERSION }}"
+      run: |
+        TAG=${{ env.K3D_VERSION }} sudo --preserve-env=TAG k3d-install
+        k3d cluster create ${{ env.K3D_CLUSTER_NAME }} --agents 1 --image rancher/k3s:${{ env.K3S_VERSION }}
 
     - name: Install Rancher
       run: |
@@ -233,21 +233,16 @@ jobs:
     # QASE Integration
 
     # Delete previous run if we have new one
-    - name: Find previous QASE run
-      if: ${{ env.QASE == 'true' && !cancelled() && github.run_attempt > 1 }}
-      uses: dawidd6/action-download-artifact@v3
-      with:
-        name: QASE_RUN_ID-${{ matrix.rancher }}-${{ matrix.mode }}
-        run_id: ${{ github.run_id }}
-        if_no_artifact_found: ignore # maybe first attempt was canceled
-        workflow_conclusion: completed
-        allow_forks: false
-
     - name: Delete previous QASE run
-      if: ${{ env.QASE == 'true' && !cancelled() && hashFiles('QASE_RUN_ID.txt') != '' }}
+      if: ${{ env.QASE == 'true' && !cancelled() && github.run_attempt > 1 }}
       run: |
-        qid=$(< QASE_RUN_ID.txt)
-        curl --request DELETE --url https://api.qase.io/v1/run/KUBEWARDEN/$qid --header 'Token: ${{secrets.QASE_APITOKEN_MKRAVEC}}' --header 'accept: application/json'
+        gh run download ${{ github.run_id }} -n QASE_RUN_ID-${{ matrix.rancher }}-${{ matrix.mode }} ||:
+        if [ -f QASE_RUN_ID.txt ]; then
+          qid=$(< QASE_RUN_ID.txt)
+          curl --request DELETE --url https://api.qase.io/v1/run/KUBEWARDEN/$qid --header 'Token: ${{secrets.QASE_APITOKEN_MKRAVEC}}' --header 'accept: application/json'
+        fi
+      env:
+        GH_TOKEN: ${{ github.token }}
 
     # Delete current run if it was canceled
     - name: Find current QASE run

--- a/tests/e2e/50-policyreports.spec.ts
+++ b/tests/e2e/50-policyreports.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from './rancher/rancher-test'
 import { Policy, ClusterAdmissionPoliciesPage } from './pages/policies.page'
 import { PolicyReporterPage } from './pages/policyreporter.page'
+import { RancherUI } from './components/rancher-ui'
 
 const testNs = 'audit-unsafe-ns'
 const testPod = 'audit-pod-privileged'
@@ -76,7 +77,10 @@ test('Check reports on resources details page', async({ ui, nav }) => {
 
   // Check namespace
   await nav.explorer('Cluster', 'Projects/Namespaces')
-  await expect(ui.tableRow(testNs).column('Compliance').locator('div.bg-error')).toHaveText('2')
+  // https://github.com/rancher/kubewarden-ui/issues/720
+  if (RancherUI.isVersion('>=2.8-0')) {
+    await expect(ui.tableRow(testNs).column('Compliance').locator('div.bg-error')).toHaveText('2')
+  }
   await ui.tableRow(testNs).open()
   await ui.tab('Compliance').click()
   await expect(ui.tableRow({ Name: testPod, Policy: policyPrivpod }).column('Status')).toHaveText('fail')

--- a/tests/e2e/rancher/rancher-apps.page.ts
+++ b/tests/e2e/rancher/rancher-apps.page.ts
@@ -62,12 +62,14 @@ export class RancherAppsPage extends BasePage {
       }
       await this.ui.button('Create').click()
 
-      // Transitions: Active ?> In Progress ?> [Active|InProgress]
+      // Transitions: Active ?> In Progress ?> [Active|InProgress] - https://github.com/rancher/dashboard/issues/10079
       const repo = await this.ui.tableRow(name).waitFor()
       // Wait out first Active state
       await this.page.waitForTimeout(1000)
       // Refresh for occasional freeze In Progress
       await repo.action('Refresh')
+      // Prevent matching Active before refresh is processed
+      await repo.toHaveState('In Progress')
       await repo.toBeActive()
     }
 


### PR DESCRIPTION
Rancher plans to restrict github actions, replace [rejected actions](https://github.com/rancher/security-team/blob/main/docs/rancher-gha-standards.md#previously-rejected).

- Remove AbsaOSS/k3d-action
- Remove dawidd6/action-download-artifact@v3
- Stabilize adding repository
- update helm version in azure/setup-helm@v4
- skip namespace report check on rancher < 2.8