### PR TITLE
Fix resource fetching when user lacks permission

### DIFF
--- a/pkg/kubewarden/chart/kubewarden/admission/ContextAware/index.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/ContextAware/index.vue
@@ -1,5 +1,4 @@
 <script>
-import { mapGetters } from 'vuex';
 import { _CREATE, _VIEW } from '@shell/config/query-params';
 import { removeAt } from '@shell/utils/array';
 
@@ -29,7 +28,9 @@ export default {
   },
 
   async fetch() {
-    await this.$store.dispatch('cluster/findAll', { type: 'apigroup' });
+    if ( this.$store.getters['cluster/canList']('apigroup') ) {
+      await this.$store.dispatch('cluster/findAll', { type: 'apigroup' });
+    }
 
     this.contextAwareResources = [];
 

--- a/pkg/kubewarden/chart/kubewarden/admission/General.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/General.vue
@@ -47,7 +47,9 @@ export default {
   },
 
   async fetch() {
-    await this.$store.dispatch('cluster/findAll', { type: KUBEWARDEN.POLICY_SERVER });
+    if ( this.$store.getters['cluster/canList'](KUBEWARDEN.POLICY_SERVER) ) {
+      await this.$store.dispatch('cluster/findAll', { type: KUBEWARDEN.POLICY_SERVER });
+    }
 
     if ( this.isCreate && !isEmpty(this.policy.spec) ) {
       set(this.policy.spec, 'mode', 'protect');

--- a/pkg/kubewarden/chart/kubewarden/admission/NamespaceSelector/index.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/NamespaceSelector/index.vue
@@ -6,8 +6,6 @@ import KeyValue from '@shell/components/form/KeyValue';
 import MatchExpressions from '@shell/components/form/MatchExpressions';
 import InfoBox from '@shell/components/InfoBox';
 
-import { RANCHER_NS_MATCH_EXPRESSION } from '../../../../types';
-
 export default {
   props: {
     mode: {

--- a/pkg/kubewarden/chart/kubewarden/admission/Rules/index.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/Rules/index.vue
@@ -28,7 +28,9 @@ export default {
   inject: ['chartType'],
 
   async fetch() {
-    await this.$store.dispatch('cluster/findAll', { type: 'apigroup' });
+    if ( this.$store.getters['cluster/canList']('apigroup') ) {
+      await this.$store.dispatch('cluster/findAll', { type: 'apigroup' });
+    }
 
     this.rules = [];
 

--- a/pkg/kubewarden/chart/kubewarden/policy-server/index.vue
+++ b/pkg/kubewarden/chart/kubewarden/policy-server/index.vue
@@ -34,10 +34,15 @@ export default {
   mixins: [ResourceFetch],
 
   async fetch() {
-    const hash = [
-      this.$fetchType(CONFIG_MAP),
-      this.$fetchType(SERVICE_ACCOUNT)
-    ];
+    const hash = [];
+
+    if ( this.$store.getters['cluster/canList'](CONFIG_MAP) ) {
+      hash.push(this.$fetchList(CONFIG_MAP));
+    }
+
+    if ( this.$store.getters['cluster/canList'](SERVICE_ACCOUNT) ) {
+      hash.push(this.$fetchList(SERVICE_ACCOUNT));
+    }
 
     await allHash(hash);
   },

--- a/pkg/kubewarden/components/DefaultsBanner.vue
+++ b/pkg/kubewarden/components/DefaultsBanner.vue
@@ -4,7 +4,6 @@ import debounce from 'lodash/debounce';
 
 import { CATALOG } from '@shell/config/types';
 import { REPO_TYPE, REPO, CHART, VERSION } from '@shell/config/query-params';
-import { checkPermissions } from '@shell/utils/auth';
 
 import { Banner } from '@components/Banner';
 
@@ -25,7 +24,7 @@ export default {
   },
 
   async fetch() {
-    this.permissions = await checkPermissions({ app: { type: CATALOG.APP } }, this.$store.getters);
+    this.permissions = this.$store.getters['cluster/canList'](CATALOG.APP);
 
     if ( this.hasPermission ) {
       this.debouncedRefreshCharts = debounce((init = false) => {

--- a/pkg/kubewarden/components/Questions/SequenceTree.vue
+++ b/pkg/kubewarden/components/Questions/SequenceTree.vue
@@ -159,65 +159,67 @@ export default {
       {{ question.label }}
     </h3>
     <div v-for="(val, vIndex) in value" :key="val + vIndex" class="seq__container mb-20">
-      <div
-        v-for="(q, index) in question.sequence_questions"
-        :key="index"
-      >
-        <template v-if="q.type.startsWith('sequence[') || (q.type.startsWith('map[') && q.subquestions)">
-          <div class="row question">
-            <div class="col span-12 mb-10">
-              <h4>{{ q.label }}</h4>
+      <template v-if="val">
+        <div
+          v-for="(q, index) in question.sequence_questions"
+          :key="index"
+        >
+          <template v-if="q.type.startsWith('sequence[') || (q.type.startsWith('map[') && q.subquestions)">
+            <div class="row question">
+              <div class="col span-12 mb-10">
+                <h4>{{ q.label }}</h4>
 
-              <!-- Sequence questions -->
-              <template v-if="q.type.startsWith('sequence[')">
-                <YamlEditor
-                  ref="yamleditor"
-                  :value="parseSequenceValues(val[q.variable], q)"
-                  class="yaml-editor"
-                  :editor-mode="isView ? 'VIEW_CODE' : 'EDIT_CODE'"
-                  @onInput="updateDeep(q, vIndex, $event)"
-                />
-              </template>
+                <!-- Sequence questions -->
+                <template v-if="q.type.startsWith('sequence[')">
+                  <YamlEditor
+                    ref="yamleditor"
+                    :value="parseSequenceValues(val[q.variable], q)"
+                    class="yaml-editor"
+                    :editor-mode="isView ? 'VIEW_CODE' : 'EDIT_CODE'"
+                    @onInput="updateDeep(q, vIndex, $event)"
+                  />
+                </template>
 
-              <!-- Subquestions -->
-              <template v-else-if="q.type.startsWith('map[') && q.subquestions">
-                <YamlEditor
-                  ref="yamleditor"
-                  :value="parseSequenceSubquestion(val, q)"
-                  class="yaml-editor"
-                  :editor-mode="isView ? 'VIEW_CODE' : 'EDIT_CODE'"
-                  @onInput="updateDeep(q, vIndex, $event)"
-                />
-              </template>
+                <!-- Subquestions -->
+                <template v-else-if="q.type.startsWith('map[') && q.subquestions">
+                  <YamlEditor
+                    ref="yamleditor"
+                    :value="parseSequenceSubquestion(val, q)"
+                    class="yaml-editor"
+                    :editor-mode="isView ? 'VIEW_CODE' : 'EDIT_CODE'"
+                    @onInput="updateDeep(q, vIndex, $event)"
+                  />
+                </template>
+              </div>
             </div>
-          </div>
-        </template>
+          </template>
 
-        <template v-else>
-          <div class="row question">
-            <div class="col span-12 mb-10">
-              <component
-                :is="componentForQuestion(q)"
-                in-store="cluster"
-                :question="q"
-                :value="get(value[vIndex], q.variable)"
-                @input="update(q.variable, vIndex, $event)"
-              />
+          <template v-else>
+            <div class="row question">
+              <div class="col span-12 mb-10">
+                <component
+                  :is="componentForQuestion(q)"
+                  in-store="cluster"
+                  :question="q"
+                  :value="get(value[vIndex], q.variable)"
+                  @input="update(q.variable, vIndex, $event)"
+                />
+              </div>
             </div>
-          </div>
-        </template>
-      </div>
+          </template>
+        </div>
 
-      <button
-        type="button"
-        :disabled="disabled"
-        class="btn role-link remove btn-sm"
-        @click="$emit('removeSeq', { question, vIndex })"
-      >
-        {{ t('generic.remove') }}
-      </button>
+        <button
+          type="button"
+          :disabled="disabled"
+          class="btn role-link remove btn-sm"
+          @click="$emit('removeSeq', { question, vIndex })"
+        >
+          {{ t('generic.remove') }}
+        </button>
 
-      <hr class="mb-20">
+        <hr class="mb-20">
+      </template>
     </div>
 
     <button

--- a/pkg/kubewarden/config/kubewarden.ts
+++ b/pkg/kubewarden/config/kubewarden.ts
@@ -10,7 +10,7 @@ export function init($plugin: any, store: any) {
     basicType,
     weightType,
     virtualType,
-    headers,
+    headers
   } = $plugin.DSL(store, $plugin.name);
 
   const {
@@ -22,7 +22,6 @@ export function init($plugin: any, store: any) {
   product({
     inStore:             'cluster',
     inExplorer:          true,
-    ifHave:              'admin-user',
     icon:                'kubewarden',
     removeable:          false,
     showNamespaceFilter: true

--- a/pkg/kubewarden/config/kubewarden.ts
+++ b/pkg/kubewarden/config/kubewarden.ts
@@ -22,6 +22,7 @@ export function init($plugin: any, store: any) {
   product({
     inStore:             'cluster',
     inExplorer:          true,
+    ifHave:              'admin-user',
     icon:                'kubewarden',
     removeable:          false,
     showNamespaceFilter: true

--- a/pkg/kubewarden/formatters/PolicyServerStatus.vue
+++ b/pkg/kubewarden/formatters/PolicyServerStatus.vue
@@ -1,6 +1,5 @@
 <script>
 import isEmpty from 'lodash/isEmpty';
-import { mapGetters } from 'vuex';
 
 import { WORKLOAD_TYPES } from '@shell/config/types';
 
@@ -18,7 +17,9 @@ export default {
   },
 
   async fetch() {
-    await this.$store.dispatch('cluster/findAll', { type: WORKLOAD_TYPES.DEPLOYMENT });
+    if ( this.$store.getters['cluster/canList'](WORKLOAD_TYPES.DEPLOYMENT) ) {
+      await this.$store.dispatch('cluster/findAll', { type: WORKLOAD_TYPES.DEPLOYMENT });
+    }
   },
 
   computed: {

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -1,5 +1,7 @@
 kubewarden:
   title: Kubewarden
+  unavailability:
+    banner: 'You do not have access to the Kubewarden Dashboard. Please contact your administrator.'
   generic:
     name: Name
   dashboard:

--- a/pkg/kubewarden/list/policies.kubewarden.io.policyserver.vue
+++ b/pkg/kubewarden/list/policies.kubewarden.io.policyserver.vue
@@ -1,6 +1,4 @@
 <script>
-import { mapGetters } from 'vuex';
-
 import { CATALOG } from '@shell/config/types';
 import { CATALOG as CATALOG_ANNOTATIONS } from '@shell/config/labels-annotations';
 
@@ -29,10 +27,13 @@ export default {
 
   async fetch() {
     await this.$store.dispatch('cluster/findAll', { type: this.resource });
-    await this.$store.dispatch('catalog/load');
 
-    if ( !this.hideBannerDefaults ) {
-      this.apps = await this.$store.dispatch('cluster/findAll', { type: CATALOG.APP });
+    if ( this.$store.getters['cluster/canList'](CATALOG.APP) ) {
+      await this.$store.dispatch('catalog/load');
+
+      if ( !this.hideBannerDefaults ) {
+        this.apps = await this.$store.dispatch('cluster/findAll', { type: CATALOG.APP });
+      }
     }
   },
 
@@ -41,7 +42,6 @@ export default {
   },
 
   computed: {
-
     defaultsApp() {
       return this.apps?.find((a) => {
         return a.spec?.chart?.metadata?.annotations?.[CATALOG_ANNOTATIONS.RELEASE_NAME] === KUBEWARDEN_APPS.RANCHER_DEFAULTS;

--- a/pkg/kubewarden/pages/c/_cluster/kubewarden/index.vue
+++ b/pkg/kubewarden/pages/c/_cluster/kubewarden/index.vue
@@ -1,5 +1,11 @@
 <script>
-import { KUBEWARDEN } from '../../../../types';
+import { isAdminUser } from '@shell/store/type-map';
+import { checkPermissions } from '@shell/utils/auth';
+import { WORKLOAD_TYPES } from '@shell/config/types';
+
+import { Banner } from '@components/Banner';
+
+import { KUBEWARDEN, PROJECT } from '../../../../types';
 import { isAirgap } from '../../../../utils/determine-airgap';
 
 import DashboardView from '../../../../components/Dashboard/DashboardView';
@@ -8,17 +14,40 @@ import InstallView from '../../../../components/Dashboard/InstallView';
 export default {
   name: 'Dashboard',
 
-  components: { DashboardView, InstallView },
+  components: {
+    Banner, DashboardView, InstallView
+  },
 
   async fetch() {
+    this.isAdminUser = isAdminUser(this.$store.getters);
+    this.permissions = await checkPermissions({
+      policyServer:           { type: KUBEWARDEN.POLICY_SERVER },
+      admissionPolicy:        { type: KUBEWARDEN.ADMISSION_POLICY },
+      clusterAdmissionPolicy: { type: KUBEWARDEN.CLUSTER_ADMISSION_POLICY },
+      app:                    { type: PROJECT.APP },
+      deployment:             { type: WORKLOAD_TYPES.DEPLOYMENT }
+    }, this.$store.getters);
+
     this.isAirgap = await isAirgap({ store: this.$store });
   },
 
   data() {
-    return { isAirgap: null };
+    return {
+      isAdminUser: false,
+      permissions: {
+        policyServer:           false,
+        admissionPolicy:        false,
+        clusterAdmissionPolicy: false,
+      },
+      isAirgap: null
+    };
   },
 
   computed: {
+    hasAvailability() {
+      return this.isAdminUser || Object.values(this.permissions).every(value => value);
+    },
+
     hasSchema() {
       return this.$store.getters['cluster/schemaFor'](KUBEWARDEN.POLICY_SERVER);
     }
@@ -27,6 +56,16 @@ export default {
 </script>
 
 <template>
-  <InstallView v-if="!hasSchema" :has-schema="hasSchema" />
-  <DashboardView v-else />
+  <div v-if="!hasAvailability">
+    <Banner
+      color="error"
+      class="mt-20 mb-20"
+      data-testid="kw-unavailability-banner"
+      label-key="kubewarden.unavailability.banner"
+    />
+  </div>
+  <div v-else>
+    <InstallView v-if="!hasSchema" :has-schema="hasSchema" />
+    <DashboardView v-else />
+  </div>
 </template>

--- a/pkg/kubewarden/plugins/policy-server-class.js
+++ b/pkg/kubewarden/plugins/policy-server-class.js
@@ -24,7 +24,9 @@ export default class PolicyServerModel extends KubewardenModel {
   get allRelatedPolicies() {
     return async() => {
       const types = [KUBEWARDEN.ADMISSION_POLICY, KUBEWARDEN.CLUSTER_ADMISSION_POLICY];
-      const promises = types.map(type => this.$dispatch('cluster/findAll', { type, opt: { force: true } }, { root: true }));
+      const promises = types
+        .filter(type => this.$rootGetters['cluster/canList'](type))
+        .map(type => this.$dispatch('cluster/findAll', { type, opt: { force: true } }, { root: true }));
 
       try {
         const out = await Promise.all(promises);

--- a/pkg/kubewarden/types/rancher.ts
+++ b/pkg/kubewarden/types/rancher.ts
@@ -46,3 +46,5 @@ export type Schema = {
   _id: string,
   _group: string,
 }
+
+export const PROJECT = { APP: 'project.cattle.io.app' };

--- a/pkg/kubewarden/utils/permissions.ts
+++ b/pkg/kubewarden/utils/permissions.ts
@@ -1,0 +1,14 @@
+import {
+  CATALOG,
+  MANAGEMENT
+} from '@shell/config/types';
+
+export function isAdminUser(getters: any) {
+  const canEditSettings = (getters['cluster/schemaFor'](MANAGEMENT.SETTING)?.resourceMethods || []).includes('PUT');
+  const canEditFeatureFlags = (getters['cluster/schemaFor'](MANAGEMENT.FEATURE)?.resourceMethods || []).includes('PUT');
+  const canInstallApps = (getters['cluster/schemaFor'](CATALOG.APP)?.resourceMethods || []).includes('PUT');
+  const canAddRepos = (getters['cluster/schemaFor'](CATALOG.CLUSTER_REPO)?.resourceMethods || []).includes('PUT');
+  const canPutHelmOperations = (getters['cluster/schemaFor'](CATALOG.OPERATION)?.resourceMethods || []).includes('PUT');
+
+  return canEditSettings && canEditFeatureFlags && canInstallApps && canAddRepos && canPutHelmOperations;
+}


### PR DESCRIPTION
Fix #774 

This will limit the ability to use the Kubewarden extension to users who do not have the proper permissions. There are many pages/components that fetch resources that will now be gated depending on the user's permission level.

The Dashboard page will now display a banner explaining this change when a user does not have access to all of the following types or they are an administrator:
- `policies.kubewarden.io.policyservers`
- `policies.kubewarden.io.clusteradmissionpolicies`
- `policies.kubewarden.io.admissionpolicies`
- `catalog.cattle.io.apps`
- `apps.deployments`

__User with no permissions__

![user-has-nothing](https://github.com/rancher/kubewarden-ui/assets/40806497/5ad61503-bf67-430d-9d97-a3432023bedc)

__User has policy server permissions__

![user-has-ps](https://github.com/rancher/kubewarden-ui/assets/40806497/b2665dda-e06d-4d16-8c0d-5dc210fdf789)

__User has both policy type permissions__

![user-has-policies](https://github.com/rancher/kubewarden-ui/assets/40806497/782e473b-0f8e-48d3-a943-4db22aad8327)


There is no elegant solution to not showing the entire Kubewarden extension to users that do not have access to Kubewarden types as the Dashboard page will always show. Since the dashboard is considered a `virtualType` and it is not tied to a Schema, we are limited in the way we can choose to display this menu item. There will need to be a change on the `@rancher/dashboard` side to fix this.