### PR TITLE
[Backport] Update tests in maintenance branch

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -93,12 +93,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rancher: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && fromJSON('["2.7", "2.8"]') || fromJSON(format('["{0}"]', inputs.rancher || 'released')) }}
+        rancher: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && fromJSON('["2.7", "2.8", "2.9"]') || fromJSON(format('["{0}"]', inputs.rancher || 'released')) }}
         mode: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && fromJSON('["base", "upgrade", "fleet"]') || fromJSON(format('["{0}"]', inputs.mode || 'base')) }}
         exclude:
+          # Run full tests on 2.8 since it's latest prime version
           - rancher: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && '2.7' }}
             mode: upgrade
           - rancher: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && '2.7' }}
+            mode: fleet
+          - rancher: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && '2.9' }}
+            mode: upgrade
+          - rancher: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && '2.9' }}
             mode: fleet
 
 
@@ -131,7 +136,8 @@ jobs:
           pull_request)
             KUBEWARDEN=source;;
           schedule)
-            KUBEWARDEN=released;;
+            # Rancher 2.9 is not prime = UI is not available from official charts
+            [[ "${{ matrix.rancher }}" == *2.9* ]] && KUBEWARDEN=rc || KUBEWARDEN=released;;
           workflow_run)
             KUBEWARDEN=rc;;
         esac

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -28,14 +28,14 @@ on:
       k3s:
         description: Kubernetes version
         type: choice
-        default: 'v1.28.11-k3s2'
+        default: 'v1.28.12-k3s1'
         required: true
         options:
         - v1.26.15-k3s1
-        - v1.27.15-k3s2
-        - v1.28.11-k3s2
-        - v1.29.6-k3s2
-        - v1.30.2-k3s2
+        - v1.27.16-k3s1
+        - v1.28.12-k3s1
+        - v1.29.7-k3s1
+        - v1.30.3-k3s1
       mode:
         description: Installation mode
         type: choice
@@ -76,7 +76,7 @@ env:
   # Github -> Secrets and variables -> Actions -> New repository variable
   KUBEWARDEN: ${{ inputs.kubewarden || 'rc' }}
   K3D_VERSION: # 'v5.6.3' - optionally pin version
-  K3S_VERSION: ${{ inputs.k3s || 'v1.28.11-k3s2' }}
+  K3S_VERSION: ${{ inputs.k3s || 'v1.28.12-k3s1' }}
   K3D_CLUSTER_NAME: ${{ github.repository_owner }}-${{ github.event.repository.name }}-runner
   # First value after the && must be truthy. Otherwise, the value after the || will always be returned
   TESTBASE: ${{ github.event_name != 'workflow_dispatch' && true || inputs.testbase }}
@@ -131,15 +131,16 @@ jobs:
           pull_request)
             KUBEWARDEN=source;;
           schedule)
-            # Rancher 2.7 chart requires kubeVersion: < 1.28.0-0
-            [[ "${{ matrix.rancher }}" == "2.7" ]] && echo K3S_VERSION="v1.27.15-k3s2" | tee -a $GITHUB_ENV
             KUBEWARDEN=released;;
           workflow_run)
             KUBEWARDEN=rc;;
         esac
 
+        # Rancher 2.7 chart requires kubeVersion: < 1.28.0-0
+        [[ "${{ matrix.rancher }}" == *2.7* ]] && echo K3S_VERSION="v1.27.16-k3s1" | tee -a $GITHUB_ENV
+
         # KW extension is prime since 2.8.3
-        [[ "$KUBEWARDEN" == "source" ]] && REPO=rancher-latest || REPO=rancher-prime
+        [[ "${{ matrix.rancher }}" == *2.[78]* ]] && REPO=rancher-prime || REPO=rancher-latest
 
         # Print matrix
         echo "Event: ${{github.event_name}}"
@@ -175,11 +176,6 @@ jobs:
         # Translate to sematic version
         [ "$RANCHER" == "rc" ] && RANCHER='*-0'
         [ "$RANCHER" == "released" ] && RANCHER='*'
-
-        # Workaround for rancher 2.9 in alpha
-        if [ "$KUBEWARDEN" == "source" ]; then
-          RANCHER='~2.9-0'
-        fi
 
         # Rancher PSP is based on kubernetes version
         RANCHER_PSP=$(kubectl version -o json | jq -r '.serverVersion.minor <= "24"')

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -28,14 +28,14 @@ on:
       k3s:
         description: Kubernetes version
         type: choice
