### PR TITLE
Fix dependabot time setting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-      time: "6:00"
+      time: "06:00"
       timezone: "Europe/Prague"
     labels: ["dependencies", "qa"]


### PR DESCRIPTION
I added time/timezone after testing PR with wrong time format, sorry about that.

Dependabot complains about in https://github.com/rancher/kubewarden-ui/network/updates
```
Dependabot encountered the following error when parsing your .github/dependabot.yml:
The property '#/updates/2/schedule/time' value "6:00" did not match the regex '^\d\d:\d\d$'
``` 