### PR TITLE
Fix empty row when adding an event listener

### DIFF
--- a/pkg/kubewarden/components/Policies/PolicyTable.vue
+++ b/pkg/kubewarden/components/Policies/PolicyTable.vue
@@ -1,5 +1,4 @@
 <script>
-import isEmpty from 'lodash/isEmpty';
 import semver from 'semver';
 
 import { SCHEMA } from '@shell/config/types';

--- a/pkg/kubewarden/components/SortableTableWrapper.vue
+++ b/pkg/kubewarden/components/SortableTableWrapper.vue
@@ -40,7 +40,7 @@ export default {
           table.querySelectorAll('tbody tr').forEach((row, index) => {
             const listener = () => this.$emit('selectRow', this.rows[index]);
 
-            row.addEventListener('click', listener);
+            row?.addEventListener('click', listener);
             this.listeners.push({ row, listener });
           });
         }
@@ -48,7 +48,7 @@ export default {
     },
 
     removeRowClickListener() {
-      this.listeners?.forEach(({ row, listener }) => row.removeEventListener('click', listener));
+      this.listeners?.forEach(({ row, listener }) => row?.removeEventListener('click', listener));
       this.listeners = [];
     }
   }


### PR DESCRIPTION
The SortableTableWrapper is [causing failures ](https://github.com/rancher/dashboard/actions/runs/9616946656/job/26527606192?pr=11286#step:4:4917)on the tests within the Rancher Dashboard repo, this should account for a null row to no add an event listener when the row doesn't exist.