### PR TITLE
Bump 1.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "1.6.3-rc.1",
+  "version": "1.6.3",
   "private": false,
   "scripts": {
     "build-pkg": "./node_modules/@rancher/shell/scripts/build-pkg.sh",

--- a/pkg/kubewarden/package.json
+++ b/pkg/kubewarden/package.json
@@ -2,7 +2,7 @@
   "name": "kubewarden",
   "description": "Kubewarden extension for Rancher Manager",
   "icon": "https://raw.githubusercontent.com/kubewarden/ui/main/pkg/kubewarden/assets/icon-kubewarden.svg",
-  "version": "1.6.3-rc.1",
+  "version": "1.6.3",
   "private": false,
   "rancher": {
     "annotations": {


### PR DESCRIPTION
This bumps to version 1.6.3.

The related fix #817 is the only change for this version. This removes the `isValidAppVersion` from the policy report fetching.

Tested `1.6.3-rc.1` with a base user with `get`, `list`, and `watch` permissions for both `wgpolicyk8s.io` types. The Compliance tab and columns will properly show the reports now.

__Base user__

![wguser-base-user](https://github.com/user-attachments/assets/626fb3d9-f3bd-453e-8157-c275bfb09cfa)

__Base user cluster roles__

![wguser-cluster-roles](https://github.com/user-attachments/assets/ad23e1e9-5535-4e4c-b319-b12a48993d16)

__Base user project roles__

![wguser-project-roles](https://github.com/user-attachments/assets/e0c23cc5-f5fe-4358-aa97-f972cde3acd7)

__wgpolicy role template__

![wgpolicy-role](https://github.com/user-attachments/assets/d4111e7a-befd-4693-8b9a-774a2e6fadb2)


__Compliance column with base user___

![compliance-column](https://github.com/user-attachments/assets/a62430b2-17ac-4b71-bc58-b37e421ad3cc)

__Compliance tab with base user__

![compliance-tab](https://github.com/user-attachments/assets/8a289feb-2ef4-4089-993d-bc17146f21fa)
