### PR TITLE
Support `matchConditions` for policy spec

### DIFF
--- a/pkg/kubewarden/chart/kubewarden/admission/MatchConditions.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/MatchConditions.vue
@@ -97,16 +97,23 @@ export default {
   },
 
   methods: {
+    emitUpdate() {
+      this.$emit('update:matchConditions', this.matchConditions);
+    },
+
     addCondition() {
       this.matchConditions.push({ name: '', expression: '' });
+      this.emitUpdate();
     },
 
     removeCondition(index) {
       this.matchConditions.splice(index, 1);
+      this.emitUpdate();
     },
 
     handleInput(e, index) {
       this.$set(this.matchConditions[index], 'expression', e);
+      this.emitUpdate();
     }
   }
 };
@@ -141,7 +148,7 @@ export default {
           </button>
         </div>
 
-        <h4>Expression</h4>
+        <h4>{{ t('kubewarden.policyConfig.matchConditions.expression.label') }}</h4>
         <CodeMirror
           :ref="`cm-${ index }`"
           :value="condition.expression"
@@ -153,7 +160,13 @@ export default {
       </InfoBox>
     </div>
 
-    <button v-if="!isView" data-testid="kw-policy-match-condition-add" type="button" class="btn role-tertiary add" @click="addCondition">
+    <button
+      v-if="!isView"
+      data-testid="kw-policy-match-condition-add"
+      type="button"
+      class="btn role-tertiary add"
+      @click="addCondition"
+    >
       {{ t('kubewarden.policyConfig.matchConditions.add') }}
     </button>
   </div>

--- a/pkg/kubewarden/chart/kubewarden/admission/MatchConditions.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/MatchConditions.vue
@@ -1,0 +1,194 @@
+<script>
+import { _CREATE, _VIEW } from '@shell/config/query-params';
+
+import CodeMirror from '@shell/components/CodeMirror';
+import InfoBox from '@shell/components/InfoBox';
+import { LabeledInput } from '@components/Form/LabeledInput';
+
+export default {
+  props: {
+    activeTab: {
+      type:    String,
+      default: null
+    },
+    mode: {
+      type:    String,
+      default: _CREATE
+    },
+    value: {
+      type:     Object,
+      required: true
+    }
+  },
+
+  components: {
+    CodeMirror, InfoBox, LabeledInput
+  },
+
+  data() {
+    const matchConditions = this.value?.policy?.spec?.matchConditions || [];
+
+    return { matchConditions };
+  },
+
+  watch: {
+    activeTab() {
+      if ( this.activeTab === 'matchConditions' ) {
+        this.$nextTick(() => {
+          Object.keys(this.$refs).forEach((refKey) => {
+            if ( refKey.startsWith('cm-') ) {
+              const cmInstance = this.$refs[refKey][0];
+
+              if ( cmInstance && typeof cmInstance.refresh === 'function' ) {
+                cmInstance.refresh();
+              }
+            }
+          });
+        });
+      }
+    }
+  },
+
+  computed: {
+    isView() {
+      return this.mode === _VIEW;
+    },
+
+    codeMirrorOptions() {
+      const readOnly = this.isView;
+
+      const gutters = [];
+
+      if ( !readOnly ) {
+        gutters.push('CodeMirror-lint-markers');
+      }
+
+      gutters.push('CodeMirror-foldgutter');
+
+      return {
+        readOnly,
+        gutters,
+        mode:            'javascript',
+        lint:            !readOnly,
+        lineNumbers:     !readOnly,
+        styleActiveLine: true,
+        tabSize:         2,
+        indentWithTabs:  false,
+        cursorBlinkRate: ( readOnly ? -1 : 530 ),
+        extraKeys:       {
+          'Ctrl-Space': 'autocomplete',
+
+          Tab: (cm) => {
+            if ( cm.somethingSelected() ) {
+              cm.indentSelection('add');
+
+              return;
+            }
+
+            cm.execCommand('insertSoftTab');
+          },
+
+          'Shift-Tab': (cm) => {
+            cm.indentSelection('subtract');
+          }
+        }
+      };
+    }
+  },
+
+  methods: {
+    addCondition() {
+      this.matchConditions.push({ name: '', expression: '' });
+    },
+
+    removeCondition(index) {
+      this.matchConditions.splice(index, 1);
+    },
+
+    handleInput(e, index) {
+      this.$set(this.matchConditions[index], 'expression', e);
+    }
+  }
+};
+</script>
+
+<template>
+  <div>
+    <p v-clean-html="t('kubewarden.policyConfig.matchConditions.description', {}, true)" class="mb-20" />
+
+    <div v-for="(condition, index) in matchConditions" :key="index" class="mb-20 condition">
+      <InfoBox>
+        <div class="condition__name-container">
+          <LabeledInput
+            v-model="condition.name"
+            class="mb-10 condition__name"
+            :data-testid="`kw-policy-match-condition-name-input-${ index }`"
+            :mode="mode"
+            :label="t('kubewarden.generic.name')"
+            :placeholder="t('kubewarden.policyConfig.matchConditions.name.placeholder')"
+            :required="true"
+          />
+
+          <button
+            v-if="!isView"
+            :data-testid="`kw-policy-match-condition-remove-button-${ index }`"
+            type="button"
+            :disabled="isView"
+            class="btn role-link remove btn-sm"
+            @click="removeCondition(index)"
+          >
+            {{ t('kubewarden.policyConfig.matchConditions.remove') }}
+          </button>
+        </div>
+
+        <h4>Expression</h4>
+        <CodeMirror
+          :ref="`cm-${ index }`"
+          :value="condition.expression"
+          :options="codeMirrorOptions"
+          :class="{fill: true}"
+          :data-testid="`kw-policy-match-condition-expression-${ index }`"
+          @onInput="(e) => handleInput(e, index)"
+        />
+      </InfoBox>
+    </div>
+
+    <button v-if="!isView" data-testid="kw-policy-match-condition-add" type="button" class="btn role-tertiary add" @click="addCondition">
+      {{ t('kubewarden.policyConfig.matchConditions.add') }}
+    </button>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+::v-deep code {
+  padding: 2px;
+}
+
+.fill {
+  flex: 1;
+}
+
+::v-deep .code-mirror  {
+  position: relative;
+
+  .CodeMirror {
+    background-color: var(--yaml-editor-bg);
+    & .CodeMirror-gutters {
+      background-color: var(--yaml-editor-bg);
+    }
+  }
+}
+
+.condition {
+  &__name-container {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+
+  &__name {
+    width: 50%;
+  }
+}
+</style>

--- a/pkg/kubewarden/chart/kubewarden/admission/index.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/index.vue
@@ -109,6 +109,14 @@ export default {
 
     setActiveTab(tab) {
       this.activeTab = tab;
+    },
+
+    updateMatchConditions(matchConditions) {
+      if ( !this.chartValues.policy.spec ) {
+        this.$set(this.chartValues.policy, 'spec', {});
+      }
+
+      this.$set(this.chartValues.policy.spec, 'matchConditions', matchConditions);
     }
   }
 };
@@ -164,7 +172,7 @@ export default {
     </template>
 
     <Tab name="matchConditions" :label="t('kubewarden.policyConfig.tabs.matchConditions')" :weight="95" @active="setActiveTab('matchConditions')">
-      <MatchConditions v-model="chartValues" :active-tab="activeTab" :mode="mode" />
+      <MatchConditions v-model="chartValues" :active-tab="activeTab" :mode="mode" @update:matchConditions="updateMatchConditions" />
     </Tab>
 
     <Tab name="rules" :label="t('kubewarden.policyConfig.tabs.rules')" :weight="94">

--- a/pkg/kubewarden/chart/kubewarden/admission/index.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/index.vue
@@ -16,6 +16,7 @@ import Rules from './Rules';
 import NamespaceSelector from './NamespaceSelector';
 import Settings from './Settings';
 import ContextAware from './ContextAware';
+import MatchConditions from './MatchConditions';
 
 export default {
   props: {
@@ -34,7 +35,7 @@ export default {
   },
 
   components: {
-    General, Questions, Rules, NamespaceSelector, Settings, ContextAware, Tab
+    General, Questions, Rules, NamespaceSelector, Settings, ContextAware, MatchConditions, Tab
   },
 
   inject: ['chartType'],
@@ -162,7 +163,11 @@ export default {
       </Tab>
     </template>
 
-    <Tab name="rules" :label="t('kubewarden.policyConfig.tabs.rules')" :weight="95">
+    <Tab name="matchConditions" :label="t('kubewarden.policyConfig.tabs.matchConditions')" :weight="95" @active="setActiveTab('matchConditions')">
+      <MatchConditions v-model="chartValues" :active-tab="activeTab" :mode="mode" />
+    </Tab>
+
+    <Tab name="rules" :label="t('kubewarden.policyConfig.tabs.rules')" :weight="94">
       <Rules v-model="chartValues" data-testid="kw-policy-config-rules-tab" :mode="mode" />
     </Tab>
   </div>

--- a/pkg/kubewarden/components/Policies/Create.vue
+++ b/pkg/kubewarden/components/Policies/Create.vue
@@ -630,6 +630,10 @@ $color: var(--body-text) !important;
   }
 }
 
+::v-deep .footer-error {
+  margin-top: 15px;
+}
+
 .wizard {
   position: relative;
   height: 100%;

--- a/pkg/kubewarden/components/Policies/Create.vue
+++ b/pkg/kubewarden/components/Policies/Create.vue
@@ -61,8 +61,6 @@ export default ({
   mixins: [CreateEditView],
 
   async fetch() {
-    this.errors = [];
-
     if ( this.hasArtifactHub ) {
       await this.getPackages();
     }
@@ -73,7 +71,6 @@ export default ({
 
   data() {
     return {
-      errors:            [],
       bannerTitle:       null,
       shortDescription:  null,
       loadingPackages:   false,
@@ -91,6 +88,7 @@ export default ({
 
       hasCustomPolicy: false,
       yamlOption:      VALUES_STATE.FORM,
+      finishAttempts:  0,
 
       // Steps
       stepPolicies: {
@@ -296,18 +294,43 @@ export default ({
         }
 
         removeEmptyAttrs(out); // Clean up empty values from questions
-        merge(this.value, out);
+
+        if ( this.finishAttempts > 0 ) {
+          // Remove keys that are not in the new spec
+          Object.keys(this.value.spec).forEach((key) => {
+            if ( !(key in out.spec) ) {
+              this.$delete(this.value.spec, key);
+            }
+          });
+
+          // Then, set or update the remaining keys
+          Object.keys(out.spec).forEach((key) => {
+            this.$set(this.value.spec, key, out.spec[key]);
+          });
+        } else {
+          merge(this.value, out);
+        }
 
         // If create new namespace option is selected, create the ns before saving the policy
         if ( this.chartType === KUBEWARDEN.ADMISSION_POLICY && this.chartValues?.isNamespaceNew ) {
           await this.createNamespace(this.value?.metadata?.namespace);
         }
 
-        await this.save(event);
+        await this.attemptSave(event);
       } catch (e) {
-        handleGrowl({ error: e, store: this.$store });
-
         console.error('Error creating policy', e); // eslint-disable-line no-console
+      }
+    },
+
+    async attemptSave(event) {
+      await this.save(event);
+
+      // Check for errors set by the mixin
+      if ( this.errors && this.errors.length > 0 ) {
+        const error = new Error('Save operation failed');
+
+        this.finishAttempts++;
+        throw error; // Force an error to be caught in the finish method
       }
     },
 

--- a/pkg/kubewarden/edit/policies.kubewarden.io.admissionpolicy.vue
+++ b/pkg/kubewarden/edit/policies.kubewarden.io.admissionpolicy.vue
@@ -84,3 +84,9 @@ export default {
     />
   </CruResource>
 </template>
+
+<style lang="scss" scoped>
+::v-deep .cru__footer {
+  z-index: 1;
+}
+</style>

--- a/pkg/kubewarden/edit/policies.kubewarden.io.clusteradmissionpolicy.vue
+++ b/pkg/kubewarden/edit/policies.kubewarden.io.clusteradmissionpolicy.vue
@@ -82,6 +82,7 @@ export default {
   <Create v-if="isCreate" :value="value" :mode="mode" />
   <CruResource
     v-else
+    :errors="errors"
     :resource="value"
     :mode="realMode"
     :can-yaml="false"
@@ -94,3 +95,9 @@ export default {
     />
   </CruResource>
 </template>
+
+<style lang="scss" scoped>
+::v-deep .cru__footer {
+  z-index: 1;
+}
+</style>

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -241,6 +241,8 @@ kubewarden:
       description: Match Conditions use <a href="https://kubernetes.io/docs/reference/using-api/cel/" target="_blank" rel="noopener noreferrer nofollow">CEL expressions</a> to define fine-grained request filtering for policies, evaluating conditions before applying policy rules. This field only takes effect if the Kubernetes cluster has the <code>AdmissionWebhookMatchConditions</code> feature gate enabled.
       name:
         placeholder: e.g. exclude-resource
+      expression:
+        label: Expression
     module:
       label: Module
       tooltip: This is the WebAssembly module that holds the validation or mutation logic.

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -230,9 +230,17 @@ kubewarden:
       namespaceSelector: Namespace Selector
       settings: Settings
       contextAware: Context Aware Resources
+      matchConditions: Match Conditions
     serverSelect:
       label: Policy Server
       tooltip: The PolicyServer that will receive the requests to be validated.
+    matchConditions:
+      label: Match Conditions
+      add: Add Match Condition
+      remove: Remove Condition
+      description: Match Conditions use <a href="https://kubernetes.io/docs/reference/using-api/cel/" target="_blank" rel="noopener noreferrer nofollow">CEL expressions</a> to define fine-grained request filtering for policies, evaluating conditions before applying policy rules. This field only takes effect if the Kubernetes cluster has the <code>AdmissionWebhookMatchConditions</code> feature gate enabled.
+      name:
+        placeholder: e.g. exclude-resource
     module:
       label: Module
       tooltip: This is the WebAssembly module that holds the validation or mutation logic.

--- a/pkg/kubewarden/types/kubewarden.ts
+++ b/pkg/kubewarden/types/kubewarden.ts
@@ -1,5 +1,6 @@
 import {
-  V1SecurityContext, V1PodSecurityContext, V1ObjectMeta, V1EnvVar, V1LabelSelector, V1Condition
+  V1SecurityContext, V1PodSecurityContext, V1ObjectMeta, V1EnvVar, V1LabelSelector, V1Condition,
+  V1MatchCondition
 } from '@kubernetes/client-node';
 
 export const KUBEWARDEN_PRODUCT_NAME = 'kubewarden';
@@ -84,6 +85,7 @@ export interface Policy {
   metadata: V1ObjectMeta;
   spec: {
     backgroundAudit?: boolean;
+    matchConditions?: V1MatchCondition[];
     matchPolicy?: string;
     mode?: string;
     module: string;

--- a/pkg/kubewarden/types/policy.ts
+++ b/pkg/kubewarden/types/policy.ts
@@ -18,6 +18,7 @@ export const DEFAULT_POLICY: Policy = {
       resources:   [],
       operations:  []
     }],
+    matchConditions:   [],
     mutating:          false,
     namespaceSelector: {
       matchExpressions: [],

--- a/tests/unit/charts/admission/MatchConditions.spec.ts
+++ b/tests/unit/charts/admission/MatchConditions.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { shallowMount } from '@vue/test-utils';
+
+import MatchConditions from '@kubewarden/chart/kubewarden/admission/MatchConditions.vue';
+
+jest.mock('@shell/components/CodeMirror', () => ({ template: '<div class="code-mirror"></div>' }));
+
+const createWrapper = (propsData = {}, mocks = {}) => {
+  return shallowMount(MatchConditions, {
+    propsData,
+    mocks,
+    stubs: {
+      CodeMirror:   true,
+      InfoBox:      true,
+      LabeledInput: true,
+    },
+  });
+};
+
+const testCondition1 = { name: 'exclude-leases', expression: '!(request.resource.group == "coordination.k8s.io" && request.resource.resource == "leases")' };
+const testCondition2 = { name: 'rbac', expression: 'request.resource.group != "rbac.authorization.k8s.io"' };
+
+describe('MatchConditions.vue', () => {
+  it('renders the correct number of conditions based on the initial value', () => {
+    const value = { policy: { spec: { matchConditions: [testCondition1, testCondition2] } } };
+    const wrapper = createWrapper({ value });
+
+    expect(wrapper.findAll('.condition').length).toBe(2);
+  });
+
+  it('adds a new condition when addCondition is called', async() => {
+    const value = { policy: { spec: { matchConditions: [] } } };
+    const wrapper = createWrapper({ value });
+
+    wrapper.vm.addCondition();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.matchConditions.length).toBe(1);
+    expect(wrapper.findAll('.condition').length).toBe(1);
+  });
+
+  it('removes a condition when removeCondition is called', async() => {
+    const value = { policy: { spec: { matchConditions: [testCondition1, testCondition2] } } };
+    const wrapper = createWrapper({ value });
+
+    wrapper.vm.removeCondition(0);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.matchConditions.length).toBe(1);
+    expect(wrapper.findAll('.condition').length).toBe(1);
+  });
+
+  it('handles input correctly when handleInput is called', async() => {
+    const newExp = '!("system:nodes" in request.userInfo.groups)';
+    const value = { policy: { spec: { matchConditions: [testCondition1, testCondition2] } } };
+    const wrapper = createWrapper({ value });
+
+    wrapper.vm.handleInput(newExp, 0);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.matchConditions[0].expression).toBe(newExp);
+  });
+
+  it('refreshes CodeMirror instances when activeTab is set to matchConditions', async() => {
+    const value = { policy: { spec: { matchConditions: [testCondition1, testCondition2] } } };
+    const wrapper = createWrapper({ value });
+
+    wrapper.vm.$refs['cm-0'] = [{ refresh: jest.fn() }];
+    wrapper.setProps({ activeTab: 'matchConditions' });
+
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.$refs['cm-0'][0].refresh).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fix #849 

This will add a "Match Conditions" tab to the policy configuration which allows the user to input multiple `matchCondition` expressions to the policy's spec.


https://github.com/user-attachments/assets/cd4e12c0-7143-456c-8d0a-c361c34a8e04

