### PR TITLE
Add watch for active tab to refresh codemirror

### DIFF
--- a/pkg/kubewarden/chart/kubewarden/admission/Settings.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/Settings.vue
@@ -6,6 +6,10 @@ import YamlEditor from '@shell/components/YamlEditor';
 
 export default {
   props: {
+    activeTab: {
+      type:    String,
+      default: null
+    },
     value: {
       type:     Object,
       required: true
@@ -22,10 +26,14 @@ export default {
     return { settingsYaml };
   },
 
-  mounted() {
-    this.$root.$on('routeChanged', () => {
-      this.$refs.yamleditor?.refresh();
-    });
+  watch: {
+    activeTab() {
+      if ( this.activeTab === 'settings' ) {
+        this.$nextTick(() => {
+          this.$refs.yamleditor.refresh();
+        });
+      }
+    }
   },
 
   computed: {

--- a/pkg/kubewarden/chart/kubewarden/admission/index.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/index.vue
@@ -40,7 +40,7 @@ export default {
   inject: ['chartType'],
 
   data() {
-    return { chartValues: null };
+    return { activeTab: null, chartValues: null };
   },
 
   created() {
@@ -104,6 +104,10 @@ export default {
   methods: {
     settingsChanged(event) {
       this.chartValues.policy.spec.settings = jsyaml.load(event);
+    },
+
+    setActiveTab(tab) {
+      this.activeTab = tab;
     }
   }
 };
@@ -122,10 +126,11 @@ export default {
     </Tab>
 
     <template v-if="showSettings">
-      <Tab name="settings" :label="t('kubewarden.policyConfig.tabs.settings')" :weight="98">
+      <Tab name="settings" :label="t('kubewarden.policyConfig.tabs.settings')" :weight="98" @active="() => setActiveTab('settings')">
         <Settings
           v-model="chartValues"
           data-testid="kw-policy-config-settings-tab"
+          :active-tab="activeTab"
           @updateSettings="settingsChanged($event)"
         />
       </Tab>


### PR DESCRIPTION
Fix #803 

Recent changes made to the Rancher Dashboard have removed the event that was emitted when a route was changed, in consequence the CodeMirror component was not being refreshed correctly.

I've added a prop to watch the active tab and to manually call the refresh method.