### PR TITLE
Workaround for artifacthub limits

### DIFF
--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -20,12 +20,13 @@ const upMap: AppVersion[] = [
   // { app: 'v1.8.0', controller: '2.0.0', crds: '1.4.2', defaults: '1.8.0' },
   // { app: 'v1.9.0', controller: '2.0.5', crds: '1.4.4', defaults: '1.9.2' },
   // { app: 'v1.10.0', controller: '2.0.8', crds: '1.4.5', defaults: '1.9.3' },
-  { app: 'v1.11.0', controller: '2.0.10', crds: '1.4.6', defaults: '1.9.4' },
+  // { app: 'v1.11.0', controller: '2.0.10', crds: '1.4.6', defaults: '1.9.4' },
   { app: 'v1.12.0', controller: '2.0.11', crds: '1.5.0', defaults: '2.0.0' },
   { app: 'v1.13.0', controller: '2.1.0', crds: '1.5.1', defaults: '2.0.3' },
   { app: 'v1.14.0', controller: '2.2.1', crds: '1.6.0', defaults: '2.1.0' },
   { app: 'v1.15.0', controller: '2.3.1', crds: '1.7.0', defaults: '2.2.1' },
   { app: 'v1.16.0', controller: '2.4.0', crds: '1.8.0', defaults: '2.3.1' },
+  { app: 'v1.17.0', controller: '3.0.1', crds: '1.9.0', defaults: '2.4.0' },
 ]
 
 // Support for Rancher 2.9 was added in KW 1.13.0
@@ -165,11 +166,13 @@ test('Whitelist Artifact Hub', async({ page, ui, nav }) => {
     // CAP
     await nav.capolicy()
     await ui.button('Create').click()
+    await cap.handleRateLimitError()
     await expect(cap.cards()).toHaveCount(capCount)
     await expect(cap.cards({ signed: true, official: true })).toHaveCount(capCount)
     // AP
     await nav.apolicy()
     await ui.button('Create').click()
+    await cap.handleRateLimitError()
     await expect(cap.cards()).toHaveCount(apCount)
     await expect(cap.cards({ signed: true, official: true })).toHaveCount(apCount)
 
@@ -184,6 +187,7 @@ test('Whitelist Artifact Hub', async({ page, ui, nav }) => {
   await test.step('Check Unofficial policies', async() => {
     await nav.capolicy()
     await ui.button('Create').click()
+    await cap.handleRateLimitError()
     // Display User policies
     await ui.checkbox('Show only official Kubewarden policies').uncheck()
     await expect(cap.cards().nth(capCount + 1)).toBeVisible()

--- a/tests/e2e/40-policies.spec.ts
+++ b/tests/e2e/40-policies.spec.ts
@@ -75,8 +75,8 @@ for (const PolicyPage of pageTypes) {
     const polPage = new PolicyPage(page)
     const p: Policy = { title: 'Pod Privileged Policy', name: '' }
 
-    // Skip on 2.9.2+ because of https://github.com/rancher/kubewarden-ui/issues/898
-    RancherUI.isVersion('<2.9.2') && await test.step('Missing required fields', async() => {
+    // Skip because of https://github.com/rancher/kubewarden-ui/issues/898
+    if (false) await test.step('Missing required fields', async() => {
       const finishBtn = ui.button('Finish')
       await polPage.open(p)
 

--- a/tests/e2e/pages/policies.page.ts
+++ b/tests/e2e/pages/policies.page.ts
@@ -114,13 +114,22 @@ export abstract class BasePolicyPage extends BasePage {
       await this.ui.button('Add ArtifactHub To Whitelist').click()
     }
 
+    // ArtifactHub error: https://github.com/kubewarden/kubewarden-controller/issues/911#issuecomment-2426954817
+    async handleRateLimitError() {
+      await this.ui.retry(async()=> {
+        await expect(this.cards({official:true, signed:true}).first()).toBeVisible({ timeout: 80_000 })
+      }, 'Artifact Hub: 429 Too Many Requests')
+    }
+
     @step
     async open(p: Policy, options?: { navigate?: boolean }) {
       if (options?.navigate !== false) {
         await this.goto()
         await this.ui.button('Create').click()
       }
+
       // Open requested policy
+      await this.handleRateLimitError()
       if (p.title === 'Custom Policy') {
         await this.ui.button('Create Custom Policy').click()
       } else {


### PR DESCRIPTION
Artifact Hub limit is reset every 75s. Details are described [here](https://github.com/kubewarden/kubewarden-controller/issues/911#issuecomment-2426954817).

If I click `Create` button and no policies are visible then reload page after 80s and retry.

