### PR TITLE
Remove cert-manager step from main installation

### DIFF
--- a/pkg/kubewarden/components/MetricsChecklist.vue
+++ b/pkg/kubewarden/components/MetricsChecklist.vue
@@ -21,6 +21,10 @@ export default {
       type:    Object,
       default: null
     },
+    certService: {
+      type: Object,
+      default: null
+    },
     conflictingGrafanaDashboards: {
       type:    Array,
       default: null
@@ -269,7 +273,12 @@ export default {
       :label="t('kubewarden.monitoring.prerequisites.warning')"
     />
     <div class="mt-20 mb-20">
-      <div class="checklist__step mt-20 mb-20" data-testid="kw-monitoring-checklist-step-open-tel">
+      <div class="checklist__step mt-20 mb-20" data-testid="kw-tracing-checklist-step-cert-manager">
+        <i class="icon mr-10" :class="badgeIcon(certService)" />
+        <p v-clean-html="t('kubewarden.tracing.certService', {}, true)" />
+      </div>
+
+      <div class="checklist__step mb-20" data-testid="kw-monitoring-checklist-step-open-tel">
         <i class="icon mr-10" :class="badgeIcon(openTelSvc)" />
         <p v-clean-html="t('kubewarden.tracing.openTelemetry', {}, true)" />
       </div>

--- a/pkg/kubewarden/components/MetricsChecklist.vue
+++ b/pkg/kubewarden/components/MetricsChecklist.vue
@@ -21,10 +21,6 @@ export default {
       type:    Object,
       default: null
     },
-    certService: {
-      type: Object,
-      default: null
-    },
     conflictingGrafanaDashboards: {
       type:    Array,
       default: null
@@ -273,11 +269,6 @@ export default {
       :label="t('kubewarden.monitoring.prerequisites.warning')"
     />
     <div class="mt-20 mb-20">
-      <div class="checklist__step mt-20 mb-20" data-testid="kw-tracing-checklist-step-cert-manager">
-        <i class="icon mr-10" :class="badgeIcon(certService)" />
-        <p v-clean-html="t('kubewarden.tracing.certService', {}, true)" />
-      </div>
-
       <div class="checklist__step mb-20" data-testid="kw-monitoring-checklist-step-open-tel">
         <i class="icon mr-10" :class="badgeIcon(openTelSvc)" />
         <p v-clean-html="t('kubewarden.tracing.openTelemetry', {}, true)" />

--- a/pkg/kubewarden/components/MetricsTab.vue
+++ b/pkg/kubewarden/components/MetricsTab.vue
@@ -196,10 +196,6 @@ export default {
       return this.allNamespaces?.find(ns => ns?.metadata?.name === 'cattle-dashboards');
     },
 
-    certService() {
-      return this.allServices?.find(s => s?.metadata?.labels?.['app'] === 'cert-manager');
-    },
-
     conflictingGrafanaDashboards() {
       return this.allConfigMaps?.filter((configMap) => {
         const name = configMap?.metadata?.name;
@@ -304,7 +300,6 @@ export default {
     <MetricsChecklist
       v-if="showChecklist"
       :cattle-dashboard-ns="cattleDashboardNs"
-      :cert-service="certService"
       :conflicting-grafana-dashboards="conflictingGrafanaDashboards"
       :controller-app="controllerApp"
       :controller-chart="controllerChart"

--- a/pkg/kubewarden/components/MetricsTab.vue
+++ b/pkg/kubewarden/components/MetricsTab.vue
@@ -196,6 +196,10 @@ export default {
       return this.allNamespaces?.find(ns => ns?.metadata?.name === 'cattle-dashboards');
     },
 
+    certService() {
+      return this.allServices?.find(s => s?.metadata?.labels?.['app'] === 'cert-manager');
+    },
+
     conflictingGrafanaDashboards() {
       return this.allConfigMaps?.filter((configMap) => {
         const name = configMap?.metadata?.name;
@@ -300,6 +304,7 @@ export default {
     <MetricsChecklist
       v-if="showChecklist"
       :cattle-dashboard-ns="cattleDashboardNs"
+      :cert-service="certService"
       :conflicting-grafana-dashboards="conflictingGrafanaDashboards"
       :controller-app="controllerApp"
       :controller-chart="controllerChart"

--- a/pkg/kubewarden/components/TraceChecklist.vue
+++ b/pkg/kubewarden/components/TraceChecklist.vue
@@ -10,6 +10,10 @@ import { Banner } from '@components/Banner';
 
 export default {
   props: {
+    certService: {
+      type: Object,
+      default: null
+    },
     controllerApp: {
       type:    Object,
       default: null
@@ -107,7 +111,11 @@ export default {
       :label="t('kubewarden.tracing.prerequisites.warning')"
     />
     <div class="checklist__container mt-20 mb-20">
-      <div class="checklist__step mt-20 mb-20" data-testid="kw-tracing-checklist-step-open-tel">
+      <div class="checklist__step mt-20 mb-20" data-testid="kw-tracing-checklist-step-cert-manager">
+        <i class="icon mr-10" :class="badgeIcon(certService)" />
+        <p v-clean-html="t('kubewarden.tracing.certService', {}, true)" />
+      </div>
+      <div class="checklist__step mb-20" data-testid="kw-tracing-checklist-step-open-tel">
         <i class="icon mr-10" :class="badgeIcon(openTelSvc)" />
         <p v-clean-html="t('kubewarden.tracing.openTelemetry', {}, true)" />
       </div>

--- a/pkg/kubewarden/components/TraceChecklist.vue
+++ b/pkg/kubewarden/components/TraceChecklist.vue
@@ -10,10 +10,6 @@ import { Banner } from '@components/Banner';
 
 export default {
   props: {
-    certService: {
-      type: Object,
-      default: null
-    },
     controllerApp: {
       type:    Object,
       default: null
@@ -111,10 +107,6 @@ export default {
       :label="t('kubewarden.tracing.prerequisites.warning')"
     />
     <div class="checklist__container mt-20 mb-20">
-      <div class="checklist__step mt-20 mb-20" data-testid="kw-tracing-checklist-step-cert-manager">
-        <i class="icon mr-10" :class="badgeIcon(certService)" />
-        <p v-clean-html="t('kubewarden.tracing.certService', {}, true)" />
-      </div>
       <div class="checklist__step mb-20" data-testid="kw-tracing-checklist-step-open-tel">
         <i class="icon mr-10" :class="badgeIcon(openTelSvc)" />
         <p v-clean-html="t('kubewarden.tracing.openTelemetry', {}, true)" />

--- a/pkg/kubewarden/components/TraceTable.vue
+++ b/pkg/kubewarden/components/TraceTable.vue
@@ -102,12 +102,16 @@ export default {
       return this.$store.getters['cluster/all'](SERVICE);
     },
 
+    certService() {
+      return this.allServices?.find(s => s?.metadata?.labels?.['app'] === 'cert-manager');
+    },
+
     controllerApp() {
       return this.allApps?.find(app => app?.spec?.chart?.metadata?.name === KUBEWARDEN_CHARTS.CONTROLLER);
     },
 
     controllerChart() {
-      return this.charts?.find(chart => chart.chartName === KUBEWARDEN_CHARTS.CONTROLLER);
+      return this.charts?.find(chart => chart?.chartName === KUBEWARDEN_CHARTS.CONTROLLER);
     },
 
     groupField() {
@@ -250,6 +254,7 @@ export default {
   <div v-else>
     <TraceChecklist
       v-if="showChecklist"
+      :cert-service="certService"
       :controller-app="controllerApp"
       :controller-chart="controllerChart"
       :tracing-configuration="tracingConfiguration"

--- a/pkg/kubewarden/components/TraceTable.vue
+++ b/pkg/kubewarden/components/TraceTable.vue
@@ -102,10 +102,6 @@ export default {
       return this.$store.getters['cluster/all'](SERVICE);
     },
 
-    certService() {
-      return this.allServices?.find(s => s?.metadata?.labels?.['app'] === 'cert-manager');
-    },
-
     controllerApp() {
       return this.allApps?.find(app => app?.spec?.chart?.metadata?.name === KUBEWARDEN_CHARTS.CONTROLLER);
     },
@@ -254,7 +250,6 @@ export default {
   <div v-else>
     <TraceChecklist
       v-if="showChecklist"
-      :cert-service="certService"
       :controller-app="controllerApp"
       :controller-chart="controllerChart"
       :tracing-configuration="tracingConfiguration"

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -171,10 +171,12 @@ kubewarden:
       label: Prerequisites
       description: There are a few resources which need to be installed for tracing to work correctly with the Kubewarden Controller.
       warning: The deployments of these resources can take a few minutes to become active.
+    certService: |
+      <a href="https://github.com/cert-manager/cert-manager" target="_blank" rel="noopener noreferrer nofollow" >Cert-Manager</a> must be installed inside the cluster, follow the <a href="https://docs.kubewarden.io/next/howtos/telemetry/opentelemetry-qs#install-opentelemetry" target="_blank" rel="noopener noreferrer nofollow">documentation</a> to setup cert-manager.
     installOpenTelemetry: |
       Click the button below  or run the <code>kubectl</code> command to install the latest version of OpenTelemetry.
     openTelemetry: |
-      The <a href="https://github.com/open-telemetry/opentelemetry-operator" target="_blank" rel="noopener noreferrer nofollow">OpenTelemetry Operator</a> must be installed, follow the <a href="https://docs.kubewarden.io/next/howtos/telemetry/opentelemetry-qs" target="_blank" rel="noopener noreferrer nofollow">documentation</a> to setup the OpenTelemetry Operator.
+      The <a href="https://github.com/open-telemetry/opentelemetry-operator" target="_blank" rel="noopener noreferrer nofollow">OpenTelemetry Operator</a> must be installed, follow the <a href="https://docs.kubewarden.io/next/howtos/telemetry/opentelemetry-qs#install-opentelemetry" target="_blank" rel="noopener noreferrer nofollow">documentation</a> to setup the OpenTelemetry Operator.
     jaeger: |
       The <a href="https://github.com/jaegertracing/jaeger-operator" target="_blank" rel="noopener noreferrer nofollow">Jaeger Operator and Instance</a> must be installed, follow the <a href="https://docs.kubewarden.io/next/howtos/telemetry/tracing-qs" target="_blank" rel="noopener noreferrer nofollow">documentation</a> to setup tracing for your policies.
     noRelatedPolicies: No related policies found.

--- a/tests/unit/components/Dashboard/InstallView.spec.ts
+++ b/tests/unit/components/Dashboard/InstallView.spec.ts
@@ -6,9 +6,6 @@ import { controllerCharts } from '@tests/unit/_templates_/controllerCharts';
 
 import InstallView from '@kubewarden/components/Dashboard/InstallView.vue';
 
-// Mock @rancher/shell/utils/clipboard.js
-jest.mock('@rancher/shell/utils/clipboard', () => ({ writeText: jest.fn() }));
-
 describe('InstallView.vue', () => {
   const commonMocks = {
     $fetchState: { pending: false },
@@ -32,7 +29,6 @@ describe('InstallView.vue', () => {
 
   const commonComputed = {
     isAirgap:           () => false,
-    certService:        () => null,
     controllerChart:    () => null,
     kubewardenRepo:     () => null,
     shellEnabled:       () => false,
@@ -67,25 +63,9 @@ describe('InstallView.vue', () => {
     expect(wrapper.find('[data-testid="kw-install-wizard"]').exists()).toBe(true);
   });
 
-  it('renders cert-manager step when not installed', async() => {
-    const wrapper = createWrapper();
-
-    const installButton = wrapper.find('[data-testid="kw-initial-install-button"]');
-
-    installButton.trigger('click');
-
-    await wrapper.vm.$nextTick();
-
-    expect(wrapper.find('[data-testid="kw-cm-title"]').exists()).toBe(true);
-  });
-
   it('renders kubewarden repo step when not installed', async() => {
     const wrapper = createWrapper({
-      data() {
-        return { initStepIndex: 1 };
-      },
       computed: {
-        certService:      () => true,
         kubewardenRepo:   () => null,
       }
     });
@@ -105,7 +85,6 @@ describe('InstallView.vue', () => {
         return { initStepIndex: 1 };
       },
       computed: {
-        certService:      () => true,
         kubewardenRepo:   () => true,
         controllerChart:  () => null,
       }
@@ -126,7 +105,6 @@ describe('InstallView.vue', () => {
         return { initStepIndex: 1, reloadReady: true };
       },
       computed: {
-        certService:      () => true,
         kubewardenRepo:   () => true,
         controllerChart:  () => false,
       }
@@ -155,7 +133,6 @@ describe('InstallView.vue', () => {
         return { initStepIndex: 1 };
       },
       computed: {
-        certService:      () => true,
         kubewardenRepo:   () => true,
         controllerChart:  () => controllerCharts,
         showPreRelease:   () => false
@@ -208,7 +185,6 @@ describe('InstallView.vue', () => {
         return { initStepIndex: 1 };
       },
       computed: {
-        certService:      () => true,
         kubewardenRepo:   () => true,
         controllerChart:  () => controllerCharts,
         showPreRelease:   () => true


### PR DESCRIPTION
Fix #489 
Fix #839 

This removes the cert-manager check and installation step during the initial installation of Kubewarden.

Since cert-manager is required for OpenTelemetry, which is used for tracing and metrics, an extra step at the beginning of each telemetry checklist has been added to check for the existence of the cert-manager service.