### PR TITLE
Show More button is not always visible

### DIFF
--- a/tests/e2e/rancher/rancher-apps.page.ts
+++ b/tests/e2e/rancher/rancher-apps.page.ts
@@ -122,9 +122,14 @@ export class RancherAppsPage extends BasePage {
 
         if (chart.version) {
           const versionPane = this.page.getByRole('heading', { name: 'Chart Versions', exact: true }).locator('..')
-          await versionPane.getByText('Show More', { exact: true }).click()
-          // Active version is bold text, not active are links
-          await versionPane.getByText(chart.version, { exact: true }).click()
+          const showMore = versionPane.getByText('Show More', { exact: true })
+          const chartVersion = versionPane.getByText(chart.version, { exact: true })
+
+          // Expand versions is necessary
+          await expect(chartVersion.or(showMore)).toBeVisible()
+          if (await showMore.isVisible()) await showMore.click()
+          // Active version has bold text, not active are links
+          await chartVersion.click()
           await expect(versionPane.locator(`b:text-is("${chart.version}")`)).toBeVisible()
         }
         await this.installBtn.click()


### PR DESCRIPTION
Older charts were removed and `Show More` button is not visible now.
https://github.com/rancher/partner-charts/pull/1025

Screenshot:
![Screenshot from 2024-06-11 13-14-35](https://github.com/rancher/kubewarden-ui/assets/538604/f2d0d517-5bb5-48c3-8763-ca1c5806694e)

