### PR TITLE
Use images from helm charts in fleet test

### DIFF
--- a/tests/e2e/fleet/cert-manager/fleet.yaml
+++ b/tests/e2e/fleet/cert-manager/fleet.yaml
@@ -3,7 +3,7 @@ defaultNamespace: cert-manager
 helm:
   releaseName: cert-manager
   chart: cert-manager
-  version: 1.13.2
+  version: 1.15.0
   repo: https://charts.jetstack.io
   values:
     installCRDs: true

--- a/tests/e2e/fleet/kubewarden/controller/fleet.yaml
+++ b/tests/e2e/fleet/kubewarden/controller/fleet.yaml
@@ -9,8 +9,8 @@ helm:
   # valuesFiles:
   #   - values.yaml
   values:
-    image:
-      tag: latest
+    # image:
+    #   tag: latest
     auditScanner:
       policyReporter: true
       cronJob:

--- a/tests/e2e/fleet/kubewarden/servers/default/fleet.yaml
+++ b/tests/e2e/fleet/kubewarden/servers/default/fleet.yaml
@@ -11,9 +11,9 @@ helm:
   values:
     recommendedPolicies:
       enabled: true
-    policyServer:
-      image:
-        tag: latest
+    # policyServer:
+    #   image:
+    #     tag: latest
 
 dependsOn:
   - selector:


### PR DESCRIPTION
Should fix fleet tests: https://github.com/rancher/kubewarden-ui/actions/runs/9572273187/job/26403740391