### PR TITLE
Install from rancher-latest repository

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -178,7 +178,6 @@ jobs:
 
         # Workaround for rancher 2.9 in alpha
         if [ "$KUBEWARDEN" == "source" ]; then
-          REPO=rancher-alpha
           RANCHER='~2.9-0'
         fi
 


### PR DESCRIPTION
Rancher 2.9 rc builds are now released in rancher-latest repository.
Switch from current `alpha` repo to `latest` one.