### PR TITLE
Bump max kube version to match 2.9.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": false,
   "scripts": {
     "build-pkg": "./node_modules/@rancher/shell/scripts/build-pkg.sh",

--- a/pkg/kubewarden/package.json
+++ b/pkg/kubewarden/package.json
@@ -2,11 +2,11 @@
   "name": "kubewarden",
   "description": "Kubewarden extension for Rancher Manager",
   "icon": "https://raw.githubusercontent.com/kubewarden/ui/main/pkg/kubewarden/assets/icon-kubewarden.svg",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": false,
   "rancher": {
     "annotations": {
-      "catalog.cattle.io/kube-version": ">= v1.16.0-0 < v1.29.0-0",
+      "catalog.cattle.io/kube-version": ">= v1.16.0-0 < v1.31.0-0",
       "catalog.cattle.io/rancher-version": ">= 2.7.5-0"
     }
   },


### PR DESCRIPTION
- Rancher 2.9.0 _should_ support kube 1.29 and 1.30
- Bump max supported kube version to under 1.31