### PR TITLE
Temporary disable of application-collection

### DIFF
--- a/tests/e2e/components/rancher-ui.ts
+++ b/tests/e2e/components/rancher-ui.ts
@@ -184,6 +184,6 @@ export class RancherUI {
 
   static get hasAppCollection(): boolean {
     // OCI repository support was added in 2.9
-    return this.isPrime && this.isVersion('>=2.9')
+    return this.isPrime && this.isVersion('>=2.9') && false
   }
 }


### PR DESCRIPTION
Auth token functionality to access application-collection is not implemented yet, disabling tests until it's ready.

Fixes nightly tests: https://github.com/rancher/kubewarden-ui/actions/runs/10604503526/job/29406537840