### PR TITLE
Fix policy server default image from fleet bundle

### DIFF
--- a/pkg/kubewarden/chart/kubewarden/policy-server/General.vue
+++ b/pkg/kubewarden/chart/kubewarden/policy-server/General.vue
@@ -41,7 +41,9 @@ export default {
 
   mixins: [ResourceFetch],
 
-  async fetch() {
+  async fetch() {},
+
+  async mounted() {
     if ( this.$store.getters['cluster/canList'](CATALOG.APP) && this.$store.getters['cluster/canList'](CATALOG.CLUSTER_REPO) ) {
       await this.$initializeFetchData(CATALOG);
       await this.$fetchType(CATALOG.CLUSTER_REPO);
@@ -167,7 +169,7 @@ export default {
     },
 
     defaultsChart() {
-      if ( this.kubewardenRepo ) {
+      if ( this.kubewardenRepo && !this.isFleet ) {
         return this.$store.getters['catalog/chart']({
           repoName:  this.kubewardenRepo.repoName,
           repoType:  this.kubewardenRepo.repoType,

--- a/pkg/kubewarden/modules/fleet.ts
+++ b/pkg/kubewarden/modules/fleet.ts
@@ -60,7 +60,7 @@ export function getPolicyServerModule(fleetBundles: FleetBundle[]): string | nul
   const fleetBundle = findFleetContent('PolicyServer', fleetBundles, 'kubewarden-crds');
 
   if ( fleetBundle ) {
-    const valuesYamlResource = fleetBundle.spec.resources.find(resource => resource.name === 'values.yaml');
+    const valuesYamlResource = fleetBundle.spec.resources.find(resource => resource.name.includes('values.yaml'));
 
     if ( valuesYamlResource ) {
       try {

--- a/tests/unit/_templates_/controllerApp.ts
+++ b/tests/unit/_templates_/controllerApp.ts
@@ -1,3 +1,4 @@
+import { FLEET } from '@shell/config/labels-annotations';
 import { CatalogApp } from '@kubewarden/types';
 
 export const mockControllerApp: CatalogApp = {
@@ -46,4 +47,21 @@ export const mockControllerApp: CatalogApp = {
     values:    {}
   },
   status: { summary: { state: 'deployed' } }
+};
+
+export const mockControllerAppWithFleet: CatalogApp = {
+  ...mockControllerApp,
+  spec: {
+    ...mockControllerApp.spec,
+    chart: {
+      ...mockControllerApp.spec.chart,
+      metadata: {
+        ...mockControllerApp.spec.chart.metadata,
+        annotations: {
+          ...mockControllerApp.spec.chart.metadata.annotations,
+          [FLEET.BUNDLE_ID]: 'fleet-default/kw-kubewarden-defaults'
+        }
+      }
+    }
+  }
 };

--- a/tests/unit/_templates_/fleetBundles.ts
+++ b/tests/unit/_templates_/fleetBundles.ts
@@ -1,0 +1,68 @@
+import { FleetBundle } from '@kubewarden/types';
+
+export const fleetBundles: FleetBundle[] = [
+  {
+    id:         'fleet-default/kw-kubewarden-defaults',
+    type:       'fleet.cattle.io.bundle',
+    apiVersion: 'fleet.cattle.io/v1alpha1',
+    kind:       'Bundle',
+    metadata:   {
+      finalizers: [
+        'fleet.cattle.io/bundle-finalizer'
+      ],
+      labels:     {
+        app:                         'kubewarden-defaults',
+        'fleet.cattle.io/commit':    'd3d98d1d971db0bc9afa6aff54c93ef4a3c45bc2',
+        'fleet.cattle.io/repo-name': 'kw'
+      },
+      name:            'kw-kubewarden-defaults',
+      namespace:       'fleet-default',
+    },
+    spec: {
+      defaultNamespace: 'kubewarden',
+      dependsOn:        [
+        { selector: { matchLabels: { app: 'kubewarden-controller' } } }
+      ],
+      helm: {
+        chart:       'kubewarden-defaults',
+        releaseName: 'kubewarden-defaults',
+        repo:        'https://charts.kubewarden.io/',
+        values:      {
+          recommendedPolicies: {
+            defaultPolicyMode: 'monitor',
+            enabled:           true
+          }
+        },
+        version: '2.2.1'
+      },
+      resources: [
+        {
+          content: '#Test resource content',
+          name:    '.chart/test/test.yaml'
+        },
+        {
+          content: `
+          kind: PolicyServer
+          global:
+            cattle:
+              systemDefaultRegistry: ghcr.io
+          policyServer:
+            image:
+              repository: "kubewarden/policy-server"
+              tag: v1.15.0
+          `,
+          name: '.chart/d496c839b4e1a2e4e1c3fcdae93ea9e344aa24e971b45300019c866216c01420/kubewarden-defaults/values.yaml'
+        }
+      ],
+      targetRestrictions: [
+        { clusterName: 'k3s-1' }
+      ],
+      targets: [
+        {
+          clusterName: 'k3s-1',
+          ignore:      {}
+        }
+      ]
+    }
+  }
+];

--- a/tests/unit/charts/policy-server/General.spec.ts
+++ b/tests/unit/charts/policy-server/General.spec.ts
@@ -3,10 +3,27 @@ import { DefaultProps } from 'vue/types/options';
 import { shallowMount } from '@vue/test-utils';
 import { describe, expect, it } from '@jest/globals';
 
-import General from '@kubewarden/chart/kubewarden/policy-server/General.vue';
 import ServiceNameSelect from '@shell/components/form/ServiceNameSelect';
+import General from '@kubewarden/chart/kubewarden/policy-server/General.vue';
 
 import { DEFAULT_POLICY_SERVER } from '@kubewarden/models/policies.kubewarden.io.policyserver.js';
+
+import { fleetBundles as bundles } from '@tests/unit/_templates_/fleetBundles';
+import { mockControllerAppWithFleet } from '@tests/unit/_templates_/controllerApp';
+
+jest.mock('@kubewarden/modules/fleet', () => ({
+  getPolicyServerModule: jest.requireActual('@kubewarden/modules/fleet').getPolicyServerModule,
+  isFleetDeployment:     jest.requireActual('@kubewarden/modules/fleet').isFleetDeployment,
+  findFleetContent:      jest.requireActual('@kubewarden/modules/fleet').findFleetContent
+}));
+
+jest.mock('@shell/mixins/resource-fetch', () => ({
+  methods: {
+    __getCountForResource: jest.fn().mockReturnValue(0),
+    $initializeFetchData:  jest.fn(),
+    $fetchType:            jest.fn()
+  }
+}));
 
 describe('component: General', () => {
   it('displays service account options', () => {
@@ -22,8 +39,8 @@ describe('component: General', () => {
         $fetchState: { pending: false },
         $store:      {
           getters: {
-            currentStore:                 () => 'current_store',
-            'current_store/all':          jest.fn(),
+            'cluster/canList':            () => true,
+            'cluster/all':                jest.fn(),
             'i18n/t':                     jest.fn(),
             'management/byId':            jest.fn(),
             'resource-fetch/refreshFlag': jest.fn()
@@ -58,8 +75,8 @@ describe('component: General', () => {
         $fetchState: { pending: false },
         $store:      {
           getters: {
-            currentStore:                 () => 'current_store',
-            'current_store/all':          jest.fn(),
+            'cluster/canList':            () => true,
+            'cluster/all':                jest.fn(),
             'i18n/t':                     jest.fn(),
             'management/byId':            jest.fn(),
             'resource-fetch/refreshFlag': jest.fn()
@@ -73,5 +90,41 @@ describe('component: General', () => {
     const selector = wrapper.findComponent(ServiceNameSelect);
 
     expect(selector.props().value).toStrictEqual(serviceAccounts[1] as String);
+  });
+
+  it('extracts latestChartVersion when isFleet is true', async() => {
+    const serviceAccounts = ['sa-1', 'sa-2', 'sa-3'];
+    const latestChartVersion = 'ghcr.io/kubewarden/policy-server:v1.15.0';
+
+    const wrapper = shallowMount(General as unknown as ExtendedVue<Vue, {}, {}, {}, DefaultProps>, {
+      propsData: { value: DEFAULT_POLICY_SERVER, serviceAccounts },
+      computed:  {
+        isCreate:      () => false,
+        defaultsChart: () => null,
+        fleetBundles:  () => bundles,
+        controllerApp: () => mockControllerAppWithFleet
+      },
+      mocks:     {
+        $fetchState: { pending: false },
+        $store:      {
+          getters: {
+            'cluster/canList':            () => true,
+            'cluster/all':                jest.fn(),
+            'management/all':             jest.fn(),
+            'i18n/t':                     jest.fn(),
+            'management/byId':            jest.fn(),
+            'resource-fetch/refreshFlag': jest.fn()
+          },
+          dispatch: jest.fn()
+        }
+      },
+      stubs: { Banner: { template: '<span />' } }
+    });
+
+    await wrapper.vm.$nextTick(); // Wait for the first DOM update
+    await wrapper.vm.$nextTick(); // Wait for another tick to ensure async operations are done
+
+    // Check that the latestChartVersion is set correctly
+    expect((wrapper.vm as any).latestChartVersion).toBe(latestChartVersion);
   });
 });


### PR DESCRIPTION
Fix #840 

When KW is installed with Fleet it should check through the bundles to find a `values.yaml` related to the policy server configuration.

The issue was caused by incorrectly searching for the `values.yaml` within a Fleet bundle's resources as well as not gating the defaults chart when managed through Fleet.



https://github.com/user-attachments/assets/db3622e2-de5c-40f3-a117-8a481c1f0ead