-        default: 'v1.27.14-k3s1'
+        default: 'v1.28.11-k3s2'
         required: true
         options:
         - v1.26.15-k3s1
-        - v1.27.14-k3s1
-        - v1.28.10-k3s1
-        - v1.29.5-k3s1
-        - v1.30.1-k3s1
+        - v1.27.15-k3s2
+        - v1.28.11-k3s2
+        - v1.29.6-k3s2
+        - v1.30.2-k3s2
       mode:
         description: Installation mode
         type: choice
@@ -76,7 +76,7 @@ env:
   # Github -> Secrets and variables -> Actions -> New repository variable
   KUBEWARDEN: ${{ inputs.kubewarden || 'rc' }}
   K3D_VERSION: # 'v5.6.3' - optionally pin version
-  K3S_VERSION: ${{ inputs.k3s || 'v1.27.14-k3s1' }}
+  K3S_VERSION: ${{ inputs.k3s || 'v1.28.11-k3s2' }}
   K3D_CLUSTER_NAME: ${{ github.repository_owner }}-${{ github.event.repository.name }}-runner
   # First value after the && must be truthy. Otherwise, the value after the || will always be returned
   TESTBASE: ${{ github.event_name != 'workflow_dispatch' && true || inputs.testbase }}
@@ -118,7 +118,7 @@ jobs:
     - name: Install playwright
       working-directory: tests
       run: |
-        yarn
+        yarn install
         yarn playwright install chromium  # --with-deps not supported on opensuse
 
 
@@ -167,7 +167,7 @@ jobs:
         done
 
         # Wait for cert-manager
-        kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml
+        kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.15.1/cert-manager.yaml
         kubectl wait --for=condition=Available deployment --timeout=2m -n cert-manager --all
 
         # Translate to sematic version

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -174,11 +174,19 @@ jobs:
         [ "$RANCHER" == "rc" ] && RANCHER='*-0'
         [ "$RANCHER" == "released" ] && RANCHER='*'
 
+        # Workaround for rancher 2.9 in alpha
+        if [ "$KUBEWARDEN" == "source" ]; then
+          REPO=rancher-alpha
+          RANCHER='~2.9-0'
+        fi
+
         # Rancher PSP is based on kubernetes version
         RANCHER_PSP=$(kubectl version -o json | jq -r '.serverVersion.minor <= "24"')
 
         helm repo add --force-update rancher-latest https://releases.rancher.com/server-charts/latest
+        helm repo add --force-update rancher-alpha https://releases.rancher.com/server-charts/alpha
         helm repo add --force-update rancher-prime https://charts.rancher.com/server-charts/prime
+
         helm search repo $REPO/rancher ${RANCHER:+--version "$RANCHER"}
         helm upgrade --install rancher $REPO/rancher --wait \
             --namespace cattle-system --create-namespace \

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -131,6 +131,8 @@ jobs:
           pull_request)
             KUBEWARDEN=source;;
           schedule)
+            # Rancher 2.7 chart requires kubeVersion: < 1.28.0-0
+            [[ "${{ matrix.rancher }}" == "2.7" ]] && echo K3S_VERSION="v1.27.15-k3s2" | tee -a $GITHUB_ENV
             KUBEWARDEN=released;;
           workflow_run)
             KUBEWARDEN=rc;;

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -178,7 +178,6 @@ jobs:
 
         # Workaround for rancher 2.9 in alpha
         if [ "$KUBEWARDEN" == "source" ]; then
-          REPO=rancher-alpha
           RANCHER='~2.9-0'
         fi
 

--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -88,15 +88,11 @@ test('Install UI extension', async({ page, ui }) => {
   })
 })
 
