### PR TITLE
Fix policyserver metrics datasource

### DIFF
--- a/pkg/kubewarden/assets/kubewarden-dashboard-policyserver.json
+++ b/pkg/kubewarden/assets/kubewarden-dashboard-policyserver.json
@@ -269,7 +269,7 @@
       "type": "stat"
     },
     {
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -383,7 +383,7 @@
       "type": "stat"
     },
     {
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": null,
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/tests/e2e/60-telemetry.spec.ts
+++ b/tests/e2e/60-telemetry.spec.ts
@@ -186,9 +186,19 @@ test.describe('Metrics', () => {
 
   test('Check metrics are visible', async({ page, nav }) => {
     await nav.pserver('default', 'Metrics')
-    await expect(page.frameLocator('iframe')
-      .getByLabel('Request accepted with no mutation percentage panel')
-      .locator('div:text-matches("[1-9][0-9.]+%")')).toBeVisible({ timeout: 7 * 60_000 })
+    for (const metric of [
+      /Request accepted with no mutation percentage/,
+      /Request rejection percentage/,
+      /Request mutation percentage/,
+      /Total accepted requests with no mutation/,
+      /Total mutated requests/,
+      /Total rejected requests/,
+      /Request count/,
+    ]) {
+      await expect(page.frameLocator('iframe')
+        .getByTestId(metric)
+        .getByText(/^[1-9][0-9.]*%?$/)).toBeVisible({ timeout: 7 * 60_000 })
+    }
   })
 
   test('Uninstall metrics', async({ ui, nav, shell }) => {


### PR DESCRIPTION
- Fix `Datasource ${DS_PROMETHEUS} was not found` error
- Fix locator on matrics test that is breaking PR e2e tests:
https://github.com/rancher/kubewarden-ui/actions/runs/10150279298/job/28067042462

![Screenshot from 2024-07-30 11-16-04](https://github.com/user-attachments/assets/aa8a2fde-adad-499c-93b9-cee36ce0d64e)
