### PR TITLE
Adapt tests for slide-in readme

### DIFF
--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -22,7 +22,7 @@ const upMap: AppVersion[] = [
   { app: 'v1.11.0', controller: '2.0.10', crds: '1.4.6', defaults: '1.9.4' },
   { app: 'v1.12.0', controller: '2.0.11', crds: '1.5.0', defaults: '2.0.0' },
   { app: 'v1.13.0', controller: '2.1.0', crds: '1.5.1', defaults: '2.0.3' },
-  { app: 'v1.14.0', controller: '2.2.0', crds: '1.6.0', defaults: '2.1.0' },
+  { app: 'v1.14.0', controller: '2.2.1', crds: '1.6.0', defaults: '2.1.0' },
 ]
 
 test('Initial rancher setup', async({ page, ui, nav }) => {

--- a/tests/e2e/40-policies.spec.ts
+++ b/tests/e2e/40-policies.spec.ts
@@ -17,17 +17,17 @@ const pMinimal: Policy = {
 async function checkPolicy(p: Policy, polPage: BasePolicyPage, ui: RancherUI) {
   await test.step(`Policy checks: ${p.name}`, async() => {
     // Check default values if unset
-    p.mode ??= 'Protect'
-    p.audit ??= 'On'
-    p.server ??= 'default'
-    p.namespace ??= 'default'
-    p.module ??= ''
+    const mode = p.mode ?? 'Protect'
+    const audit = p.audit ?? 'On'
+    const server = p.server ?? 'default'
+    const namespace = p.namespace ?? 'default'
+    const module = p.module ?? ''
     const row = ui.tableRow(p.name)
 
     // Check overview page
     await polPage.goto()
-    await expect(row.column('Mode')).toHaveText(p.mode)
-    await expect(row.column('Policy Server')).toHaveText(p.server)
+    await expect(row.column('Mode')).toHaveText(mode)
+    await expect(row.column('Policy Server')).toHaveText(server)
     test.info().annotations.push({ type: 'Feature', description: 'Policy title (module) should be visible' })
     test.info().annotations.push({ type: 'Feature', description: 'AdmissionPolicy namespace should be visible on overview page' })
 
@@ -39,12 +39,12 @@ async function checkPolicy(p: Policy, polPage: BasePolicyPage, ui: RancherUI) {
     // Check config page
     await ui.button('Config').click()
     await expect(polPage.name).toHaveValue(p.name)
-    if (p.title === 'Custom Policy') await expect(polPage.module).toHaveValue(p.module)
-    await expect(polPage.mode(p.mode)).toBeChecked()
-    await expect(polPage.audit(p.audit)).toBeChecked()
-    await expect(polPage.server).toContainText(p.server)
+    if (p.title === 'Custom Policy') await expect(polPage.module).toHaveValue(module)
+    await expect(polPage.mode(mode)).toBeChecked()
+    await expect(polPage.audit(audit)).toBeChecked()
+    await expect(polPage.server).toContainText(server)
     if (isAP(polPage)) {
-      await expect(polPage.namespace).toContainText(p.namespace)
+      await expect(polPage.namespace).toContainText(namespace)
     }
 
     // Check edit config

--- a/tests/e2e/40-policies.spec.ts
+++ b/tests/e2e/40-policies.spec.ts
@@ -47,8 +47,7 @@ async function checkPolicy(p: Policy, polPage: BasePolicyPage, ui: RancherUI) {
     await expect(polPage.audit(p.audit)).toBeChecked()
     await expect(polPage.server).toContainText(p.server)
     if (isAP(polPage)) {
-      // Workaround for https://github.com/rancher/kubewarden-ui/issues/672
-      if (MODE !== 'fleet') await expect(polPage.namespace).toContainText(p.namespace)
+      await expect(polPage.namespace).toContainText(p.namespace)
     }
 
     // Check edit config

--- a/tests/e2e/40-policies.spec.ts
+++ b/tests/e2e/40-policies.spec.ts
@@ -95,6 +95,14 @@ for (const PolicyPage of pageTypes) {
       await expect(finishBtn).toBeEnabled()
     })
 
+    await test.step('Readme is visible', async() => {
+      await ui.button('Show Readme').click()
+      await expect(polPage.readme).toBeInViewport()
+      await expect(polPage.readme).toContainText(p.title)
+      await ui.button(/^Close/).click()
+      await expect(polPage.readme).not.toBeInViewport()
+    })
+
     await test.step('Policy specific fields A/CA', async() => {
       // Open page and wait for the form
       await polPage.open(p)

--- a/tests/e2e/components/rancher-ui.ts
+++ b/tests/e2e/components/rancher-ui.ts
@@ -23,9 +23,10 @@ export class RancherUI {
   // ==================================================================================================
 
   // Button
-  button(name: string) {
+  button(name: string|RegExp) {
     return this.page.getByRole('button', { name, exact: true }).or(
-      this.page.locator(`a.btn:text-is("${name}")`))
+      this.page.locator('a.btn').filter({ has: this.page.getByText(name, { exact: true }) })
+    )
   }
 
   // Labeled Input

--- a/tests/e2e/pages/policies.page.ts
+++ b/tests/e2e/pages/policies.page.ts
@@ -44,6 +44,7 @@ export abstract class BasePolicyPage extends BasePage {
     readonly namespace: Locator;
     readonly modeGroup: Locator;
     readonly auditGroup: Locator;
+    readonly readme: Locator;
 
     constructor(page: Page) {
       super(page)
@@ -53,6 +54,7 @@ export abstract class BasePolicyPage extends BasePage {
       this.namespace = this.ui.select('Namespace*')
       this.modeGroup = this.ui.radioGroup('Mode')
       this.auditGroup = this.ui.radioGroup('Background Audit')
+      this.readme = page.locator('div.policy-info-content')
     }
 
     cards = (options?: {name?: policyTitle, signed?: boolean, official?: boolean, aware?: boolean, mutation?: boolean }): Locator => {
@@ -123,13 +125,11 @@ export abstract class BasePolicyPage extends BasePage {
         await this.ui.button('Create Custom Policy').click()
       } else {
         await this.ui.tableRow(p.title).row.click()
-        // Go to policy tab, skip readme
-        await expect(this.page.getByTestId('kw-policy-create-readme')).toBeVisible()
-        await this.ui.button('Next').click()
       }
       // Check we are on policy creation page
-      await expect(this.page.getByRole('heading', { name: p.title })).toBeVisible()
-      await expect(this.page.getByRole('heading', { name: 'General' })).toBeVisible()
+      const wizard = this.page.getByTestId('kw-policy-create-wizard')
+      await expect(wizard.getByRole('heading', { name: p.title })).toBeVisible()
+      await expect(wizard.getByRole('heading', { name: 'General' })).toBeVisible()
     }
 
     async setValues(p: Policy) {

--- a/tests/e2e/pages/policies.page.ts
+++ b/tests/e2e/pages/policies.page.ts
@@ -21,7 +21,7 @@ export interface Policy {
     mode?: 'Monitor' | 'Protect'
     audit?: 'On' | 'Off'
     server?: string
-    module?: string
+    module?: string // Custom Policy specific
     namespace?: string // AdmissionPolicy specific
     ignoreRancherNS?: boolean // ClusterAdmissionAdmissionPolicy specific
     settings?(ui: RancherUI): Promise<void>


### PR DESCRIPTION
To be merged after https://github.com/rancher/kubewarden-ui/pull/776
- Adapt tests for slide-in readme
- Remove fleet namespace workaround
- Allow to use regex in ui.button locator
- Remove policy module input
- Don't modify tested policy object
