### PR TITLE
Navigation should wait until PS page loads

### DIFF
--- a/tests/e2e/components/navigation.ts
+++ b/tests/e2e/components/navigation.ts
@@ -116,7 +116,10 @@ export class Navigation {
     @step // Policy Servers
     async pserver(name?: string, tab?: 'Policies' | 'Metrics' | 'Tracing' | 'Conditions' | 'Recent Events' | 'Related Resources') {
       await this.explorer('Kubewarden', 'PolicyServers')
-      if (name) await this.ui.tableRow(name).open()
+      if (name) {
+        await this.ui.tableRow(name).open()
+        await expect(this.page.getByTestId('kw-ps-detail-status-title')).toBeVisible()
+      }
       if (tab) await this.ui.tab(tab).click()
     }
 


### PR DESCRIPTION
This fixes problem in tests when button is clicked before page loads and action fails.