### PR TITLE
Fix metrics test for old rancher

### DIFF
--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -18,12 +18,13 @@ expect(MODE).toMatch(/^(base|fleet|upgrade)$/)
 // Known Kubewarden versions for upgrade test, start at [0]
 const upMap: AppVersion[] = [
   // { app: 'v1.8.0', controller: '2.0.0', crds: '1.4.2', defaults: '1.8.0' },
-  { app: 'v1.9.0', controller: '2.0.5', crds: '1.4.4', defaults: '1.9.2' },
+  // { app: 'v1.9.0', controller: '2.0.5', crds: '1.4.4', defaults: '1.9.2' },
   { app: 'v1.10.0', controller: '2.0.8', crds: '1.4.5', defaults: '1.9.3' },
   { app: 'v1.11.0', controller: '2.0.10', crds: '1.4.6', defaults: '1.9.4' },
   { app: 'v1.12.0', controller: '2.0.11', crds: '1.5.0', defaults: '2.0.0' },
   { app: 'v1.13.0', controller: '2.1.0', crds: '1.5.1', defaults: '2.0.3' },
   { app: 'v1.14.0', controller: '2.2.1', crds: '1.6.0', defaults: '2.1.0' },
+  { app: 'v1.15.0', controller: '2.3.0', crds: '1.7.0', defaults: '2.2.0' },
 ]
 
 test('Initial rancher setup', async({ page, ui, nav }) => {


### PR DESCRIPTION
Rancher 2.7 and 2.8 runs with older grafana version, this fixes backwards compatibility.