### PR TITLE
Fix qase run id parsing

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -248,7 +248,7 @@ jobs:
     - name: Find current QASE run
       if: ${{ env.QASE == 'true' && always() && hashFiles('tests/qase-report.log') != '' }}
       run: |
-        grep -Eo 'qase: Using run [0-9]+' tests/qase-report.log | awk '{print $NF}' | tee QASE_RUN_ID.txt
+        grep -Eom1 'qase:.* [Rr]un.* [0-9]+' tests/qase-report.log | awk '{print $NF}' | tee QASE_RUN_ID.txt
 
     - name: Delete current QASE run if job was canceled
       if: ${{ env.QASE == 'true' && cancelled() && hashFiles('tests/qase-report.log') != '' }}


### PR DESCRIPTION
Output that we parse changed from
```
# from
qase: Using run 123

# to (depends on debug mode)
qase: Test run created: 338
qase: Run 338
```

Follow-up for https://github.com/rancher/kubewarden-ui/pull/726