### PR TITLE
Initial defaults chart version tied to controller appVersion

### DIFF
--- a/pkg/kubewarden/modules/kubewardenController.ts
+++ b/pkg/kubewarden/modules/kubewardenController.ts
@@ -6,7 +6,7 @@ import { CATALOG as CATALOG_ANNOTATIONS } from '@shell/config/labels-annotations
 import { KUBEWARDEN_APPS, CatalogApp } from '../types';
 
 export const fetchControllerApp = async(store: Store<any>): Promise<CatalogApp | undefined> => {
-  if ( store.getters['cluster/schemaFor'](CATALOG.APP) ) {
+  if ( store?.getters['cluster/schemaFor'](CATALOG.APP) ) {
     const allApps: CatalogApp[] = await store.dispatch('cluster/findAll', { type: CATALOG.APP });
 
     const controllerApp = allApps?.find(app => (

--- a/tests/unit/components/Dashboard/DashboardView.spec.ts
+++ b/tests/unit/components/Dashboard/DashboardView.spec.ts
@@ -1,6 +1,8 @@
 import { shallowMount } from '@vue/test-utils';
 import { describe, expect, it } from '@jest/globals';
 
+import { SHOW_PRE_RELEASE } from '@shell/store/prefs';
+
 import DashboardView from '@kubewarden/components/Dashboard/DashboardView.vue';
 import DefaultsBanner from '@kubewarden/components/DefaultsBanner';
 import ConsumptionGauge from '@shell/components/ConsumptionGauge';
@@ -299,6 +301,14 @@ describe('component: DashboardView', () => {
   it('calculates the correct chart for pre-release versions', () => {
     const oldControllerApp = { spec: { chart: { metadata: { version: '2.0.5', appVersion: 'v1.9.0' } } } };
 
+    commonMocks.$store.getters['prefs/get'].mockImplementation((key) => {
+      if ( key === SHOW_PRE_RELEASE ) {
+        return true;
+      }
+
+      return undefined;
+    });
+
     const wrapper = createWrapper({
       computed: {
         controllerApp:   () => oldControllerApp,
@@ -318,6 +328,14 @@ describe('component: DashboardView', () => {
 
   it('does not show pre-release upgrades when preference is false', () => {
     const oldControllerApp = { spec: { chart: { metadata: { version: '2.0.5', appVersion: 'v1.9.0' } } } };
+
+    commonMocks.$store.getters['prefs/get'].mockImplementation((key) => {
+      if ( key === SHOW_PRE_RELEASE ) {
+        return false;
+      }
+
+      return undefined;
+    });
 
     const wrapper = createWrapper({
       computed: {


### PR DESCRIPTION
Fix #721 

The kubewarden-defaults chart install banner was not tied to the installed kubewarden-controller `appVersion`, in order to make this work I restructured the methods used in the Dashboard component into utilities and added a method for finding the compatible defaults chart based on the installed controller's `appVersion`.


https://github.com/rancher/kubewarden-ui/assets/40806497/39ccf533-9927-4966-ae42-3840ca730812

