### PR TITLE
Remove isValidAppVersion check for policy reports

### DIFF
--- a/pkg/kubewarden/modules/policyReporter.ts
+++ b/pkg/kubewarden/modules/policyReporter.ts
@@ -47,7 +47,7 @@ export async function getReports(
       controllerApp = await fetchControllerApp(store);
     }
 
-    if ( schema && isValidAppVersion(controllerApp) ) {
+    if ( schema ) {
       try {
         const reports = await store.dispatch('cluster/findAll', { type: reportType }, { root: true });
 


### PR DESCRIPTION
Fix #816 

We were initially checking for a valid app version based on the policy reporting refactoring on the backend. This will remove the unnecessary requirement of having permissions to list/get the `catalog.cattle.io.app` resource. Users should be able to see policy reports without this.

I have tested this with the latest kubewarden controller version that has the new policy report structure as well as `1.6.2` version which uses the old structure. The only difference I found was that the summary of the reports did not show up as they are not structured in a way that lends them to be shown correctly. I believe this is more acceptable as the the reports would not show even if the `catalog.cattle.io.app` permissions were given to the user.