### PR TITLE
Cancel previous job for the same PR

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -68,6 +68,10 @@ on:
   schedule:
     - cron: "0 21 * * *"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   # Github -> Secrets and variables -> Actions -> New repository variable
   KUBEWARDEN: ${{ inputs.kubewarden || 'rc' }}


### PR DESCRIPTION
Dependabot schedules new job for every synchronization but does not cancel previous one.
This leads to a lot of duplicit jobs in the queue.