### PR TITLE
Add policy report results to dashboard view

### DIFF
--- a/pkg/kubewarden/components/Dashboard/Card.vue
+++ b/pkg/kubewarden/components/Dashboard/Card.vue
@@ -27,23 +27,23 @@ export default {
     :class="setLoading"
   >
     <div class="d-header">
-      <slot name="count" />
-      <div class="title">
-        <router-link :to="card.link">
-          <h1 class="link">
-            {{ t(card.title) }}
-          </h1>
-        </router-link>
-        <p v-clean-html="t(card.description)" class="mb-0" />
+      <div class="title-container">
+        <slot name="count" />
+        <div class="title">
+          <router-link :to="card.link">
+            <h1 class="link">
+              {{ t(card.title) }}
+            </h1>
+          </router-link>
+          <p v-clean-html="t(card.description)" class="mb-0" />
+        </div>
       </div>
+
+      <slot name="action" class="action" />
     </div>
 
     <div class="d-slot">
       <slot name="content" />
-    </div>
-
-    <div class="d-action">
-      <slot name="action" />
     </div>
   </div>
 </template>
@@ -66,6 +66,14 @@ export default {
   .d-header {
     display: flex;
     align-items: center;
+    justify-content: space-between;
+    width: 100%;
+
+    .title-container {
+      display: flex;
+      align-items: center;
+      width: 55%;
+    }
 
     .title {
       display: flex;
@@ -85,6 +93,10 @@ export default {
     p {
       font-size: 10.5px;
       font-weight: 700;
+    }
+
+    .action {
+      width: 45%;
     }
   }
 
@@ -129,7 +141,7 @@ export default {
   }
 
   .d-action {
-    width: 100%;
+    width: auto;
   }
 }
 

--- a/pkg/kubewarden/components/Dashboard/Card.vue
+++ b/pkg/kubewarden/components/Dashboard/Card.vue
@@ -27,24 +27,23 @@ export default {
     :class="setLoading"
   >
     <div class="d-header">
-      <router-link :to="card.link">
-        <h1>
-          {{ t(card.title) }}
-        </h1>
-      </router-link>
+      <slot name="count" />
+      <div class="title">
+        <router-link :to="card.link">
+          <h1 class="link">
+            {{ t(card.title) }}
+          </h1>
+        </router-link>
+        <p v-clean-html="t(card.description)" class="mb-0" />
+      </div>
     </div>
 
-    <p v-clean-html="t(card.description)" />
-
-    <router-link class="btn role-secondary" :to="card.cta">
-      {{ t(card.linkText) }}
-    </router-link>
-
-    <hr>
-
     <div class="d-slot">
-      <h2>{{ t(card.slotTitle) }}</h2>
-      <slot />
+      <slot name="content" />
+    </div>
+
+    <div class="d-action">
+      <slot name="action" />
     </div>
   </div>
 </template>
@@ -54,7 +53,9 @@ export default {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  justify-content: space-between;
   height: 100%;
+  width: 100%;
   padding: $space-m;
   grid-auto-rows: 1fr;
   gap: $space-m;
@@ -66,14 +67,25 @@ export default {
     display: flex;
     align-items: center;
 
+    .title {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+    }
+
     h1 {
       margin: 0;
-      font-size: 18px;
+      color: var(--link);
     }
-  }
 
-  p {
-    min-height: 48px;
+    h1:hover {
+      color: var(--body-text);
+    }
+
+    p {
+      font-size: 10.5px;
+      font-weight: 700;
+    }
   }
 
   .d-slot {
@@ -115,7 +127,12 @@ export default {
       }
     }
   }
+
+  .d-action {
+    width: 100%;
+  }
 }
+
 .loading {
   min-height: 325px;
   overflow: hidden;

--- a/pkg/kubewarden/components/Dashboard/DashboardView.vue
+++ b/pkg/kubewarden/components/Dashboard/DashboardView.vue
@@ -352,7 +352,6 @@ export default {
               <template v-if="showReports">
                 <Reports :gauges="namespacedResultsGauges" :show-reporter-link="showReporterLink" />
                 <ReportsGauge
-                  v-if="namespacedResultsGauges?.total !== 0"
                   data-testid="kw-dashboard-ap-gauge"
                   resource-name="Active"
                   :reports="namespacedResultsGauges"
@@ -366,7 +365,6 @@ export default {
               <template v-if="showReports">
                 <Reports :gauges="clusterResultsGauges" :show-reporter-link="showReporterLink" />
                 <ReportsGauge
-                  v-if="clusterResultsGauges?.total !== 0"
                   data-testid="kw-dashboard-cap-gauge"
                   resource-name="Active"
                   :reports="clusterResultsGauges"

--- a/pkg/kubewarden/components/Dashboard/DashboardView.vue
+++ b/pkg/kubewarden/components/Dashboard/DashboardView.vue
@@ -56,7 +56,7 @@ export default {
 
   data() {
     const colorStops = {
-      25: '--error', 50: '--warning', 70: '--info'
+      25: '--error', 50: '--warning', 70: '--success'
     };
 
     return {

--- a/pkg/kubewarden/components/Dashboard/DashboardView.vue
+++ b/pkg/kubewarden/components/Dashboard/DashboardView.vue
@@ -288,18 +288,23 @@ export default {
             status: {
               success: res?.status?.success + ( neu?.result === 'pass' ? 1 : 0 ),
               fail:    res?.status?.fail + ( neu?.result === 'fail' ? 1 : 0 ),
+              error:   res?.status?.error + ( neu?.result === 'error' ? 1 : 0 )
             },
             total: res?.total + 1
           };
         }, {
-          status: { success: 0, fail: 0 },
-          total:  0
+          status: {
+            success: 0, fail: 0, error: 0
+          },
+          total: 0
         });
       }
 
       return {
-        status: { success: 0, fail: 0 },
-        total:  0
+        status: {
+          success: 0, fail: 0, error: 0
+        },
+        total: 0
       };
     }
   }
@@ -322,6 +327,23 @@ export default {
             <span v-if="index === 0" class="count">{{ namespacedPolicies.length || 0 }}</span>
             <span v-if="index === 1" class="count">{{ globalPolicies.length || 0 }}</span>
             <span v-if="index === 2" class="count">{{ allPolicyServers.length || 0 }}</span>
+          </template>
+
+          <template #action>
+            <router-link
+              class="btn action"
+              :class="{
+                'role-primary': (index === 0 && namespacedPolicies.length < 1) ||
+                  (index === 1 && globalPolicies.length < 1) ||
+                  (index === 2 && allPolicyServers.length < 1),
+                'role-secondary': (index === 0 && namespacedPolicies.length >= 1) ||
+                  (index === 1 && globalPolicies.length >= 1) ||
+                  (index === 2 && allPolicyServers.length >= 1)
+              }"
+              :to="card.cta"
+            >
+              {{ t(card.linkText) }}
+            </router-link>
           </template>
 
           <template #content>
@@ -364,12 +386,6 @@ export default {
               />
             </span>
           </template>
-
-          <template #action>
-            <router-link class="btn role-secondary action" :to="card.cta">
-              {{ t(card.linkText) }}
-            </router-link>
-          </template>
         </Card>
       </div>
     </div>
@@ -383,7 +399,7 @@ export default {
 
   .get-started {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
     grid-gap: 20px;
 
     .card-container {

--- a/pkg/kubewarden/components/Dashboard/Masthead.vue
+++ b/pkg/kubewarden/components/Dashboard/Masthead.vue
@@ -1,0 +1,297 @@
+<script>
+import { mapGetters } from 'vuex';
+import isEmpty from 'lodash/isEmpty';
+
+import { CATALOG } from '@shell/config/types';
+import { CATALOG as CATALOG_ANNOTATIONS } from '@shell/config/labels-annotations';
+import { REPO_TYPE, REPO, CHART, VERSION } from '@shell/config/query-params';
+
+import { Banner } from '@components/Banner';
+
+import { KUBEWARDEN_APPS, KUBEWARDEN_CHARTS, KUBEWARDEN_PRODUCT_NAME } from '../../types';
+
+import { newPolicyReportCompatible } from '../../modules/policyReporter';
+import { appVersionSatisfiesConstraint, checkUpgradeAvailable } from '../../utils/chart';
+import { handleGrowl } from '../../utils/handle-growl';
+
+import DefaultsBanner from '../DefaultsBanner';
+
+export default {
+  props: {
+    controllerApp: {
+      type: Object,
+      default: null
+    }
+  },
+
+  components: { Banner, DefaultsBanner },
+
+  computed: {
+    ...mapGetters(['currentCluster']),
+    ...mapGetters({ charts: 'catalog/charts' }),
+
+    appVersionSatisfies() {
+      const satisfies = appVersionSatisfiesConstraint(this.$store, this.controllerAppVersion, this.defaultsAppVersion, '=');
+
+      return satisfies || false;
+    },
+
+    allApps() {
+      return this.$store.getters['cluster/all'](CATALOG.APP);
+    },
+
+    controllerAppVersion() {
+      return this.controllerApp?.spec?.chart?.metadata?.appVersion;
+    },
+
+    controllerChart() {
+      if (!isEmpty(this.charts)) {
+        return this.charts.find(chart => chart?.chartName === KUBEWARDEN_CHARTS.CONTROLLER);
+      }
+
+      return null;
+    },
+
+    controllerUpgradeAvailable() {
+      if (this.controllerApp && this.controllerChart) {
+        return checkUpgradeAvailable(this.$store, this.controllerApp, this.controllerChart);
+      }
+
+      return null;
+    },
+
+    defaultsApp() {
+      if (this.allApps) {
+        return this.allApps?.find((a) => {
+          return a.spec?.chart?.metadata?.annotations?.[CATALOG_ANNOTATIONS.RELEASE_NAME] === KUBEWARDEN_APPS.RANCHER_DEFAULTS;
+        });
+      }
+
+      return false;
+    },
+
+    defaultsAppVersion() {
+      return this.defaultsApp?.spec?.chart?.metadata?.appVersion;
+    },
+
+    defaultsChart() {
+      if (!isEmpty(this.charts)) {
+        return this.charts.find(chart => chart?.chartName === KUBEWARDEN_CHARTS.DEFAULTS);
+      }
+
+      return null;
+    },
+
+    defaultsUpgradeAvailable() {
+      if (!this.appVersionSatisfies) {
+        return checkUpgradeAvailable(this.$store, this.defaultsApp, this.defaultsChart);
+      }
+
+      return null;
+    },
+
+    hideBannerDefaults() {
+      return this.$store.getters['kubewarden/hideBannerDefaults'] || !!this.defaultsApp;
+    },
+
+    kubewardenExtension() {
+      const extensionsInstalled = this.$store.getters['uiplugins/plugins'] || [];
+
+      return extensionsInstalled.find(ext => ext.id.includes(KUBEWARDEN_PRODUCT_NAME));
+    },
+
+    policyReportsCompatible() {
+      const uiPluginVersion = this.kubewardenExtension?.version;
+
+      if (this.controllerAppVersion && uiPluginVersion) {
+        return newPolicyReportCompatible(this.controllerAppVersion, uiPluginVersion);
+      }
+
+      return {
+        oldPolicyReports: true,
+        newPolicyReports:  true
+      };
+    }
+  },
+
+  methods: {
+    getChartRoute(upgradeAvailable) {
+      if (upgradeAvailable) {
+        const {
+          repoType, repoName, name, version
+        } = upgradeAvailable;
+
+        if ( version ) {
+          const query = {
+            [REPO_TYPE]: repoType,
+            [REPO]:      repoName,
+            [CHART]:     name,
+            [VERSION]:   version
+          };
+
+          this.$router.push({
+            name:   'c-cluster-apps-charts-install',
+            params: { cluster: this.currentCluster?.id || '_' },
+            query,
+          });
+        } else {
+          const error = {
+            _statusText: this.t('kubewarden.dashboard.appInstall.versionError.title'),
+            message:     this.t('kubewarden.dashboard.appInstall.versionError.message')
+          };
+
+          handleGrowl({ error, store: this.$store });
+        }
+      }
+    }
+  }
+};
+</script>
+
+<template>
+  <div>
+    <Banner
+      v-if="controllerApp && kubewardenExtension && !policyReportsCompatible.newPolicyReports"
+      :label="t('kubewarden.dashboard.policyReports.newPolicyReportsIncompatible', { version: kubewardenExtension?.version }, true)"
+      color="warning"
+      class="mb-40"
+      data-testid="kw-dashboard-pr-incompatible-banner-new-policy-structure"
+    />
+
+    <Banner
+      v-else-if="controllerApp && kubewardenExtension && !policyReportsCompatible.oldPolicyReports"
+      :label="t('kubewarden.dashboard.policyReports.oldPolicyReportsIncompatible', { version: controllerAppVersion }, true)"
+      color="warning"
+      class="mb-40"
+      data-testid="kw-dashboard-pr-incompatible-banner-old-policy-structure"
+    />
+
+    <div class="head">
+      <div class="head-title">
+        <h1 data-testid="kw-dashboard-title">
+          {{ t('kubewarden.dashboard.intro') }}
+        </h1>
+
+        <div v-if="controllerAppVersion && defaultsApp && !appVersionSatisfies">
+          <Banner
+            :label="t('kubewarden.dashboard.upgrade.appVersionUnsatisfied', { controllerAppVersion, defaultsAppVersion }, true)"
+            color="warning"
+            class="mb-20"
+            data-testid="kw-dashboard-upgrade-unsatisfied-banner"
+          />
+        </div>
+
+        <div v-if="controllerAppVersion" class="head-version-container">
+          <div class="head-version bg-primary mr-10">
+            {{ t('kubewarden.dashboard.upgrade.appVersion') }}: {{ controllerAppVersion }}
+          </div>
+          <!-- Controller upgrade -->
+          <div
+            v-if="controllerUpgradeAvailable && appVersionSatisfies"
+            data-testid="kw-app-controller-upgrade-button"
+            class="head-upgrade badge-state bg-warning hand mr-10"
+            :disabled="!controllerChart"
+            @click.prevent="getChartRoute(controllerUpgradeAvailable)"
+          >
+            <i class="icon icon-upload" />
+            <span>{{ t('kubewarden.dashboard.upgrade.appUpgrade') }}: {{ controllerUpgradeAvailable.appVersion }}</span>
+            <span class="p-0">-</span>
+            <span>{{ t('kubewarden.dashboard.upgrade.controllerChart') }}: {{ controllerUpgradeAvailable.version }}</span>
+          </div>
+          <!-- Defaults upgrade -->
+          <div
+            v-if="defaultsUpgradeAvailable"
+            data-testid="kw-app-defaults-upgrade-button"
+            class="head-upgrade badge-state bg-warning hand"
+            :disabled="!defaultsChart"
+            @click.prevent="getChartRoute(defaultsUpgradeAvailable)"
+          >
+            <i class="icon icon-upload" />
+            <span>{{ t('kubewarden.dashboard.upgrade.appUpgrade') }}: {{ defaultsUpgradeAvailable.appVersion }}</span>
+            <span class="p-0">-</span>
+            <span>{{ t('kubewarden.dashboard.upgrade.defaultsChart') }}: {{ defaultsUpgradeAvailable.version }}</span>
+          </div>
+        </div>
+      </div>
+
+      <p class="head-subheader">
+        {{ t('kubewarden.dashboard.blurb') }}
+      </p>
+
+      <p>
+        {{ t('kubewarden.dashboard.description') }}
+      </p>
+
+      <div class="head-links">
+        <a
+          href="https://kubewarden.io/"
+          target="_blank"
+          rel="noopener noreferrer nofollow"
+        >
+          {{ t('kubewarden.dashboard.getStarted') }}
+        </a>
+        <a
+          href="https://github.com/kubewarden/kubewarden-controller/issues"
+          target="_blank"
+          rel="noopener noreferrer nofollow"
+        >
+          {{ t('kubewarden.dashboard.issues') }}
+        </a>
+      </div>
+    </div>
+
+    <DefaultsBanner v-if="!hideBannerDefaults" />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.head {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-content: center;
+  gap: $space-m;
+  outline: 1px solid var(--border);
+  border-radius: var(--border-radius);
+  margin: 0 0 64px 0;
+  padding: $space-m;
+  gap: $space-m;
+
+  &-title {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+
+    h1 {
+      margin: 0;
+    }
+  }
+
+  &-version-container {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  &-upgrade {
+    display: flex;
+    align-items: center;
+  }
+
+  &-version, &-upgrade {
+    border-radius: var(--border-radius);
+    padding: 4px 8px;
+  }
+
+  &-subheader {
+    font-size: 1.2rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+  }
+
+  &-links {
+    display: flex;
+    gap: 10px;
+  }
+}
+</style>

--- a/pkg/kubewarden/components/Dashboard/Masthead.vue
+++ b/pkg/kubewarden/components/Dashboard/Masthead.vue
@@ -31,7 +31,7 @@ export default {
     ...mapGetters({ charts: 'catalog/charts' }),
 
     appVersionSatisfies() {
-      const satisfies = appVersionSatisfiesConstraint(this.$store, this.controllerAppVersion, this.defaultsAppVersion, '=');
+      const satisfies = appVersionSatisfiesConstraint(this.$store, this.controllerAppVersion, this.defaultsAppVersion, '<=');
 
       return satisfies || false;
     },

--- a/pkg/kubewarden/components/Dashboard/Modes.vue
+++ b/pkg/kubewarden/components/Dashboard/Modes.vue
@@ -1,0 +1,25 @@
+<script>
+export default {
+  props: {
+    gauges: {
+      type:     Object,
+      required: true
+    }
+  }
+};
+</script>
+
+<template>
+  <div class="modes">
+    <h4 class="text-bold mb-0">
+      {{ t('kubewarden.dashboard.headers.modes.title') }}:&nbsp;
+    </h4>
+    <span>{{ gauges.mode.protect }} {{ t('kubewarden.dashboard.headers.modes.protect') }}</span>
+    <span>&nbsp;/&nbsp;</span>
+    <span>{{ gauges.mode.monitor }} {{ t('kubewarden.dashboard.headers.modes.monitor') }}</span>
+  </div>
+</template>
+
+<style scoped>
+/* Your styles */
+</style>

--- a/pkg/kubewarden/components/Dashboard/Reports.vue
+++ b/pkg/kubewarden/components/Dashboard/Reports.vue
@@ -1,0 +1,51 @@
+<script>
+import { KUBEWARDEN_PRODUCT_NAME, POLICY_REPORTER_PRODUCT } from '../../types';
+
+export default {
+  props: {
+    gauges: {
+      type:     Object,
+      required: true
+    },
+    showReporterLink: {
+      type:     Boolean,
+      default:  false
+    }
+  },
+  data() {
+    const reporterLink = {
+      name:   `c-cluster-${ KUBEWARDEN_PRODUCT_NAME }-${ POLICY_REPORTER_PRODUCT }`,
+      params: { product: KUBEWARDEN_PRODUCT_NAME }
+    }
+
+    return {
+      reporterLink
+    };
+  }
+};
+</script>
+
+<template>
+  <div class="mb-20 reports">
+    <h4 class="text-bold mb-0">
+      {{ t('kubewarden.dashboard.headers.reports.title') }}:&nbsp;
+    </h4>
+    <span class="text-success">{{ gauges.status.success }} {{ t('kubewarden.dashboard.headers.reports.success') }}</span>
+    <span>&nbsp;/&nbsp;</span>
+    <span class="text-error">{{ gauges.status.fail }} {{ t('kubewarden.dashboard.headers.reports.fail') }}</span>
+    <router-link
+      v-if="showReporterLink && gauges.total > 0"
+      :to="reporterLink"
+      class="ml-10"
+    >
+      Show All
+    </router-link>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.reports {
+  display: flex;
+  align-items: flex-end;
+}
+</style>

--- a/pkg/kubewarden/components/Dashboard/ReportsGauge.vue
+++ b/pkg/kubewarden/components/Dashboard/ReportsGauge.vue
@@ -18,12 +18,16 @@ export default {
       }
 
       return (Math.round(this.reports?.status.success * 100) / this.reports.total).toFixed(0);
+    },
+
+    secondaryColor() {
+      return this.reports?.total === 0 ? '--default-text' : '--error';
     }
   },
 
   methods: {
     formattedPercentage(type) {
-      return `${ (Math.round(this.reports?.status[type] * 100) / this.reports.total).toFixed(0) }%`;
+      return `${ ((Math.round(this.reports?.status[type] * 100) / this.reports.total) || 0).toFixed(0) }%`;
     }
   }
 };
@@ -48,7 +52,7 @@ export default {
       <Bar
         :percentage="percentageBarValue"
         primary-color="--success"
-        secondary-color="--error"
+        :secondary-color="secondaryColor"
       />
     </div>
   </div>

--- a/pkg/kubewarden/components/Dashboard/ReportsGauge.vue
+++ b/pkg/kubewarden/components/Dashboard/ReportsGauge.vue
@@ -21,7 +21,7 @@ export default {
     },
 
     secondaryColor() {
-      return this.reports?.total === 0 ? '--default-text' : '--error';
+      return this.reports?.total === 0 ? '--border' : '--error';
     }
   },
 

--- a/pkg/kubewarden/components/Dashboard/ReportsGauge.vue
+++ b/pkg/kubewarden/components/Dashboard/ReportsGauge.vue
@@ -1,0 +1,81 @@
+<script>
+import Bar from '@shell/components/graph/Bar';
+
+export default {
+  props:      {
+    reports: {
+      type:     Object,
+      required: true
+    }
+  },
+
+  components: { Bar },
+
+  computed: {
+    percentageBarValue() {
+      if (!this.reports.total) {
+        return 0;
+      }
+
+      return (Math.round(this.reports?.status.success * 100) / this.reports.total).toFixed(0);
+    }
+  },
+
+  methods: {
+    formattedPercentage(type) {
+      return `${ (Math.round(this.reports?.status[type] * 100) / this.reports.total).toFixed(0) }%`;
+    }
+  }
+};
+</script>
+
+<template>
+  <div class="reports-gauge">
+    <div class="numbers">
+      <div class="numbers-stats success">
+        <span class="text-success">{{ reports.status.success }}</span>
+        <span>Success</span>
+        <span class="percentage"><i>/&nbsp;</i>{{ formattedPercentage('success') }}</span>
+      </div>
+
+      <div class="numbers-stats fail">
+        <span class="text-error">{{ reports.status.fail }}</span>
+        <span>Fail</span>
+        <span class="percentage"><i>/&nbsp;</i>{{ formattedPercentage('fail') }}</span>
+      </div>
+    </div>
+    <div>
+      <Bar
+        :percentage="percentageBarValue"
+        primary-color="--success"
+        secondary-color="--error"
+      />
+    </div>
+  </div>
+</template>
+
+<style lang="scss">
+.reports-gauge {
+  .numbers {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    width: 100%;
+
+    &-stats {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      align-self: baseline;
+      font-size: 12px;
+      gap: 4px;
+    }
+
+    .percentage {
+      i {
+        margin-right: 4px;
+      }
+    }
+  }
+}
+</style>

--- a/pkg/kubewarden/components/Graph/Bar.vue
+++ b/pkg/kubewarden/components/Graph/Bar.vue
@@ -1,0 +1,75 @@
+<script>
+export default {
+  props: {
+    percentages: {
+      type:     Array,
+      required: true,
+      validator(value) {
+        return value.reduce((acc, val) => acc + val, 0) <= 100;
+      },
+    },
+    colors: {
+      type:     Array,
+      default: () => ['--success', '--error', '--warning']
+    },
+  },
+  computed: {
+    sliceStyles() {
+      let accumulatedPercentage = 0;
+      const allZero = this.percentages.every(percentage => percentage === 0);
+
+      if ( allZero ) {
+        return [
+          {
+            width:           '100%',
+            backgroundColor: 'var(--disabled-bg)',
+            left:            '0%',
+          },
+        ];
+      }
+
+      return this.percentages.map((percentage, index) => {
+        const style = {
+          width:           `${ percentage }%`,
+          backgroundColor: `var(${ this.colors[index] })`,
+          left:            `${ accumulatedPercentage }%`,
+        };
+
+        accumulatedPercentage += percentage;
+
+        return style;
+      });
+    },
+  },
+};
+</script>
+
+<template>
+  <div class="bar">
+    <div
+      v-for="(sliceStyle, i) in sliceStyles"
+      :key="i"
+      class="slice"
+      :style="sliceStyle"
+    />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.bar {
+  $height: 15px;
+
+  width: 100%;
+  height: $height;
+  border-radius: math.div($height, 2);
+  overflow: hidden;
+  position: relative;
+
+  .slice {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    height: 100%;
+  }
+}
+</style>

--- a/pkg/kubewarden/config/table-headers.ts
+++ b/pkg/kubewarden/config/table-headers.ts
@@ -155,17 +155,6 @@ export const DASHBOARD_HEADERS = [
     isEnabled:   true,
     isLoaded:    true,
     icon:        'icon-question-mark',
-    cta:         createKubewardenRoute({ name: 'c-cluster-product-resource-create', params: { resource: KUBEWARDEN.POLICY_SERVER } }),
-    link:        createKubewardenRoute({ name: 'c-cluster-product-resource', params: { resource: KUBEWARDEN.POLICY_SERVER } }),
-    linkText:    'kubewarden.dashboard.headers.policyServer.linkText',
-    description: 'kubewarden.dashboard.headers.policyServer.description',
-    slotTitle:   'kubewarden.dashboard.headers.policyServer.slotTitle',
-    title:       'kubewarden.dashboard.headers.policyServer.title'
-  },
-  {
-    isEnabled:   true,
-    isLoaded:    true,
-    icon:        'icon-question-mark',
     cta:         createKubewardenRoute({ name: 'c-cluster-product-resource-create', params: { resource: KUBEWARDEN.ADMISSION_POLICY } }),
     link:        createKubewardenRoute({ name: 'c-cluster-product-resource', params: { resource: KUBEWARDEN.ADMISSION_POLICY } }),
     linkText:    'kubewarden.dashboard.headers.admissionPolicy.linkText',
@@ -183,7 +172,18 @@ export const DASHBOARD_HEADERS = [
     description: 'kubewarden.dashboard.headers.clusterAdmissionPolicy.description',
     slotTitle:   'kubewarden.dashboard.headers.clusterAdmissionPolicy.slotTitle',
     title:       'kubewarden.dashboard.headers.clusterAdmissionPolicy.title'
-  }
+  },
+  {
+    isEnabled:   true,
+    isLoaded:    true,
+    icon:        'icon-question-mark',
+    cta:         createKubewardenRoute({ name: 'c-cluster-product-resource-create', params: { resource: KUBEWARDEN.POLICY_SERVER } }),
+    link:        createKubewardenRoute({ name: 'c-cluster-product-resource', params: { resource: KUBEWARDEN.POLICY_SERVER } }),
+    linkText:    'kubewarden.dashboard.headers.policyServer.linkText',
+    description: 'kubewarden.dashboard.headers.policyServer.description',
+    slotTitle:   'kubewarden.dashboard.headers.policyServer.slotTitle',
+    title:       'kubewarden.dashboard.headers.policyServer.title'
+  },
 ];
 
 export const TRACE_HEADERS = [

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -30,23 +30,24 @@ kubewarden:
     headers:
       policyServer:
         title: Policy Servers
-        description: Kubewarden uses Policy Servers to receive requests to be validated. It does that by executing Kubewarden's policies.
+        description: Policy Servers validate requests
         linkText: Create Policy Server
-        slotTitle: Policy Server Pods
       admissionPolicy:
-        title: Admission Policies
-        description: An Admission Policy is a namespace-wide resource. The policy will process only the requests that are targeting the Namespace where the Admission Policy is defined.
-        linkText: Create Admission Policy
-        slotTitle: Policies
+        title: Namespaced Policies
+        description: Namespace-wide policy validation
+        linkText: Create Namespaced Policy
       clusterAdmissionPolicy:
-        title: Cluster Admission Policies
-        description: The Cluster Admission Policy resource is the core of the Kubewarden stack. This resource defines how policies evaluate requests.
-        linkText: Create Cluster Admission Policy
-        slotTitle: Policies
+        title: Cluster Policies
+        description: Cluster-wide policy validation
+        linkText: Create Cluster Policy
       modes:
-        title: Policy Modes
+        title: Modes
         monitor: Monitor
         protect: Protect
+      reports:
+        title: Reports
+        success: Success
+        fail: Fail
     appInstall:
       title: Kubewarden App Install
       description: This will take you to the app installation page for Kubewarden.

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -48,6 +48,7 @@ kubewarden:
         title: Reports
         success: Success
         fail: Fail
+        error: Error
     appInstall:
       title: Kubewarden App Install
       description: This will take you to the app installation page for Kubewarden.

--- a/tests/unit/components/Dashboard/DashboardView.spec.ts
+++ b/tests/unit/components/Dashboard/DashboardView.spec.ts
@@ -1,14 +1,8 @@
 import { shallowMount } from '@vue/test-utils';
 import { describe, expect, it } from '@jest/globals';
 
-import { SHOW_PRE_RELEASE } from '@shell/store/prefs';
-
 import DashboardView from '@kubewarden/components/Dashboard/DashboardView.vue';
-import DefaultsBanner from '@kubewarden/components/DefaultsBanner';
 import ConsumptionGauge from '@shell/components/ConsumptionGauge';
-
-import DEFAULTS_APP from '@tests/unit/_templates_/defaultsApp';
-import { controllerCharts } from '@tests/unit/_templates_/controllerCharts';
 
 describe('component: DashboardView', () => {
   const commonMocks = {
@@ -16,7 +10,6 @@ describe('component: DashboardView', () => {
     $store:      {
       getters: {
         currentCluster:                  () => 'current_cluster',
-        'kubewarden/hideBannerDefaults': jest.fn(),
         'i18n/t':                        jest.fn(),
         'catalog/chart':                 jest.fn(),
         'catalog/charts':                jest.fn(),
@@ -28,14 +21,8 @@ describe('component: DashboardView', () => {
   };
 
   const commonComputed = {
-    controllerApp:      () => null,
-    controllerChart:    () => null,
-    defaultsApp:        () => DEFAULTS_APP,
-    hideBannerDefaults: () => false,
     globalPolicies:     () => [],
-    namespacedPolicies: () => [],
-    version:            () => '1.25',
-    upgradeAvailable:   () => null,
+    namespacedPolicies: () => []
   };
 
   const createWrapper = (overrides) => {
@@ -45,19 +32,6 @@ describe('component: DashboardView', () => {
       ...overrides,
     });
   };
-
-  it('renders defaults banner when default app is not found', () => {
-    const wrapper = createWrapper({
-      stubs: {
-        Card:             { template: '<span />' },
-        ConsumptionGauge: { template: '<span />' },
-      },
-    });
-
-    const banner = wrapper.findComponent(DefaultsBanner);
-
-    expect(banner.exists()).toBe(true);
-  });
 
   it('renders correct gauge info of policy servers', () => {
     const pods = [
@@ -83,13 +57,13 @@ describe('component: DashboardView', () => {
 
     const wrapper = createWrapper({
       computed: { policyServerPods: () => pods },
-      stubs:    { DefaultsBanner: { template: '<span />' } },
+      stubs:    { Masthead: { template: '<span />' } },
     });
 
     const gauges = wrapper.findAllComponents(ConsumptionGauge);
 
-    expect(gauges.at(0).props().capacity).toStrictEqual(pods.length as Number);
-    expect(gauges.at(0).props().used).toStrictEqual(1 as Number);
+    expect(gauges.at(2).props().capacity).toStrictEqual(pods.length as Number);
+    expect(gauges.at(2).props().used).toStrictEqual(1 as Number);
   });
 
   it('renders correct gauge info of admission policies', () => {
@@ -119,183 +93,14 @@ describe('component: DashboardView', () => {
 
     const wrapper = createWrapper({
       computed: { namespacedPolicies: () => policies },
-      stubs:    { DefaultsBanner: { template: '<span />' } },
+      stubs:    { Masthead: { template: '<span />' } }
     });
 
     const gauges = wrapper.findAllComponents(ConsumptionGauge);
 
-    expect(gauges.at(1).props().capacity).toStrictEqual(
+    expect(gauges.at(0).props().capacity).toStrictEqual(
       policies.length as Number
     );
-    expect(gauges.at(1).props().used).toStrictEqual(1 as Number);
-  });
-
-  it('renders the Upgradable button when an upgrade is available', () => {
-    const oldControllerApp = { spec: { chart: { metadata: { version: '2.0.4', appVersion: 'v1.9.0' } } } };
-
-    const wrapper = createWrapper({
-      computed: {
-        controllerApp:   () => oldControllerApp,
-        controllerChart: () => controllerCharts,
-        version:         () => 'v1.9.0',
-      },
-    });
-
-    const upgradeButton = wrapper.find('[data-testid="kw-app-controller-upgrade-button"]');
-
-    expect(upgradeButton.exists()).toBe(true);
-    expect(upgradeButton.text()).toContain(
-      '%kubewarden.dashboard.upgrade.appUpgrade%: v1.9.0 - %kubewarden.dashboard.upgrade.controllerChart%: 2.0.5'
-    );
-  });
-
-  it('calculates the correct chart for a supported MAJOR version upgrade', () => {
-    const oldControllerApp = { spec: { chart: { metadata: { version: '0.4.6', appVersion: 'v0.5.5' } } } };
-
-    const wrapper = createWrapper({
-      computed: {
-        controllerApp:   () => oldControllerApp,
-        controllerChart: () => controllerCharts,
-        version:         () => 'v0.5.5',
-      },
-    });
-
-    const upgradeButton = wrapper.find('[data-testid="kw-app-controller-upgrade-button"]');
-
-    expect(upgradeButton.exists()).toBe(true);
-    expect(upgradeButton.text()).toContain(
-      '%kubewarden.dashboard.upgrade.appUpgrade%: v1.0.0 - %kubewarden.dashboard.upgrade.controllerChart%: 1.0.0'
-
-    );
-  });
-
-  it('calculates the correct chart for a supported MINOR version upgrade', () => {
-    const oldControllerApp = { spec: { chart: { metadata: { version: '1.1.1', appVersion: 'v1.1.0' } } } };
-
-    const wrapper = createWrapper({
-      computed: {
-        controllerApp:   () => oldControllerApp,
-        controllerChart: () => controllerCharts,
-        version:         () => 'v1.1.0',
-      },
-    });
-
-    const upgradeButton = wrapper.find('[data-testid="kw-app-controller-upgrade-button"]');
-
-    expect(upgradeButton.exists()).toBe(true);
-    expect(upgradeButton.text()).toContain(
-      '%kubewarden.dashboard.upgrade.appUpgrade%: v1.1.1 - %kubewarden.dashboard.upgrade.controllerChart%: 1.2.3'
-    );
-  });
-
-  it('calculates the correct chart for a supported PATCH version upgrade', () => {
-    const oldControllerApp = { spec: { chart: { metadata: { version: '2.0.0', appVersion: 'v1.8.0' } } } };
-
-    const wrapper = createWrapper({
-      computed: {
-        controllerApp:   () => oldControllerApp,
-        controllerChart: () => controllerCharts,
-        version:         () => 'v1.8.0',
-      },
-    });
-
-    const upgradeButton = wrapper.find('[data-testid="kw-app-controller-upgrade-button"]');
-
-    expect(upgradeButton.exists()).toBe(true);
-    expect(upgradeButton.text()).toContain(
-      '%kubewarden.dashboard.upgrade.appUpgrade%: v1.9.0 - %kubewarden.dashboard.upgrade.controllerChart%: 2.0.5'
-    );
-    expect(wrapper.vm.controllerUpgradeAvailable).toBe(controllerCharts.versions[1]);
-  });
-
-  it('calculates the correct chart for multiple appVersions with chart PATCH available', () => {
-    const oldControllerApp = { spec: { chart: { metadata: { version: '1.6.0', appVersion: 'v1.7.0' } } } };
-
-    const wrapper = createWrapper({
-      computed: {
-        controllerApp:   () => oldControllerApp,
-        controllerChart: () => controllerCharts,
-        version:         () => 'v1.7.0',
-      },
-    });
-
-    const upgradeButton = wrapper.find('[data-testid="kw-app-controller-upgrade-button"]');
-
-    expect(upgradeButton.exists()).toBe(true);
-    expect(upgradeButton.text()).toContain(
-      '%kubewarden.dashboard.upgrade.appUpgrade%: v1.8.0 - %kubewarden.dashboard.upgrade.controllerChart%: 2.0.2'
-    );
-  });
-
-  it('calculates the correct chart for inconsistent appVersion semantics', () => {
-    const oldControllerApp = { spec: { chart: { metadata: { version: '1.4.0', appVersion: '1.5.0' } } } };
-
-    const wrapper = createWrapper({
-      computed: {
-        controllerApp:   () => oldControllerApp,
-        controllerChart: () => controllerCharts,
-        version:         () => '1.5.0',
-      },
-    });
-
-    const upgradeButton = wrapper.find('[data-testid="kw-app-controller-upgrade-button"]');
-
-    expect(upgradeButton.exists()).toBe(true);
-    expect(upgradeButton.text()).toContain(
-      '%kubewarden.dashboard.upgrade.appUpgrade%: v1.6.0 - %kubewarden.dashboard.upgrade.controllerChart%: 1.5.3'
-    );
-  });
-
-  it('calculates the correct chart for pre-release versions', () => {
-    const oldControllerApp = { spec: { chart: { metadata: { version: '2.0.5', appVersion: 'v1.9.0' } } } };
-
-    commonMocks.$store.getters['prefs/get'].mockImplementation((key) => {
-      if ( key === SHOW_PRE_RELEASE ) {
-        return true;
-      }
-
-      return undefined;
-    });
-
-    const wrapper = createWrapper({
-      computed: {
-        controllerApp:   () => oldControllerApp,
-        controllerChart: () => controllerCharts,
-        version:         () => 'v1.9.0',
-        showPreRelease:  () => true,
-      },
-    });
-
-    const upgradeButton = wrapper.find('[data-testid="kw-app-controller-upgrade-button"]');
-
-    expect(upgradeButton.exists()).toBe(true);
-    expect(upgradeButton.text()).toContain(
-      '%kubewarden.dashboard.upgrade.appUpgrade%: v1.10.0-rc1 - %kubewarden.dashboard.upgrade.controllerChart%: 2.0.6-rc1'
-    );
-  });
-
-  it('does not show pre-release upgrades when preference is false', () => {
-    const oldControllerApp = { spec: { chart: { metadata: { version: '2.0.5', appVersion: 'v1.9.0' } } } };
-
-    commonMocks.$store.getters['prefs/get'].mockImplementation((key) => {
-      if ( key === SHOW_PRE_RELEASE ) {
-        return false;
-      }
-
-      return undefined;
-    });
-
-    const wrapper = createWrapper({
-      computed: {
-        controllerApp:   () => oldControllerApp,
-        controllerChart: () => controllerCharts,
-        version:         () => 'v1.9.0',
-        showPreRelease:  () => false,
-      },
-    });
-
-    const upgradeButton = wrapper.find('[data-testid="kw-app-controller-upgrade-button"]');
-
-    expect(upgradeButton.exists()).toBe(false);
+    expect(gauges.at(0).props().used).toStrictEqual(1 as Number);
   });
 });

--- a/tests/unit/components/Dashboard/DashboardView.spec.ts
+++ b/tests/unit/components/Dashboard/DashboardView.spec.ts
@@ -1,8 +1,16 @@
-import { shallowMount } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
 import { describe, expect, it } from '@jest/globals';
 
-import DashboardView from '@kubewarden/components/Dashboard/DashboardView.vue';
 import ConsumptionGauge from '@shell/components/ConsumptionGauge';
+import Loading from '@shell/components/Loading';
+
+import DashboardView from '@kubewarden/components/Dashboard/DashboardView.vue';
+import Card from '@kubewarden/components/Dashboard/Card.vue';
+import Masthead from '@kubewarden/components/Dashboard/Masthead.vue';
+import Modes from '@kubewarden/components/Dashboard/Modes.vue';
+import Events from '@kubewarden/components/Dashboard/Events.vue';
+import EventsGauge from '@kubewarden/components/Dashboard/EventsGauge.vue';
+import { DASHBOARD_HEADERS } from '@kubewarden/config/table-headers';
 
 describe('component: DashboardView', () => {
   const commonMocks = {
@@ -14,7 +22,7 @@ describe('component: DashboardView', () => {
         'catalog/chart':                 jest.fn(),
         'catalog/charts':                jest.fn(),
         'cluster/all':                   jest.fn(),
-        'cluster/canList':               () => true,
+        'cluster/canList':               jest.fn(() => true),
         'prefs/get':                     jest.fn(),
       },
     },
@@ -22,16 +30,116 @@ describe('component: DashboardView', () => {
 
   const commonComputed = {
     globalPolicies:     () => [],
-    namespacedPolicies: () => []
+    namespacedPolicies: () => [],
+    allPolicyServers:   () => [],
+    policyServerCounts: () => ({
+      status: {
+        running: 0, stopped: 0, pending: 0
+      },
+      total: 0
+    }),
   };
 
+  const commonStubs = { 'router-link': { template: '<span />' } };
+
   const createWrapper = (overrides) => {
-    return shallowMount(DashboardView, {
+    return mount(DashboardView, {
       mocks:    commonMocks,
       computed: commonComputed,
+      stubs:    commonStubs,
       ...overrides,
     });
   };
+
+  it('renders the Masthead component', () => {
+    const wrapper = createWrapper({});
+
+    expect(wrapper.findComponent(Masthead).exists()).toBe(true);
+  });
+
+  it('renders the Loading component when fetch state is pending', () => {
+    const wrapper = createWrapper({
+      mocks: {
+        ...commonMocks,
+        $fetchState: { pending: true },
+      },
+    });
+
+    expect(wrapper.findComponent(Loading).exists()).toBe(true);
+  });
+
+  it('renders the correct number of Card components based on DASHBOARD_HEADERS', () => {
+    const wrapper = createWrapper({});
+    const cardComponents = wrapper.findAllComponents(Card);
+
+    expect(cardComponents.length).toBe(DASHBOARD_HEADERS.length);
+  });
+
+  it('renders ConsumptionGauge component with correct props', () => {
+    const wrapper = createWrapper({
+      computed: {
+        globalPolicies:     () => [],
+        namespacedPolicies: () => [],
+        allPolicyServers:   () => [],
+        policyServerCounts: () => ({
+          status: {
+            running: 1, stopped: 0, pending: 0
+          },
+          total: 2
+        })
+      }
+    });
+
+    const gauge = wrapper.findComponent(ConsumptionGauge);
+
+    expect(gauge.exists()).toBe(true);
+    expect(gauge.props('capacity')).toBe(2);
+    expect(gauge.props('used')).toBe(1);
+    expect(gauge.props('colorStops')).toEqual({
+      25: '--error', 50: '--warning', 70: '--info'
+    });
+  });
+
+  it('correctly applies class names based on policy server counts', () => {
+    const wrapper = createWrapper({
+      computed: {
+        globalPolicies:     () => [],
+        namespacedPolicies: () => [],
+        allPolicyServers:   () => [{}, {}]
+      }
+    });
+
+    const btn = wrapper.find('.role-secondary');
+
+    expect(btn.exists()).toBe(true);
+  });
+
+  it('renders EventsGauge component when namespacedPolicies are present', () => {
+    const wrapper = createWrapper({
+      computed: {
+        globalPolicies:     () => [],
+        namespacedPolicies: () => [{}, {}],
+        allPolicyServers:   () => []
+      }
+    });
+
+    const eventsGauge = wrapper.findComponent(EventsGauge);
+
+    expect(eventsGauge.exists()).toBe(true);
+  });
+
+  it('renders Events and Modes components for namespaced policies', () => {
+    const wrapper = createWrapper({
+      computed: {
+        globalPolicies:     () => [],
+        namespacedPolicies: () => [{}, {}],
+        allPolicyServers:   () => []
+      }
+    });
+
+    expect(wrapper.findComponent(Events).exists()).toBe(true);
+    expect(wrapper.findComponent(Modes).exists()).toBe(true);
+  });
 
   it('renders correct gauge info of policy servers', () => {
     const pods = [
@@ -56,51 +164,55 @@ describe('component: DashboardView', () => {
     ];
 
     const wrapper = createWrapper({
-      computed: { policyServerPods: () => pods },
-      stubs:    { Masthead: { template: '<span />' } },
+      computed: {
+        globalPolicies:     () => [],
+        namespacedPolicies: () => [],
+        allPolicyServers:   () => [{}],
+        policyServerPods:   () => pods
+      },
+      stubs: { Masthead: { template: '<span />' } },
     });
 
-    const gauges = wrapper.findAllComponents(ConsumptionGauge);
+    const gauges = wrapper.findComponent(ConsumptionGauge);
 
-    expect(gauges.at(2).props().capacity).toStrictEqual(pods.length as Number);
-    expect(gauges.at(2).props().used).toStrictEqual(1 as Number);
+    expect(gauges.props().capacity).toStrictEqual(pods.length as Number);
+    expect(gauges.props().used).toStrictEqual(1 as Number);
   });
 
-  it('renders correct gauge info of admission policies', () => {
+  it('renders correct gauge info for admission policy events', () => {
     const policies = [
       {
-        status: {
-          policyStatus: 'active',
-          error:        false,
-        },
-        spec: { mode: 'protect' },
+        result: 'pass',
+        policy: 'namespaced-policy-1',
       },
       {
-        status: {
-          policyStatus: 'pending',
-          error:        false,
-        },
-        spec: { mode: 'protect' },
+        result: 'fail',
+        policy: 'namespaced-policy-2',
       },
       {
-        status: {
-          policyStatus: 'unschedulable',
-          error:        true,
-        },
-        spec: { mode: 'monitor' },
+        result: 'error',
+        policy: 'namespaced-policy-3',
       },
     ];
+    const summary = {
+      status: {
+        error: 1, fail: 1, success: 1
+      },
+      total: 3
+    };
 
     const wrapper = createWrapper({
-      computed: { namespacedPolicies: () => policies },
-      stubs:    { Masthead: { template: '<span />' } }
+      computed: {
+        admissionPolicyResults: () => policies,
+        namespacedPolicies:     () => [],
+        globalPolicies:         () => [],
+        allPolicyServers:       () => [],
+      }
     });
 
-    const gauges = wrapper.findAllComponents(ConsumptionGauge);
+    const gauges = wrapper.findAllComponents(EventsGauge);
 
-    expect(gauges.at(0).props().capacity).toStrictEqual(
-      policies.length as Number
-    );
-    expect(gauges.at(0).props().used).toStrictEqual(1 as Number);
+    expect(gauges.at(0).exists()).toBe(true);
+    expect(gauges.at(0).props().events).toStrictEqual(summary);
   });
 });

--- a/tests/unit/components/Dashboard/Masthead.spec.ts
+++ b/tests/unit/components/Dashboard/Masthead.spec.ts
@@ -1,0 +1,229 @@
+import { shallowMount } from '@vue/test-utils';
+import { describe, expect, it } from '@jest/globals';
+
+import { SHOW_PRE_RELEASE } from '@shell/store/prefs';
+
+import Masthead from '@kubewarden/components/Dashboard/Masthead.vue';
+import DefaultsBanner from '@kubewarden/components/DefaultsBanner';
+
+import DEFAULTS_APP from '@tests/unit/_templates_/defaultsApp';
+import { controllerCharts } from '@tests/unit/_templates_/controllerCharts';
+
+describe('component: Masthead', () => {
+  const commonMocks = {
+    $fetchState: { pending: false },
+    $store:      {
+      getters: {
+        currentCluster:                  () => 'current_cluster',
+        'kubewarden/hideBannerDefaults': jest.fn(),
+        'i18n/t':                        jest.fn(),
+        'catalog/chart':                 jest.fn(),
+        'catalog/charts':                jest.fn(),
+        'cluster/all':                   jest.fn(),
+        'cluster/canList':               () => true,
+        'prefs/get':                     jest.fn(),
+      },
+    },
+  };
+
+  const commonComputed = {
+    controllerApp:      () => null,
+    controllerChart:    () => null,
+    defaultsApp:        () => DEFAULTS_APP,
+    hideBannerDefaults: () => false,
+    globalPolicies:     () => [],
+    namespacedPolicies: () => [],
+    version:            () => '1.25',
+    upgradeAvailable:   () => null,
+  };
+
+  const createWrapper = (overrides) => {
+    return shallowMount(Masthead, {
+      mocks:    commonMocks,
+      computed: commonComputed,
+      ...overrides,
+    });
+  };
+
+  it('renders defaults banner when default app is not found', () => {
+    const wrapper = createWrapper({
+      stubs: {
+        Card:             { template: '<span />' },
+        ConsumptionGauge: { template: '<span />' },
+      },
+    });
+
+    const banner = wrapper.findComponent(DefaultsBanner);
+
+    expect(banner.exists()).toBe(true);
+  });
+
+  it('renders the Upgradable button when an upgrade is available', () => {
+    const oldControllerApp = { spec: { chart: { metadata: { version: '2.0.4', appVersion: 'v1.9.0' } } } };
+
+    const wrapper = createWrapper({
+      computed: {
+        controllerApp:   () => oldControllerApp,
+        controllerChart: () => controllerCharts,
+        version:         () => 'v1.9.0',
+      },
+    });
+
+    const upgradeButton = wrapper.find('[data-testid="kw-app-controller-upgrade-button"]');
+
+    expect(upgradeButton.exists()).toBe(true);
+    expect(upgradeButton.text()).toContain(
+      '%kubewarden.dashboard.upgrade.appUpgrade%: v1.9.0 - %kubewarden.dashboard.upgrade.controllerChart%: 2.0.5'
+    );
+  });
+
+  it('calculates the correct chart for a supported MAJOR version upgrade', () => {
+    const oldControllerApp = { spec: { chart: { metadata: { version: '0.4.6', appVersion: 'v0.5.5' } } } };
+
+    const wrapper = createWrapper({
+      computed: {
+        controllerApp:   () => oldControllerApp,
+        controllerChart: () => controllerCharts,
+        version:         () => 'v0.5.5',
+      },
+    });
+
+    const upgradeButton = wrapper.find('[data-testid="kw-app-controller-upgrade-button"]');
+
+    expect(upgradeButton.exists()).toBe(true);
+    expect(upgradeButton.text()).toContain(
+      '%kubewarden.dashboard.upgrade.appUpgrade%: v1.0.0 - %kubewarden.dashboard.upgrade.controllerChart%: 1.0.0'
+
+    );
+  });
+
+  it('calculates the correct chart for a supported MINOR version upgrade', () => {
+    const oldControllerApp = { spec: { chart: { metadata: { version: '1.1.1', appVersion: 'v1.1.0' } } } };
+
+    const wrapper = createWrapper({
+      computed: {
+        controllerApp:   () => oldControllerApp,
+        controllerChart: () => controllerCharts,
+        version:         () => 'v1.1.0',
+      },
+    });
+
+    const upgradeButton = wrapper.find('[data-testid="kw-app-controller-upgrade-button"]');
+
+    expect(upgradeButton.exists()).toBe(true);
+    expect(upgradeButton.text()).toContain(
+      '%kubewarden.dashboard.upgrade.appUpgrade%: v1.1.1 - %kubewarden.dashboard.upgrade.controllerChart%: 1.2.3'
+    );
+  });
+
+  it('calculates the correct chart for a supported PATCH version upgrade', () => {
+    const oldControllerApp = { spec: { chart: { metadata: { version: '2.0.0', appVersion: 'v1.8.0' } } } };
+
+    const wrapper = createWrapper({
+      computed: {
+        controllerApp:   () => oldControllerApp,
+        controllerChart: () => controllerCharts,
+        version:         () => 'v1.8.0',
+      },
+    });
+
+    const upgradeButton = wrapper.find('[data-testid="kw-app-controller-upgrade-button"]');
+
+    expect(upgradeButton.exists()).toBe(true);
+    expect(upgradeButton.text()).toContain(
+      '%kubewarden.dashboard.upgrade.appUpgrade%: v1.9.0 - %kubewarden.dashboard.upgrade.controllerChart%: 2.0.5'
+    );
+    expect(wrapper.vm.controllerUpgradeAvailable).toBe(controllerCharts.versions[1]);
+  });
+
+  it('calculates the correct chart for multiple appVersions with chart PATCH available', () => {
+    const oldControllerApp = { spec: { chart: { metadata: { version: '1.6.0', appVersion: 'v1.7.0' } } } };
+
+    const wrapper = createWrapper({
+      computed: {
+        controllerApp:   () => oldControllerApp,
+        controllerChart: () => controllerCharts,
+        version:         () => 'v1.7.0',
+      },
+    });
+
+    const upgradeButton = wrapper.find('[data-testid="kw-app-controller-upgrade-button"]');
+
+    expect(upgradeButton.exists()).toBe(true);
+    expect(upgradeButton.text()).toContain(
+      '%kubewarden.dashboard.upgrade.appUpgrade%: v1.8.0 - %kubewarden.dashboard.upgrade.controllerChart%: 2.0.2'
+    );
+  });
+
+  it('calculates the correct chart for inconsistent appVersion semantics', () => {
+    const oldControllerApp = { spec: { chart: { metadata: { version: '1.4.0', appVersion: '1.5.0' } } } };
+
+    const wrapper = createWrapper({
+      computed: {
+        controllerApp:   () => oldControllerApp,
+        controllerChart: () => controllerCharts,
+        version:         () => '1.5.0',
+      },
+    });
+
+    const upgradeButton = wrapper.find('[data-testid="kw-app-controller-upgrade-button"]');
+
+    expect(upgradeButton.exists()).toBe(true);
+    expect(upgradeButton.text()).toContain(
+      '%kubewarden.dashboard.upgrade.appUpgrade%: v1.6.0 - %kubewarden.dashboard.upgrade.controllerChart%: 1.5.3'
+    );
+  });
+
+  it('calculates the correct chart for pre-release versions', () => {
+    const oldControllerApp = { spec: { chart: { metadata: { version: '2.0.5', appVersion: 'v1.9.0' } } } };
+
+    commonMocks.$store.getters['prefs/get'].mockImplementation((key) => {
+      if ( key === SHOW_PRE_RELEASE ) {
+        return true;
+      }
+
+      return undefined;
+    });
+
+    const wrapper = createWrapper({
+      computed: {
+        controllerApp:   () => oldControllerApp,
+        controllerChart: () => controllerCharts,
+        version:         () => 'v1.9.0',
+        showPreRelease:  () => true,
+      },
+    });
+
+    const upgradeButton = wrapper.find('[data-testid="kw-app-controller-upgrade-button"]');
+
+    expect(upgradeButton.exists()).toBe(true);
+    expect(upgradeButton.text()).toContain(
+      '%kubewarden.dashboard.upgrade.appUpgrade%: v1.10.0-rc1 - %kubewarden.dashboard.upgrade.controllerChart%: 2.0.6-rc1'
+    );
+  });
+
+  it('does not show pre-release upgrades when preference is false', () => {
+    const oldControllerApp = { spec: { chart: { metadata: { version: '2.0.5', appVersion: 'v1.9.0' } } } };
+
+    commonMocks.$store.getters['prefs/get'].mockImplementation((key) => {
+      if ( key === SHOW_PRE_RELEASE ) {
+        return false;
+      }
+
+      return undefined;
+    });
+
+    const wrapper = createWrapper({
+      computed: {
+        controllerApp:   () => oldControllerApp,
+        controllerChart: () => controllerCharts,
+        version:         () => 'v1.9.0',
+        showPreRelease:  () => false,
+      },
+    });
+
+    const upgradeButton = wrapper.find('[data-testid="kw-app-controller-upgrade-button"]');
+
+    expect(upgradeButton.exists()).toBe(false);
+  });
+});


### PR DESCRIPTION
Fix #798

This adds policy report results to the dashboard view.

Along with the reports added, the layout of the cards has been updated.
- The Policy Servers card has been moved to the end
- Both policy types no longer show the ConsumptionGuage component showing their status
- Events gauge is now displayed in place of the policy status gauge
- The Create buttons have been moved into the header of the card

![dashboard](https://github.com/user-attachments/assets/7d19c51d-6479-4485-89de-fef6f87ae0dc)
