### PR TITLE
Use node18 for playwright

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -117,15 +117,6 @@ jobs:
     # Check out code and install requirements
     # Use local kuberlr to avoid version skew
     - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-      with:
-        node-version: '16'
-    - name: Install playwright
-      working-directory: tests
-      run: |
-        yarn install
-        yarn playwright install chromium  # --with-deps not supported on opensuse
-
 
     # ==================================================================================================
     # Set up parameters and ENV
@@ -214,13 +205,28 @@ jobs:
     # ==================================================================================================
     # Setup playwright ENV and run tests
     # https://rancher.github.io/dashboard/testing/e2e-test#setup-for-local-tests
+    - uses: actions/setup-node@v4
+      if: env.KUBEWARDEN == 'source'
+      with:
+        node-version: '16'
+
     - name: Build Kubewarden extension
       if: env.KUBEWARDEN == 'source'
       run: |
         yarn install --ignore-engines
         VERSION=0.0.1 yarn build-pkg kubewarden
 
-    - name: Install & Execute tests
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+
+    - name: Install playwright
+      working-directory: tests
+      run: |
+        yarn install
+        yarn playwright install chromium  # --with-deps not supported on opensuse
+
+    - name: Execute tests
       timeout-minutes: 120
       working-directory: tests
       run: |

--- a/tests/package.json
+++ b/tests/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "devDependencies": {
-    "@playwright/test": "~1.44.1",
+    "@playwright/test": "^1.46.0",
     "@types/js-yaml": "^4.0.9",
     "@types/lodash": "^4.17.7",
     "@types/semver": "^7.5.8",
@@ -12,6 +12,9 @@
     "lodash": "^4.17.21",
     "playwright-qase-reporter": "^2.0.9",
     "semver": "^7.6.3"
+  },
+  "engines": {
+    "node": ">=18"
   },
   "scripts": {}
 }

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -17,12 +17,12 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@playwright/test@~1.44.1":
-  version "1.44.1"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.44.1.tgz#cc874ec31342479ad99838040e99b5f604299bcb"
-  integrity sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==
+"@playwright/test@^1.46.0":
+  version "1.46.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.46.0.tgz#ccea6d22c40ee7fa567e4192fafbdf2a907e2714"
+  integrity sha512-/QYft5VArOrGRP5pgkrfKksqsKA6CEFyGQ/gjNe6q0y4tZ1aaPfq4gIjudr1s3D+pXyrPRdsy4opKDrjBabE5w==
   dependencies:
-    playwright "1.44.1"
+    playwright "1.46.0"
 
 "@types/js-yaml@^4.0.9":
   version "4.0.9"
@@ -343,10 +343,10 @@ path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-playwright-core@1.44.1:
-  version "1.44.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.44.1.tgz#53ec975503b763af6fc1a7aa995f34bc09ff447c"
-  integrity sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==
+playwright-core@1.46.0:
+  version "1.46.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.46.0.tgz#2336ac453a943abf0dc95a76c117f9d3ebd390eb"
+  integrity sha512-9Y/d5UIwuJk8t3+lhmMSAJyNP1BUC/DqP3cQJDQQL/oWqAiuPTLgy7Q5dzglmTLwcBRdetzgNM/gni7ckfTr6A==
 
 playwright-qase-reporter@^2.0.9:
   version "2.0.9"
@@ -357,12 +357,12 @@ playwright-qase-reporter@^2.0.9:
     qase-javascript-commons "^2.0.8"
     uuid "^9.0.0"
 
-playwright@1.44.1:
-  version "1.44.1"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.44.1.tgz#5634369d777111c1eea9180430b7a184028e7892"
-  integrity sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==
+playwright@1.46.0:
+  version "1.46.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.46.0.tgz#c7ff490deae41fc1e814bf2cb62109dd9351164d"
+  integrity sha512-XYJ5WvfefWONh1uPAUAi0H2xXV5S3vrtcnXe6uAOgdGi3aSpqOSXX08IAjXW34xitfuOJsvXU5anXZxPSEQiJw==
   dependencies:
-    playwright-core "1.44.1"
+    playwright-core "1.46.0"
   optionalDependencies:
     fsevents "2.3.2"
 


### PR DESCRIPTION
Playwright requires node18, but rancher is tied to node16 for now.
 - use node16 when building extension, then switch to node18 for tests
 - upgrade playwright to 1.46.0