### PR TITLE
[backport] Pin otel operator version to 0.69

### DIFF
--- a/tests/e2e/60-telemetry.spec.ts
+++ b/tests/e2e/60-telemetry.spec.ts
@@ -5,7 +5,9 @@ import { RancherUI } from './components/rancher-ui'
 
 // OpenTelemetry
 const otelRepo: ChartRepo = { name: 'open-telemetry', url: 'https://open-telemetry.github.io/opentelemetry-helm-charts' }
-const otelChart: Chart = { title: 'opentelemetry-operator', name: 'opentelemetry-operator', namespace: 'open-telemetry', check: 'opentelemetry-operator' }
+// In 0.70.0 (opentelemetry-collector-contrib:109) Log is redirected to file in otc-container, which breaks "Everything is ready." check
+// Pin to <0.69.0 until https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35474 is out
+const otelChart: Chart = { title: 'opentelemetry-operator', name: 'opentelemetry-operator', namespace: 'open-telemetry', check: 'opentelemetry-operator', version: '0.69.0' }
 // Jaeger Tracing
 const jaegerRepo: ChartRepo = { name: 'jaegertracing', url: 'https://jaegertracing.github.io/helm-charts' }
 const jaegerChart: Chart = { title: 'jaeger-operator', name: 'jaeger-operator', namespace: 'jaeger', check: 'jaeger-operator' }


### PR DESCRIPTION
Failing check:
```
kubectl logs -l app=kubewarden-policy-server-default -n cattle-kubewarden-system -c otc-container | grep -F "Everything is ready."
```