### PR TITLE
Ensure user has availability to display policy reporter page

### DIFF
--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -1,7 +1,10 @@
 kubewarden:
   title: Kubewarden
   unavailability:
-    banner: 'You do not have access to the Kubewarden Dashboard. Please contact your administrator.'
+    banner: 'You do not have access to the {type}. Please contact your administrator.'
+    type:
+      dashboard: Kubewarden Dashboard
+      policyReporter: Policy Reporter
   generic:
     name: Name
   dashboard:

--- a/pkg/kubewarden/pages/c/_cluster/kubewarden/index.vue
+++ b/pkg/kubewarden/pages/c/_cluster/kubewarden/index.vue
@@ -68,7 +68,7 @@ export default {
       color="error"
       class="mt-20 mb-20"
       data-testid="kw-unavailability-banner"
-      label-key="kubewarden.unavailability.banner"
+      :label="t('kubewarden.unavailability.banner', { type: t('kubewarden.unavailability.type.dashboard') })"
     />
   </div>
   <div v-else>

--- a/tests/unit/components/PolicyReporter/PolicyReporter.spec.ts
+++ b/tests/unit/components/PolicyReporter/PolicyReporter.spec.ts
@@ -10,6 +10,7 @@ const defaultMocks = {
   $fetchState: { pending: false },
   $store:      {
     getters: {
+      'cluster/canList':            jest.fn,
       'cluster/schemaFor':          jest.fn(),
       'i18n/t':                     jest.fn(),
       'management/byId':            () => 'local',
@@ -18,7 +19,19 @@ const defaultMocks = {
   }
 };
 
+const defaultData = {
+  isAdminUser: true,
+  permissions: {
+    policyServer:           true,
+    admissionPolicy:        true,
+    clusterAdmissionPolicy: true,
+    app:                    true,
+    deployment:             true
+  }
+};
+
 const defaultComputed = {
+  hasAvailablitity:             () => null,
   hasPolicyServerSchema:        () => null,
   hasClusterPolicyReportSchema: () => null,
   hasPolicyReportSchema:        () => null,
@@ -46,9 +59,23 @@ const kwVersions = {
 };
 
 describe('component: PolicyReporter', () => {
-  it('Should show Install Kubewarden button when uninstalled', () => {
+  it('Should show unavailable banner when no permissions', () => {
     const wrapper = shallowMount(PolicyReporter as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
       mocks:    defaultMocks,
+      computed: defaultComputed,
+    });
+
+    const banner = wrapper.find('[data-testid="kw-unavailability-banner"]');
+
+    expect(banner.exists()).toBe(true);
+  });
+
+  it('Should show Install Kubewarden button when uninstalled', () => {
+    const wrapper = shallowMount(PolicyReporter as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      mocks: defaultMocks,
+      data() {
+        return defaultData;
+      },
       computed: defaultComputed,
       stubs:    { 'n-link': { template: '<span />' } }
     });
@@ -60,7 +87,10 @@ describe('component: PolicyReporter', () => {
 
   it('Should show incompatible banner with old version', () => {
     const wrapper = shallowMount(PolicyReporter as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
-      mocks:    defaultMocks,
+      mocks: defaultMocks,
+      data() {
+        return defaultData;
+      },
       computed: {
         ...defaultComputed,
         hasPolicyServerSchema: () => true,
@@ -79,7 +109,10 @@ describe('component: PolicyReporter', () => {
 
   it('Should show CRDs warning banner when not installed', () => {
     const wrapper = shallowMount(PolicyReporter as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
-      mocks:    defaultMocks,
+      mocks: defaultMocks,
+      data() {
+        return defaultData;
+      },
       computed: {
         ...defaultComputed,
         hasPolicyServerSchema: () => true,
@@ -95,7 +128,10 @@ describe('component: PolicyReporter', () => {
 
   it('Should show warning banner when main service is unavailable', () => {
     const wrapper = shallowMount(PolicyReporter as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
-      mocks:    defaultMocks,
+      mocks: defaultMocks,
+      data() {
+        return defaultData;
+      },
       computed: {
         ...defaultComputed,
         hasPolicyServerSchema: () => true,
@@ -113,7 +149,7 @@ describe('component: PolicyReporter', () => {
   it('Should show warning banner when UI service is unavailable', () => {
     const wrapper = shallowMount(PolicyReporter as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
       data() {
-        return { reporterReportingService: true };
+        return { ...defaultData, reporterReportingService: true };
       },
       mocks:    defaultMocks,
       computed: {
@@ -136,6 +172,7 @@ describe('component: PolicyReporter', () => {
     const wrapper = shallowMount(PolicyReporter as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
       data() {
         return {
+          ...defaultData,
           reporterReportingService: true,
           reporterUIService:        true,
           reporterUrl:              url


### PR DESCRIPTION
Fix #834 

The Policy Reporter page will now run the same checks as the Dashboard page to ensure that the user can view the Kubewarden resources and can install Kubewarden before showing anything.

## To Test

- As an admin install Kubewarden with the policy reporter UI
- Create a base user with access to both of the `wgpolicyk8s.io` types (`ClusterPolicyReports` and `PolicyReports`)
- Add base user to cluster
- Login as base user and navigate to policy reporter

## Screenshots

__User without permissions__

![pr-no-perm](https://github.com/user-attachments/assets/accdab39-20f0-4bbc-a191-6f1629eda294)

__User with permissions__

![pr-has-perm](https://github.com/user-attachments/assets/d1331e86-228d-47b4-a2d2-a2adc88ce659)
