### PR TITLE
Fix area/qa label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,4 +24,4 @@ updates:
       day: "monday"
       time: "06:00"
       timezone: "Europe/Prague"
-    labels: ["dependencies", "qa"]
+    labels: ["dependencies", "area/qa"]


### PR DESCRIPTION
This will fix the label for dependabot when opening a PR within the `/tests` directory to `area/qa`.