### PR TITLE
Run tests from maintenance branch on old rancher

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -114,9 +114,17 @@ jobs:
     runs-on: self-hosted
     steps:
     # ==================================================================================================
-    # Check out code and install requirements
+    # Check out code
     # Use local kuberlr to avoid version skew
+
+    # Test from maintenance branch for Rancher < 2.9
+    - name: Find checkout branch ref
+      id: set-ref
+      run: echo "ref=$( [[ ${{matrix.rancher}} == 2.[78]* ]] && echo 'release-1.6' || echo '')" | tee -a $GITHUB_OUTPUT
+
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ steps.set-ref.outputs.ref }}
 
     # ==================================================================================================
     # Set up parameters and ENV


### PR DESCRIPTION
Trigger tests from selected branch based on rancher version:
 - rancher 2.9: main
 - rancher 2.7 & 2.8: release-1.6

To be merged with 1.6.4 release because it requires https://github.com/rancher/kubewarden-ui/pull/860