### PR TITLE
Fix version check for defaults chart settings route

### DIFF
--- a/pkg/kubewarden/models/policies.kubewarden.io.clusteradmissionpolicy.js
+++ b/pkg/kubewarden/models/policies.kubewarden.io.clusteradmissionpolicy.js
@@ -29,6 +29,12 @@ export default class ClusterAdmissionPolicy extends PolicyModel {
   }
 
   editPolicySettings() {
-    this.currentRouter().push(this.kubewardenDefaultsRoute);
+    const route = this.kubewardenDefaultsRoute;
+
+    if (route) {
+      this.currentRouter().push(route);
+    } else {
+      console.error('Could not determine the route to the Kubewarden Defaults chart.');
+    }
   }
 }


### PR DESCRIPTION
Fix #930 

This will fix the version computation when selecting the "Edit Settings" action on a policy from the defaults chart.


https://github.com/user-attachments/assets/979dadb7-1949-4125-821a-fef8b9454663

