### PR TITLE
Extend upgrade timeout and add KW 1.13.0

### DIFF
--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -16,11 +16,12 @@ expect(MODE).toMatch(/^(base|fleet|upgrade)$/)
 
 // Known Kubewarden versions for upgrade test, start at [0]
 const upMap: AppVersion[] = [
-  { app: 'v1.8.0', controller: '2.0.0', crds: '1.4.2', defaults: '1.8.0' },
+  // { app: 'v1.8.0', controller: '2.0.0', crds: '1.4.2', defaults: '1.8.0' },
   { app: 'v1.9.0', controller: '2.0.5', crds: '1.4.4', defaults: '1.9.2' },
   { app: 'v1.10.0', controller: '2.0.8', crds: '1.4.5', defaults: '1.9.3' },
   { app: 'v1.11.0', controller: '2.0.10', crds: '1.4.6', defaults: '1.9.4' },
   { app: 'v1.12.0', controller: '2.0.11', crds: '1.5.0', defaults: '2.0.0' },
+  { app: 'v1.13.0', controller: '2.1.0', crds: '1.5.1', defaults: '2.0.3' },
 ]
 
 test('Initial rancher setup', async({ page, ui, nav }) => {

--- a/tests/e2e/pages/kubewarden.page.ts
+++ b/tests/e2e/pages/kubewarden.page.ts
@@ -172,7 +172,7 @@ export class KubewardenPage extends BasePage {
       if (from?.controller || to?.controller) {
         await expect(apps.stepTitle).toContainText(`${from?.controller || ''} > ${to?.controller || ''}`)
       }
-      await apps.updateApp('rancher-kubewarden-controller', { navigate: false, timeout: 120_000 })
+      await apps.updateApp('rancher-kubewarden-controller', { navigate: false, timeout: 4 * 60_000 })
       await shell.waitPods()
 
       // Defaults upgrade


### PR DESCRIPTION
- fix controller upgrade failing on 2m timeout:
https://github.com/rancher/kubewarden-ui/actions/runs/9554836578/job/26361099254
- add upgrade path to Kubewarden  1.13.0