### PR TITLE
Revert "Pin otel operatov version to 0.69"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![E2E](https://github.com/kubewarden/ui/actions/workflows/playwright.yml/badge.svg)](https://github.com/kubewarden/ui/actions/workflows/playwright.yml)
+[![E2E](https://github.com/rancher/kubewarden-ui/actions/workflows/playwright.yml/badge.svg)](https://github.com/rancher/kubewarden-ui/actions/workflows/playwright.yml)
 
 # Kubewarden UI
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,3 +1,16 @@
+## [Extension test matrix](https://github.com/rancher/kubewarden-ui/blob/main/.github/workflows/playwright.yml)
+
+| Trigger            	| Rancher    	| Mode    	| UI Ext 	| K3S  	| Notes                            	| Status 	|
+|--------------------	|------------	|---------	|--------	|------	|----------------------------------	|:------:	|
+| nightly (schedule) 	| 2.7 (p)    	| base    	| prime  	| 1.27 	|                                  	| [![E2E](https://github.com/rancher/kubewarden-ui/actions/workflows/playwright.yml/badge.svg?event=schedule)](https://github.com/rancher/kubewarden-ui/actions/workflows/playwright.yml?query=event%3Aschedule) |
+|                    	| 2.8 (p)    	| base    	| prime  	| 1.28 	|                                  	|  |
+|                    	| 2.9 (p)    	| base    	| prime  	| 1.30 	| install kubewarden from UI       	|  |
+|                    	| 2.9 (p)    	| upgrade 	| prime  	| 1.30 	| upgrade path of kubewarden stack 	|  |
+|                    	| 2.9 (p)    	| fleet   	| prime  	| 1.30 	| install kubewarden by fleet      	|  |
+| release (tag)      	| ^          	| ^       	| github 	| ^    	| same matrix as nightly job       	| [![E2E](https://github.com/rancher/kubewarden-ui/actions/workflows/playwright.yml/badge.svg?event=workflow_run)](https://github.com/rancher/kubewarden-ui/actions/workflows/playwright.yml?query=event%3Aworkflow_run) |
+| pull request       	| latest (c) 	| base    	| source 	| 1.30 	|                                  	|  |
+| manual             	| any        	| any      	| any    	| any  	|                                  	|  |
+
 ## Setup
 
 ```bash

--- a/tests/e2e/60-telemetry.spec.ts
+++ b/tests/e2e/60-telemetry.spec.ts
@@ -5,9 +5,7 @@ import { RancherUI } from './components/rancher-ui'
 
 // OpenTelemetry
 const otelRepo: ChartRepo = { name: 'open-telemetry', url: 'https://open-telemetry.github.io/opentelemetry-helm-charts' }
-// In 0.70.0 (opentelemetry-collector-contrib:109) Log is redirected to file in otc-container, which breaks "Everything is ready." check
-// Pin to <0.69.0 until https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35474 is out
-const otelChart: Chart = { title: 'opentelemetry-operator', name: 'opentelemetry-operator', namespace: 'open-telemetry', check: 'opentelemetry-operator', version: '0.69.0' }
+const otelChart: Chart = { title: 'opentelemetry-operator', name: 'opentelemetry-operator', namespace: 'open-telemetry', check: 'opentelemetry-operator' }
 // Jaeger Tracing
 const jaegerRepo: ChartRepo = { name: 'jaegertracing', url: 'https://jaegertracing.github.io/helm-charts' }
 const jaegerChart: Chart = { title: 'jaeger-operator', name: 'jaeger-operator', namespace: 'jaeger', check: 'jaeger-operator' }


### PR DESCRIPTION
- OTEL version with a fix was released, removing fixed version.
- add testing matrix for overview on what we run
- fix kubewarden-ui badge url