### PR TITLE
Remove readme step from policy creation - add slide-in for readme

### DIFF
--- a/pkg/kubewarden/chart/kubewarden/admission/index.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/index.vue
@@ -112,26 +112,17 @@ export default {
 <template>
   <div>
     <Tab name="general" :label="t('kubewarden.policyConfig.tabs.general')" :weight="99">
-      <General v-model="chartValues" data-testid="kw-policy-config-general-tab" :mode="mode" :target-namespace="targetNamespace" />
+      <General
+        v-model="chartValues"
+        data-testid="kw-policy-config-general-tab"
+        :mode="mode"
+        :target-namespace="targetNamespace"
+        :is-custom="isCustom"
+      />
     </Tab>
-    <Tab name="rules" :label="t('kubewarden.policyConfig.tabs.rules')" :weight="98">
-      <Rules v-model="chartValues" data-testid="kw-policy-config-rules-tab" :mode="mode" />
-    </Tab>
-
-    <template v-if="isGlobal">
-      <Tab name="namespaceSelector" :label="t('kubewarden.policyConfig.tabs.namespaceSelector')" :weight="97">
-        <NamespaceSelector v-model="chartValues.policy.spec.namespaceSelector" data-testid="kw-policy-config-ns-selector-tab" :mode="mode" />
-      </Tab>
-    </template>
-
-    <template v-if="showContextAware">
-      <Tab name="contextAware" :label="t('kubewarden.policyConfig.tabs.contextAware')" :weight="97">
-        <ContextAware v-model="chartValues" data-testid="kw-policy-config-context-tab" :mode="mode" />
-      </Tab>
-    </template>
 
     <template v-if="showSettings">
-      <Tab name="settings" :label="t('kubewarden.policyConfig.tabs.settings')" :weight="95">
+      <Tab name="settings" :label="t('kubewarden.policyConfig.tabs.settings')" :weight="98">
         <Settings
           v-model="chartValues"
           data-testid="kw-policy-config-settings-tab"
@@ -142,7 +133,7 @@ export default {
 
     <!-- Values as questions -->
     <template v-if="hasQuestions">
-      <Tab name="Settings" label="Settings" :weight="95">
+      <Tab name="Settings" label="Settings" :weight="98">
         <Questions
           v-model="chartValues.policy.spec.settings"
           data-testid="kw-policy-config-questions-tab"
@@ -153,5 +144,21 @@ export default {
         />
       </Tab>
     </template>
+
+    <template v-if="isGlobal">
+      <Tab name="namespaceSelector" :label="t('kubewarden.policyConfig.tabs.namespaceSelector')" :weight="97">
+        <NamespaceSelector v-model="chartValues.policy.spec.namespaceSelector" data-testid="kw-policy-config-ns-selector-tab" :mode="mode" />
+      </Tab>
+    </template>
+
+    <template v-if="showContextAware">
+      <Tab name="contextAware" :label="t('kubewarden.policyConfig.tabs.contextAware')" :weight="96">
+        <ContextAware v-model="chartValues" data-testid="kw-policy-config-context-tab" :mode="mode" />
+      </Tab>
+    </template>
+
+    <Tab name="rules" :label="t('kubewarden.policyConfig.tabs.rules')" :weight="95">
+      <Rules v-model="chartValues" data-testid="kw-policy-config-rules-tab" :mode="mode" />
+    </Tab>
   </div>
 </template>

--- a/pkg/kubewarden/components/Policies/Create.vue
+++ b/pkg/kubewarden/components/Policies/Create.vue
@@ -506,11 +506,11 @@ export default ({
         <div class="banner__title">
           <h2>{{ bannerTitle }}</h2>
           <template v-if="!customPolicy">
-            <p class="banner__short-description mb-10">
+            <p class="banner__short-description">
               {{ shortDescription }}
             </p>
-            <button class="btn btn-sm role-link" @click="showReadme">
-              {{ t('kubewarden.policyConfig.description.showMore') }}
+            <button class="btn btn-sm role-link banner__readme-button" @click="showReadme">
+              {{ t('kubewarden.policyConfig.description.showReadme') }}
             </button>
           </template>
         </div>
@@ -642,6 +642,10 @@ $color: var(--body-text) !important;
     margin-bottom: 10px;
     border-bottom: 1px solid var(--border);
     min-height: 60px;
+  }
+
+  &__readme-button {
+    padding: 0 7px 0 0;
   }
 }
 </style>

--- a/pkg/kubewarden/components/Policies/Create.vue
+++ b/pkg/kubewarden/components/Policies/Create.vue
@@ -14,7 +14,6 @@ import { Banner } from '@components/Banner';
 
 import AsyncButton from '@shell/components/AsyncButton';
 import Loading from '@shell/components/Loading';
-import ChartReadme from '@shell/components/ChartReadme';
 import Wizard from '@shell/components/Wizard';
 
 import {
@@ -29,6 +28,7 @@ import { handleGrowl } from '../../utils/handle-growl';
 
 import { DATA_ANNOTATIONS } from '../../types/artifacthub';
 import PolicyTable from './PolicyTable';
+import PolicyReadmePanel from './PolicyReadmePanel';
 import Values from './Values';
 
 export default ({
@@ -50,9 +50,9 @@ export default ({
     AsyncButton,
     Banner,
     Loading,
-    ChartReadme,
     Wizard,
     PolicyTable,
+    PolicyReadmePanel,
     Values
   },
 
@@ -75,6 +75,7 @@ export default ({
     return {
       errors:            [],
       bannerTitle:       null,
+      shortDescription:  null,
       loadingPackages:   false,
       packages:          null,
       repository:        null,
@@ -100,20 +101,12 @@ export default ({
         showSteps: false,
         weight:    99
       },
-      stepReadme: {
-        hidden:    false,
-        name:      'readme',
-        label:     'Readme',
-        ready:     true,
-        showSteps: false,
-        weight:    98
-      },
       stepValues: {
         name:      'values',
         label:     'Values',
         ready:     true,
         showSteps: false,
-        weight:    97
+        weight:    98
       },
     };
   },
@@ -192,7 +185,6 @@ export default ({
 
       steps.push(
         this.stepPolicies,
-        this.stepReadme,
         this.stepValues
       );
 
@@ -402,6 +394,8 @@ export default ({
       if ( packageQuestions ) {
         set(this.chartValues, 'questions', packageQuestions);
       }
+
+      this.shortDescription = policyDetails?.description;
     },
 
     reset(event) {
@@ -410,6 +404,7 @@ export default ({
           const initialState = [
             'errors',
             'bannerTitle',
+            'shortDescription',
             'type',
             'typeModule',
             'version',
@@ -421,7 +416,7 @@ export default ({
           });
 
           this.stepPolicies.ready = false;
-          this.stepReadme.hidden = false;
+          this.stepValues.hidden = false;
 
           this.chartValues = {
             policy:    {},
@@ -437,10 +432,8 @@ export default ({
       this.type = type;
 
       if ( this.customPolicy ) {
-        this.stepReadme.hidden = true;
         this.$set(this, 'hasCustomPolicy', true);
       } else {
-        !!this.packageValues ? this.stepReadme.hidden = false : this.stepReadme.hidden = true;
         this.$set(this, 'hasCustomPolicy', false);
       }
 
@@ -449,6 +442,10 @@ export default ({
       this.$refs.wizard.next();
       this.bannerTitle = this.customPolicy ? 'Custom Policy' : type?.display_name;
       this.typeModule = this.chartValues?.policy?.spec.module;
+    },
+
+    showReadme() {
+      this.$refs.readmePanel.show();
     }
   }
 
@@ -505,22 +502,18 @@ export default ({
         />
       </template>
 
-      <template #readme>
-        <h2 class="banner-title">
-          {{ bannerTitle }}
-        </h2>
-        <ChartReadme
-          v-if="packageValues && packageValues.readme"
-          data-testid="kw-policy-create-readme"
-          :version-info="packageValues"
-          class="mb-20"
-        />
-      </template>
-
       <template #values>
-        <h2 class="banner-title">
-          {{ bannerTitle }}
-        </h2>
+        <div class="banner__title">
+          <h2>{{ bannerTitle }}</h2>
+          <template v-if="!customPolicy">
+            <p class="banner__short-description mb-10">
+              {{ shortDescription }}
+            </p>
+            <button class="btn btn-sm role-link" @click="showReadme">
+              {{ t('kubewarden.policyConfig.description.showMore') }}
+            </button>
+          </template>
+        </div>
         <Values
           :value="value"
           :chart-values="chartValues"
@@ -541,6 +534,13 @@ export default ({
         />
       </template>
     </Wizard>
+
+    <template v-if="packageValues && !customPolicy">
+      <PolicyReadmePanel
+        ref="readmePanel"
+        :package-values="packageValues"
+      />
+    </template>
   </div>
 </template>
 
@@ -633,12 +633,15 @@ $color: var(--body-text) !important;
 .wizard {
   position: relative;
   height: 100%;
+  z-index: 1;
 }
 
-.banner-title {
-  padding-top: 10px;
-  margin-bottom: 10px;
-  border-bottom: 1px solid var(--border);
-  min-height: 60px;
+.banner {
+  &__title {
+    padding-top: 10px;
+    margin-bottom: 10px;
+    border-bottom: 1px solid var(--border);
+    min-height: 60px;
+  }
 }
 </style>

--- a/pkg/kubewarden/components/Policies/PolicyReadmePanel.vue
+++ b/pkg/kubewarden/components/Policies/PolicyReadmePanel.vue
@@ -71,7 +71,8 @@ export default {
           <div class="policy-header pb-10">
             <div class="slideIn__header__buttons">
               <button class="btn btn-sm role-link" @click="hide">
-                {{ t('generic.close') }}
+                <span>{{ t('generic.close') }}</span>
+                <i class="icon icon-chevron-right" />
               </button>
             </div>
           </div>
@@ -90,6 +91,10 @@ export default {
 </template>
 
 <style lang="scss" scoped>
+::v-deep(.btn-sm) {
+  padding: 0 7px 0 0;
+}
+
 .policy-info-panel {
   position: fixed;
   top: 0;
@@ -165,6 +170,7 @@ export default {
 
       &__buttons {
         display: flex;
+        align-items: center;
       }
 
       &__button {
@@ -172,11 +178,12 @@ export default {
         display: flex;
         align-items: center;
         justify-content: center;
-        padding: 2px;
+
         > i {
           font-size: 20px;
           opacity: 0.5;
         }
+
         &:hover {
           background-color: var(--wm-closer-hover-bg);
         }

--- a/pkg/kubewarden/components/Policies/PolicyReadmePanel.vue
+++ b/pkg/kubewarden/components/Policies/PolicyReadmePanel.vue
@@ -1,0 +1,193 @@
+<script>
+import { mapGetters } from 'vuex';
+
+import ChartReadme from '@shell/components/ChartReadme';
+
+export default {
+  props: {
+    packageValues: {
+      type:     Object,
+      required: true,
+    },
+  },
+
+  components: { ChartReadme },
+
+  data() {
+    return {
+      showSlideIn:      false,
+      info:             undefined,
+      infoVersion:      undefined,
+      versionInfo:      undefined,
+      versionError:     undefined,
+      headerBannerSize: 0,
+    };
+  },
+
+  computed: {
+    ...mapGetters({ theme: 'prefs/theme' }),
+
+    applyDarkModeBg() {
+      if (this.theme === 'dark') {
+        return { 'dark-mode': true };
+      }
+
+      return {};
+    },
+  },
+
+  methods: {
+    show() {
+      this.showSlideIn = true;
+    },
+
+    hide() {
+      this.showSlideIn = false;
+    }
+  }
+};
+</script>
+<template>
+  <div
+    class="policy-info-panel"
+    :style="`--banner-top-offset: 0px`"
+  >
+    <div
+      v-if="showSlideIn"
+      class="glass"
+      data-testid="extension-details-bg"
+      @click="hide()"
+    />
+    <div
+      class="slideIn"
+      data-testid="extension-details"
+      :class="{'hide': false, 'slideIn__show': showSlideIn}"
+    >
+      <div class="slideIn__header">
+        <div
+          v-if="packageValues"
+          class="policy-info-content"
+        >
+          <div class="policy-header mt-10">
+            <div class="policy-title">
+              <h3 class="policy-info-title">
+                {{ packageValues.display_name }}
+              </h3>
+            </div>
+            <div class="slideIn__header__buttons">
+              <div
+                class="slideIn__header__button"
+                @click="hide()"
+              >
+                <i class="icon icon-x" />
+              </div>
+            </div>
+          </div>
+
+          <ChartReadme class="mt-20" :version-info="packageValues" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.policy-info-panel {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 2;
+  overflow-y: auto;
+
+  $slideout-width: 35%;
+  $title-height: 50px;
+  $padding: 5px;
+  $slideout-width: 45%;
+  --banner-top-offset: 0;
+  $header-height: calc(54px + var(--banner-top-offset));
+
+  .glass {
+    position: fixed;
+    top: $header-height;
+    height: calc(100% - $header-height);
+    left: 0;
+    width: 100%;
+    opacity: 0;
+    overflow-y: auto;
+  }
+
+  .slideIn {
+    border-left: var(--header-border-size) solid var(--header-border);
+    position: fixed;
+    top: $header-height;
+    right: -$slideout-width;
+    height: calc(100% - $header-height);
+    background-color: var(--topmenu-bg);
+    width: $slideout-width;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+
+    padding: 10px;
+
+    transition: right .5s ease;
+
+    &__header {
+      text-transform: capitalize;
+    }
+
+    .policy-info-content {
+      display: flex;
+      flex-direction: column;
+      overflow-y: auto;
+    }
+
+    h3 {
+      font-size: 14px;
+      margin: 0;
+      opacity: 0.7;
+      text-transform: uppercase;
+    }
+
+    .policy-header {
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      padding-bottom: 20px;
+
+      .policy-title {
+        flex: 1;
+      }
+    }
+
+    &__header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+
+      &__buttons {
+        display: flex;
+      }
+
+      &__button {
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 2px;
+        > i {
+          font-size: 20px;
+          opacity: 0.5;
+        }
+        &:hover {
+          background-color: var(--wm-closer-hover-bg);
+        }
+      }
+    }
+
+    &__show {
+      right: 0;
+    }
+  }
+}
+</style>

--- a/pkg/kubewarden/components/Policies/PolicyReadmePanel.vue
+++ b/pkg/kubewarden/components/Policies/PolicyReadmePanel.vue
@@ -68,20 +68,18 @@ export default {
           v-if="packageValues"
           class="policy-info-content"
         >
-          <div class="policy-header mt-10">
-            <div class="policy-title">
-              <h3 class="policy-info-title">
-                {{ packageValues.display_name }}
-              </h3>
-            </div>
+          <div class="policy-header pb-10">
             <div class="slideIn__header__buttons">
-              <div
-                class="slideIn__header__button"
-                @click="hide()"
-              >
-                <i class="icon icon-x" />
-              </div>
+              <button class="btn btn-sm role-link" @click="hide">
+                {{ t('generic.close') }}
+              </button>
             </div>
+          </div>
+
+          <div class="policy-title mt-20">
+            <h2 class="policy-info-title">
+              {{ packageValues.display_name }}
+            </h2>
           </div>
 
           <ChartReadme class="mt-20" :version-info="packageValues" />
@@ -127,6 +125,7 @@ export default {
     display: flex;
     flex-direction: column;
     overflow-y: auto;
+    box-shadow: -3px 0 5px rgba(0, 0, 0, 0.1);
 
     padding: 10px;
 
@@ -153,7 +152,6 @@ export default {
       border-bottom: 1px solid var(--border);
       display: flex;
       align-items: center;
-      padding-bottom: 20px;
 
       .policy-title {
         flex: 1;

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -231,6 +231,7 @@ kubewarden:
     module:
       label: Module
       tooltip: This is the WebAssembly module that holds the validation or mutation logic.
+      placeholder: ghcr.io/example/policies/custom-policy:v0.1.0
     mutating:
       label: Mutating
       tooltip: A mutating policy will rebuild the requests with definied values that are conformant with the policy definition.
@@ -290,6 +291,8 @@ kubewarden:
         kind:
           label: Kind
           tooltip: Singular PascalCase name of the resource
+    description:
+      showMore: Show More
   policyServerConfig:
     securityContexts:
       containerConfig: Container configuration

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -292,7 +292,7 @@ kubewarden:
           label: Kind
           tooltip: Singular PascalCase name of the resource
     description:
-      showMore: Show More
+      showReadme: Show Readme
   policyServerConfig:
     securityContexts:
       containerConfig: Container configuration

--- a/tests/unit/components/Policies/PolicyReadmePanel.spec.ts
+++ b/tests/unit/components/Policies/PolicyReadmePanel.spec.ts
@@ -9,7 +9,12 @@ const commons = {
   computed:  { applyDarkModeBg: () => jest.fn() },
   mocks:     {
     $fetchState: { pending: false },
-    $store:      { getters: { 'prefs/theme': () => 'light' } },
+    $store:      {
+      getters: {
+        'prefs/theme': () => 'light',
+        'i18n/t':      jest.fn()
+      }
+    },
   },
 };
 

--- a/tests/unit/components/Policies/PolicyReadmePanel.spec.ts
+++ b/tests/unit/components/Policies/PolicyReadmePanel.spec.ts
@@ -1,0 +1,58 @@
+import { createWrapper } from '@tests/unit/_utils_/wrapper';
+import { policyPackages } from '@tests/unit/_templates_/policyPackages';
+
+import ChartReadme from '@shell/components/ChartReadme';
+import PolicyReadmePanel from '@kubewarden/components/Policies/PolicyReadmePanel.vue';
+
+const commons = {
+  propsData: { packageValues: {} },
+  computed:  { applyDarkModeBg: () => jest.fn() },
+  mocks:     {
+    $fetchState: { pending: false },
+    $store:      { getters: { 'prefs/theme': () => 'light' } },
+  },
+};
+
+const createPolicyReadmePanelWrapper = createWrapper(PolicyReadmePanel, commons);
+
+describe('PolicyDetail.vue', () => {
+  it('renders correctly when showSlideIn is true', () => {
+    const wrapper = createPolicyReadmePanelWrapper({
+      propsData: { packageValues: policyPackages[0] },
+      data() {
+        return { showSlideIn: true };
+      }
+    });
+
+    expect(wrapper.find('.glass').exists()).toBe(true);
+    expect(wrapper.find('.slideIn').classes()).toContain('slideIn__show');
+  });
+
+  it('renders correctly when showSlideIn is false', () => {
+    const wrapper = createPolicyReadmePanelWrapper({ propsData: { packageValues: policyPackages[0] } });
+
+    expect(wrapper.find('.glass').exists()).toBe(false);
+    expect(wrapper.find('.slideIn').classes()).not.toContain('slideIn__show');
+  });
+
+  it('toggles showSlideIn when show and hide methods are called', async() => {
+    const wrapper = createPolicyReadmePanelWrapper({ propsData: { packageValues: policyPackages[0] } });
+
+    wrapper.vm.show();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.showSlideIn).toBe(true);
+
+    wrapper.vm.hide();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.showSlideIn).toBe(false);
+  });
+
+  it('renders ChartReadme component with correct props', () => {
+    const wrapper = createPolicyReadmePanelWrapper({ propsData: { packageValues: policyPackages[0] } });
+
+    const chartReadme = wrapper.findComponent(ChartReadme);
+
+    expect(chartReadme.exists()).toBe(true);
+    expect(chartReadme.props().versionInfo).toStrictEqual(policyPackages[0]);
+  });
+});


### PR DESCRIPTION
Fix #775 

This will remove the policy readme step and replaces it with a slide out component showing the readme.

I also updated the ordering of the configuration tabs, and removed the module input if the policy is not custom.


https://github.com/rancher/kubewarden-ui/assets/40806497/c705361c-a450-440d-8fc6-eadbb1ff50e9


