### PR TITLE
Allow to select table columns/rows by index

### DIFF
--- a/tests/e2e/components/rancher-ui.ts
+++ b/tests/e2e/components/rancher-ui.ts
@@ -80,7 +80,7 @@ export class RancherUI {
 
   // ==================================================================================================
   // Table Handler
-  tableRow(arg: string | RegExp | { [key: string]: string | RegExp }, options?: { group?: string }): TableRow {
+  tableRow(arg: number | string | RegExp | { [key: string]: string | RegExp }, options?: { group?: string }): TableRow {
     return new TableRow(this, arg, options)
   }
 

--- a/tests/e2e/components/table-row.ts
+++ b/tests/e2e/components/table-row.ts
@@ -33,7 +33,7 @@ export class TableRow {
      * @param arg:object row value under selected column(s) {column1: "value", "column 2": "value2"}
      * @param options.group When there are multiple tbodies filter by group-tab (Project, Namespace, ..)
      */
-    constructor(private readonly ui: RancherUI, arg: string | RegExp | { [key: string]: string | RegExp }, options?: { group?: string }) {
+    constructor(private readonly ui: RancherUI, arg: number | string | RegExp | { [key: string]: string | RegExp }, options?: { group?: string }) {
       let table = ui.page.locator('table.sortable-table > tbody:visible')
 
       // Filter by project / namespace
@@ -44,7 +44,10 @@ export class TableRow {
       let rows = table.locator('tr.main-row')
 
       // Filter by argument
-      if (typeof arg === 'string' || arg instanceof RegExp) {
+      if (typeof arg === 'number') {
+        this.strval = arg.toString()
+        rows = rows.nth(arg)
+      } else if (typeof arg === 'string' || arg instanceof RegExp) {
         this.strval = arg.toString()
         rows = rows.filter({ has: this.findCell('Name', arg) })
       } else if (typeof arg === 'object') {

--- a/tests/e2e/components/table-row.ts
+++ b/tests/e2e/components/table-row.ts
@@ -9,21 +9,26 @@ export class TableRow {
     readonly strval: string
 
     /**
-     * Filter cells for requested column. Has to be applied to this.row (tr)
-     * Based on column counting - find th with requested name and count th preceeding siblings. Use this count as td index.
-     * @param name exact name of the table column
-     * @returns XPath locator for table cells under column. Returns first column if not found
+     * Filter rows by column header or index. Has to be applied to this.row (tr)
+     * @param index Index of the column starting from 0
+     * @param name Column header name, you can provide alternative names (State|Status)
+     * @returns XPath locator for table cells under column
      */
-    private findColumn(...names: string[]): Locator {
-      // Compare text of column header with parameter(s)
-      const filter = names.map(str => `normalize-space(.)="${str}"`).join(' or ')
-      // Returns: xpath=td[count(ancestor::table[1]/thead/tr/th[normalize-space(.)="Name"]/preceding-sibling::th)+1]
-      return this.ui.page.locator(`xpath=td[count(ancestor::table[1]/thead/tr/th[${filter}]/preceding-sibling::th)+1]`)
-    }
+    private getByColumn(...args: (number|string)[]): Locator {
+      if (typeof args[0] === 'number') {
+        return this.ui.page.locator('td').nth(args[0])
+      } else {
+        // Compare text of column header with requested name(s)
+        const filter = args.map(str => `normalize-space(.)="${str}"`).join(' or ')
 
-    // Locator to filter rows by [column & name] value. Has to be applied to this.row (tr)
-    private findCell(columnName: string, name: string | RegExp): Locator {
-      return this.findColumn(columnName).filter({ has: this.ui.page.getByText(name, { exact: true }) })
+        // Make sure column with header exists in the table
+        const check = `ancestor::table[1]/thead/tr/th[${filter}]`
+        // Get column index - find th with requested name and count th preceeding siblings. Use this count as td index.
+        const index = `count(ancestor::table[1]/thead/tr/th[${filter}]/preceding-sibling::th)+1`
+
+        // Returns: xpath=td[count(ancestor::table[1]/thead/tr/th[normalize-space(.)="Name"]/preceding-sibling::th)+1]
+        return this.ui.page.locator(`xpath=td[${check}][${index}]`)
+      }
     }
 
     /**
@@ -34,27 +39,26 @@ export class TableRow {
      * @param options.group When there are multiple tbodies filter by group-tab (Project, Namespace, ..)
      */
     constructor(private readonly ui: RancherUI, arg: number | string | RegExp | { [key: string]: string | RegExp }, options?: { group?: string }) {
+      // Table filter by project / namespace
       let table = ui.page.locator('table.sortable-table > tbody:visible')
-
-      // Filter by project / namespace
       if (options?.group) {
         const groupRegex = new RegExp(`^((Project|Namespace): )?${options.group}`)
         table = table.filter({ has: ui.page.getByRole('cell', { name: groupRegex }) })
       }
-      let rows = table.locator('tr.main-row')
 
-      // Filter by argument
+      // Row filter by argument
+      let rows = table.locator('tr.main-row')
       if (typeof arg === 'number') {
         this.strval = arg.toString()
         rows = rows.nth(arg)
       } else if (typeof arg === 'string' || arg instanceof RegExp) {
         this.strval = arg.toString()
-        rows = rows.filter({ has: this.findCell('Name', arg) })
+        rows = rows.filter({ has: this.getByColumn('Name').getByText(arg, { exact: true }) })
       } else if (typeof arg === 'object') {
         this.strval = Object.keys(arg).map(key => `${key}: ${arg[key]}`).join(',')
         for (const colName in arg) {
           const colValue = arg[colName]
-          rows = rows.filter({ has: this.findCell(colName, colValue) })
+          rows = rows.filter({ has: this.getByColumn(colName).getByText(colValue, { exact: true }) })
         }
       }
 
@@ -71,8 +75,10 @@ export class TableRow {
      * @param names header(s) of the column, you can provide alternative names (State|Status)
      * @returns table cell (td) that is under requested column. Returns first cell if no match was found
      */
-    column(...names: string[]): Locator {
-      return this.row.locator(this.findColumn(...names))
+    column(index: number): Locator;
+    column(name: string, ...altNames: string[]): Locator;
+    column(...args: (number|string)[]): Locator {
+      return this.row.locator(this.getByColumn(...args))
     }
 
     /**


### PR DESCRIPTION
- allow to select rows / columns by index
- fail if column with requested name does not exist (instead of returning first one)
Fixes issue where code like `tableRow(1).column('does-not-exist').click()` would pass.