### PR TITLE
Fix version checks

### DIFF
--- a/tests/e2e/50-policyreports.spec.ts
+++ b/tests/e2e/50-policyreports.spec.ts
@@ -78,7 +78,7 @@ test('Check reports on resources details page', async({ ui, nav }) => {
   // Check namespace
   await nav.explorer('Cluster', 'Projects/Namespaces')
   // https://github.com/rancher/kubewarden-ui/issues/720
-  if (RancherUI.isVersion('>=2.8-0')) {
+  if (RancherUI.isVersion('>=2.8')) {
     await expect(ui.tableRow(testNs).column('Compliance').locator('div.bg-error')).toHaveText('2')
   }
   await ui.tableRow(testNs).open()

--- a/tests/e2e/components/kubectl-shell.ts
+++ b/tests/e2e/components/kubectl-shell.ts
@@ -58,7 +58,7 @@ export class Shell {
       switch (runner) {
         case 'nodejs': return this.runExec(cmd, options)
         case 'rancher':
-          if (RancherUI.isVersion('>=2.9-0')) {
+          if (RancherUI.isVersion('>=2.9')) {
             return await this.runCanvas(cmd, options)
           } else {
             return await this.runXterm(cmd, options)

--- a/tests/e2e/components/rancher-ui.ts
+++ b/tests/e2e/components/rancher-ui.ts
@@ -173,6 +173,7 @@ export class RancherUI {
 
   static isVersion(query: string|Range): boolean {
     if (!process.env.RANCHER_VERSION) throw new Error('RANCHER_VERSION not set')
-    return semver.satisfies(process.env.RANCHER_VERSION, query)
+    if (!semver.validRange(query)) throw new Error(`Invalid range: ${query}`)
+    return semver.satisfies(process.env.RANCHER_VERSION, query, { includePrerelease: true })
   }
 }


### PR DESCRIPTION
- string `>=2.X-0` used for version check is not valid range
- `includePrerelease`: by default range `>1.2.3-alpha.3` would not match `3.4.5-alpha.9`
https://docs.npmjs.com/cli/v6/using-npm/semver#prerelease-tags