### PR TITLE
Re-enable dependabot for tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,11 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 10
+  - package-ecosystem: "npm"
+    directory: "/tests"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "6:00"
+      timezone: "Europe/Prague"
+    labels: ["dependencies", "qa"]


### PR DESCRIPTION
We have 2 package.json files - for extension & tests. Track both files with dependabot.

This was original configuration, I removed tests/package.json tracking by mistake in https://github.com/rancher/kubewarden-ui/pull/736.