### PR TITLE
Test tracing on fleet deployments

### DIFF
--- a/tests/e2e/60-telemetry.spec.ts
+++ b/tests/e2e/60-telemetry.spec.ts
@@ -12,12 +12,12 @@ const jaegerChart: Chart = { title: 'jaeger-operator', name: 'jaeger-operator', 
 // Monitoring
 const monitoringChart: Chart = { title: 'Monitoring', check: 'rancher-monitoring' }
 
-test.skip(process.env.MODE === 'fleet')
-
 /**
  * Expect timeout has to be increased after telemetry installation on local cluster
  */
 test('Install OpenTelemetry', async({ page, nav }) => {
+  test.skip(process.env.MODE === 'fleet')
+
   const apps = new RancherAppsPage(page)
   const telPage = new TelemetryPage(page)
 
@@ -50,6 +50,8 @@ test.describe('Tracing', () => {
   })
 
   test('Install Jaeger', async({ nav }) => {
+    test.skip(process.env.MODE === 'fleet')
+
     // Jaeger is not installed
     await telPage.toBeIncomplete('jaeger')
     await expect(telPage.configBtn).toBeDisabled()
@@ -72,6 +74,8 @@ test.describe('Tracing', () => {
   })
 
   test('Enable tracing', async({ ui, shell }) => {
+    test.skip(process.env.MODE === 'fleet')
+
     await telPage.toBeIncomplete('config')
     await telPage.configBtn.click()
     await apps.updateApp('rancher-kubewarden-controller', {
@@ -103,6 +107,8 @@ test.describe('Tracing', () => {
   })
 
   test('Uninstall tracing', async({ ui, nav, shell }) => {
+    test.skip(process.env.MODE === 'fleet')
+
     // Clean up
     await apps.updateApp('rancher-kubewarden-controller', {
       questions: async() => {
@@ -125,6 +131,8 @@ test.describe('Tracing', () => {
 })
 
 test.describe('Metrics', () => {
+  test.skip(process.env.MODE === 'fleet')
+
   let apps: RancherAppsPage
   let telPage: TelemetryPage
 
@@ -230,6 +238,8 @@ test.describe('Metrics', () => {
 })
 
 test('Uninstall OpenTelemetry', async({ page }) => {
+  test.skip(process.env.MODE === 'fleet')
+
   const apps = new RancherAppsPage(page)
   await apps.deleteApp('opentelemetry-operator')
   await apps.deleteRepository(otelRepo)

--- a/tests/e2e/fleet/jaeger-operator/fleet.yaml
+++ b/tests/e2e/fleet/jaeger-operator/fleet.yaml
@@ -1,0 +1,15 @@
+defaultNamespace: jaeger
+
+helm:
+  releaseName: jaeger-operator
+  chart: jaeger-operator
+  version: "*" # 2.56.0
+  repo: https://jaegertracing.github.io/helm-charts
+  values:
+    rbac:
+      clusterRole: true
+    jaeger:
+      create: true
+
+labels:
+  name: jaeger-operator

--- a/tests/e2e/fleet/kubewarden/controller/fleet.yaml
+++ b/tests/e2e/fleet/kubewarden/controller/fleet.yaml
@@ -15,6 +15,27 @@ helm:
       policyReporter: true
       cronJob:
         schedule: "*/1 * * * *" # every minute
+    telemetry:
+      # metrics:
+        # enabled: true
+        # port: 8080
+      tracing:
+        enabled: true
+        jaeger:
+          endpoint: jaeger-operator-jaeger-collector.jaeger.svc.cluster.local:4317
+          tls:
+           insecure: true
+    auditScanner:
+      policyReporter: true
+
+diff:
+  comparePatches:
+  - apiVersion: opentelemetry.io/v1alpha1
+    kind: OpenTelemetryCollector
+    name: kubewarden
+    namespace: cattle-kubewarden-system
+    operations:
+    - {"op": "remove", "path": "/spec"}
 
 labels:
   app: rancher-kubewarden-controller
@@ -23,3 +44,9 @@ dependsOn:
   - selector:
       matchLabels:
         app: rancher-kubewarden-crds
+  - selector:
+      matchLabels:
+        name: opentelemetry
+  - selector:
+      matchLabels:
+        name: jaeger-operator

--- a/tests/e2e/fleet/open-telemetry/fleet.yaml
+++ b/tests/e2e/fleet/open-telemetry/fleet.yaml
@@ -1,0 +1,12 @@
+defaultNamespace: opentelemetry
+helm:
+  releaseName: opentelemetry
+  chart: opentelemetry-operator
+  version: "*" # 0.68.1
+  repo: https://open-telemetry.github.io/opentelemetry-helm-charts
+  values:
+    manager:
+      collectorImage:
+        repository: "otel/opentelemetry-collector-contrib"
+labels:
+  name: opentelemetry


### PR DESCRIPTION
Currently metrics & tracing tests are skipped on fleet.

This adds setup for tracing in fleet deployment and schedule tracing test.