-test('Install Kubewarden', async({ page, ui, nav, context }) => {
+test('Install Kubewarden', async({ page, ui, nav }) => {
   test.skip(MODE === 'fleet')
 
-  // Required by cert-manager copy on click
-  // Setting clipboard-write on model is broken, probably playwright issue
-  await context.grantPermissions(['clipboard-read', 'clipboard-write'])
   const kwPage = new KubewardenPage(page)
   await kwPage.installKubewarden({ version: MODE === 'upgrade' ? upMap[0].controller : undefined })
-  await context.clearPermissions()
 
   // Check UI is active
   await nav.explorer('Kubewarden')

--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -18,12 +18,13 @@ expect(MODE).toMatch(/^(base|fleet|upgrade)$/)
 // Known Kubewarden versions for upgrade test, start at [0]
 const upMap: AppVersion[] = [
   // { app: 'v1.8.0', controller: '2.0.0', crds: '1.4.2', defaults: '1.8.0' },
-  { app: 'v1.9.0', controller: '2.0.5', crds: '1.4.4', defaults: '1.9.2' },
+  // { app: 'v1.9.0', controller: '2.0.5', crds: '1.4.4', defaults: '1.9.2' },
   { app: 'v1.10.0', controller: '2.0.8', crds: '1.4.5', defaults: '1.9.3' },
   { app: 'v1.11.0', controller: '2.0.10', crds: '1.4.6', defaults: '1.9.4' },
   { app: 'v1.12.0', controller: '2.0.11', crds: '1.5.0', defaults: '2.0.0' },
   { app: 'v1.13.0', controller: '2.1.0', crds: '1.5.1', defaults: '2.0.3' },
   { app: 'v1.14.0', controller: '2.2.1', crds: '1.6.0', defaults: '2.1.0' },
+  { app: 'v1.15.0', controller: '2.3.0', crds: '1.7.0', defaults: '2.2.0' },
 ]
 
 test('Initial rancher setup', async({ page, ui, nav }) => {

--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -19,12 +19,13 @@ expect(MODE).toMatch(/^(base|fleet|upgrade)$/)
 const upMap: AppVersion[] = [
   // { app: 'v1.8.0', controller: '2.0.0', crds: '1.4.2', defaults: '1.8.0' },
   // { app: 'v1.9.0', controller: '2.0.5', crds: '1.4.4', defaults: '1.9.2' },
-  { app: 'v1.10.0', controller: '2.0.8', crds: '1.4.5', defaults: '1.9.3' },
+  // { app: 'v1.10.0', controller: '2.0.8', crds: '1.4.5', defaults: '1.9.3' },
   { app: 'v1.11.0', controller: '2.0.10', crds: '1.4.6', defaults: '1.9.4' },
   { app: 'v1.12.0', controller: '2.0.11', crds: '1.5.0', defaults: '2.0.0' },
   { app: 'v1.13.0', controller: '2.1.0', crds: '1.5.1', defaults: '2.0.3' },
   { app: 'v1.14.0', controller: '2.2.1', crds: '1.6.0', defaults: '2.1.0' },
   { app: 'v1.15.0', controller: '2.3.1', crds: '1.7.0', defaults: '2.2.1' },
+  { app: 'v1.16.0', controller: '2.4.0', crds: '1.8.0', defaults: '2.3.0' },
 ]
 
 test('Initial rancher setup', async({ page, ui, nav }) => {

--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -24,7 +24,7 @@ const upMap: AppVersion[] = [
   { app: 'v1.12.0', controller: '2.0.11', crds: '1.5.0', defaults: '2.0.0' },
   { app: 'v1.13.0', controller: '2.1.0', crds: '1.5.1', defaults: '2.0.3' },
   { app: 'v1.14.0', controller: '2.2.1', crds: '1.6.0', defaults: '2.1.0' },
-  { app: 'v1.15.0', controller: '2.3.0', crds: '1.7.0', defaults: '2.2.0' },
+  { app: 'v1.15.0', controller: '2.3.1', crds: '1.7.0', defaults: '2.2.1' },
 ]
 
 test('Initial rancher setup', async({ page, ui, nav }) => {

--- a/tests/e2e/30-policyservers.spec.ts
+++ b/tests/e2e/30-policyservers.spec.ts
@@ -4,7 +4,6 @@ import { PolicyServersPage, PolicyServer } from './pages/policyservers.page'
 import { Policy, AdmissionPoliciesPage, ClusterAdmissionPoliciesPage } from './pages/policies.page'
 
 const expect3m = expect.configure({ timeout: 3 * 60_000 })
-const MODE = process.env.MODE
 
 test('Policy Servers', async({ page, ui, nav }) => {
   const server: PolicyServer = { name: 'test-policyserver' }
@@ -71,4 +70,18 @@ test('Policy Servers', async({ page, ui, nav }) => {
     await expect(page.locator('table.sortable-table')).toBeVisible()
     await expect(capRow.row).not.toBeVisible()
   })
+})
+
+test('Configure with custom values', async({ page, ui, nav }) => {
+  const psPage = new PolicyServersPage(page)
+  const ps = { name: 'test-policyserver', image: 'ghcr.io/kubewarden/policy-server:latest', replicas: 2 }
+  await psPage.create(ps, { wait: false })
+
+  await nav.pserver(ps.name)
+  await ui.button('Config').click()
+  await expect(ui.input('Name*')).toHaveValue(ps.name)
+  await expect(ui.input('Image URL')).toHaveValue(ps.image)
+  await expect(ui.input('Replicas*')).toHaveValue(ps.replicas.toString())
+
+  await psPage.delete(ps.name)
 })

--- a/tests/e2e/30-policyservers.spec.ts
+++ b/tests/e2e/30-policyservers.spec.ts
@@ -33,11 +33,7 @@ test('Policy Servers', async({ page, ui, nav }) => {
     const defaultImage = (await ui.tableRow('default').column('Image').textContent())?.trim().split(':') || []
     const createdImage = (await psRow.column('Image').textContent())?.trim().split(':') || []
     const [dImg, dVer] = [defaultImage[0], defaultImage[1]]
-    let [cImg, cVer] = [createdImage[0], createdImage[1]]
-    const latestVer = '99.0.0'
-
-    // Convert "latest" string to a valid version
-    if (MODE === 'fleet' && cVer === 'latest') cVer = latestVer
+    const [cImg, cVer] = [createdImage[0], createdImage[1]]
 
     // Validate URLs
     expect(cImg).toEqual(dImg)
@@ -47,15 +43,8 @@ test('Policy Servers', async({ page, ui, nav }) => {
     expect(semver.valid(cVer)).not.toBeNull()
     expect(semver.valid(dVer)).not.toBeNull()
 
-    if (MODE === 'fleet') {
-      expect(semver.gte(cVer, dVer)).toBeTruthy()
-      // Stable version could not be determined, using latest
-      if (semver.gt(cVer, dVer)) {
-        expect(semver.eq(cVer, latestVer)).toBeTruthy()
-      }
-    } else {
-      expect(semver.eq(cVer, dVer)).toBeTruthy()
-    }
+    // Validate version is equal to default
+    expect(semver.eq(cVer, dVer)).toBeTruthy()
   })
 
   await test.step('Check Details page', async() => {

--- a/tests/e2e/30-policyservers.spec.ts
+++ b/tests/e2e/30-policyservers.spec.ts
@@ -47,16 +47,7 @@ test('Policy Servers', async({ page, ui, nav }) => {
     expect(semver.valid(cVer)).not.toBeNull()
     expect(semver.valid(dVer)).not.toBeNull()
 
-    // Created PS should use released version
-    expect(semver.prerelease(cVer)).toBeNull()
-
-    if (MODE === 'upgrade') {
-      expect(semver.lte(cVer, dVer)).toBeTruthy()
-      // Default PS could be updated to latest rc
-      if (semver.lt(cVer, dVer)) {
-        expect(semver.prerelease(dVer)).not.toBeNull()
-      }
-    } else if (MODE === 'fleet') {
+    if (MODE === 'fleet') {
       expect(semver.gte(cVer, dVer)).toBeTruthy()
       // Stable version could not be determined, using latest
       if (semver.gt(cVer, dVer)) {

--- a/tests/e2e/60-telemetry.spec.ts
+++ b/tests/e2e/60-telemetry.spec.ts
@@ -49,7 +49,7 @@ test.describe('Tracing', () => {
     await nav.pserver('default', 'Tracing')
   })
 
-  test('Install Jaeger', async({ nav, shell }) => {
+  test('Install Jaeger', async({ nav }) => {
     // Jaeger is not installed
     await telPage.toBeIncomplete('jaeger')
     await expect(telPage.configBtn).toBeDisabled()
@@ -64,8 +64,6 @@ test.describe('Tracing', () => {
           'rbac.clusterRole': true,
         }
       })
-      // Workaround for https://github.com/jaegertracing/helm-charts/issues/581
-      await shell.run('kubectl get clusterrole jaeger-operator -o json | jq \'.rules[] |= (select(.apiGroups | index("networking.k8s.io")).resources += ["ingressclasses"])\' | kubectl apply -f -')
     }
 
     // Jaeger is installed

--- a/tests/e2e/60-telemetry.spec.ts
+++ b/tests/e2e/60-telemetry.spec.ts
@@ -186,9 +186,19 @@ test.describe('Metrics', () => {
 
   test('Check metrics are visible', async({ page, nav }) => {
     await nav.pserver('default', 'Metrics')
-    await expect(page.frameLocator('iframe')
-      .getByLabel('Request accepted with no mutation percentage panel')
-      .locator('div:text-matches("[1-9][0-9.]+%")')).toBeVisible({ timeout: 7 * 60_000 })
+    for (const metric of [
+      /Request accepted with no mutation percentage/,
+      /Request rejection percentage/,
+      /Request mutation percentage/,
+      /Total accepted requests with no mutation/,
+      /Total mutated requests/,
+      /Total rejected requests/,
+      /Request count/,
+    ]) {
+      await expect(page.frameLocator('iframe')
+        .getByTestId(metric)
+        .getByText(/^[1-9][0-9.]*%?$/)).toBeVisible({ timeout: 7 * 60_000 })
+    }
   })
 
   test('Uninstall metrics', async({ ui, nav, shell }) => {

--- a/tests/e2e/components/navigation.ts
+++ b/tests/e2e/components/navigation.ts
@@ -116,7 +116,10 @@ export class Navigation {
     @step // Policy Servers
     async pserver(name?: string, tab?: 'Policies' | 'Metrics' | 'Tracing' | 'Conditions' | 'Recent Events' | 'Related Resources') {
       await this.explorer('Kubewarden', 'PolicyServers')
-      if (name) await this.ui.tableRow(name).open()
+      if (name) {
+        await this.ui.tableRow(name).open()
+        await expect(this.page.getByTestId('kw-ps-detail-status-title')).toBeVisible()
+      }
       if (tab) await this.ui.tab(tab).click()
     }
 

--- a/tests/e2e/pages/kubewarden.page.ts
+++ b/tests/e2e/pages/kubewarden.page.ts
@@ -74,10 +74,8 @@ export class KubewardenPage extends BasePage {
       // ==================================================================================================
       // Requirements Dialog
       const welcomeStep = this.page.getByText('Kubewarden is a policy engine for Kubernetes.')
-      const certStep = this.page.getByText('Install Cert-Manager Package')
       const addRepoStep = this.page.getByRole('heading', { name: 'Repository', exact: true })
       const appInstallStep = this.page.getByRole('heading', { name: 'Kubewarden App Install', exact: true })
-      const shellBtn = this.page.getByRole('button', { name: 'Open Kubectl Shell' })
       const installBtn = this.ui.button('Install Kubewarden')
       const addRepoBtn = this.ui.button('Add Kubewarden Repository')
       const failRepo = this.page.getByText('Unable to fetch Kubewarden Helm chart')
@@ -90,20 +88,6 @@ export class KubewardenPage extends BasePage {
 
       await expect(welcomeStep).toBeVisible()
       await installBtn.click()
-
-      // Cert-Manager
-      await certStep.or(addRepoBtn).waitFor()
-      if (await certStep.isVisible()) {
-        // Copy command by clicking and read it from clipboard
-        await this.page.locator('code.copy').click()
-        const copiedText = await this.page.evaluate(() => navigator.clipboard.readText())
-        expect(copiedText).toContain('kubectl')
-        // Run copied command in shell
-        await shellBtn.click()
-        const shell = new Shell(this.page)
-        await expect(shell.screen).toBeVisible()
-        await shell.run(copiedText as string)
-      }
 
       // Add repository screen
       await expect(addRepoStep).toBeVisible()

--- a/tests/e2e/pages/policyservers.page.ts
+++ b/tests/e2e/pages/policyservers.page.ts
@@ -55,6 +55,9 @@ export class PolicyServersPage extends BasePage {
         await this.goto()
         await this.ui.button('Create').click()
       }
+      // Page is ready when it loads default image
+      await expect(this.page.getByTestId('ps-config-image-inputs').getByText('Default Image')).toBeVisible()
+
       await this.setValues(ps)
       await this.ui.button('Create').click()
       // Get row and wait for Active state


### PR DESCRIPTION
New features are released only to rancher 2.9, which will soon break test compatibility between main and maintenance branch (release-1.6).
This brings tests in release-1.6 branch up-to-date with main. They will be used for testing rancher 2.7 and 2.8 and kept in maintenance mode.

Test improvements for 2.9 will go into main branch.

To be merged with `1.6.4` release because it requires
 - fleet fix https://github.com/rancher/kubewarden-ui/pull/856
 - metrics fix https://github.com/rancher/kubewarden-ui/pull/828