### PR TITLE
Require name input for policies and policy server

### DIFF
--- a/pkg/kubewarden/chart/kubewarden/admission/General.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/General.vue
@@ -181,6 +181,7 @@ export default {
           :description-hidden="true"
           :namespaced="!isGlobal"
           :namespace-new-allowed="true"
+          :required="true"
           name-key="metadata.name"
           namespace-key="metadata.namespace"
           @isNamespaceNew="isNamespaceNew = $event"

--- a/pkg/kubewarden/chart/kubewarden/policy-server/General.vue
+++ b/pkg/kubewarden/chart/kubewarden/policy-server/General.vue
@@ -217,7 +217,7 @@ export default {
           :disabled="!isCreate"
           :label="t('nameNsDescription.name.label')"
           :placeholder="t('nameNsDescription.name.placeholder')"
-          required
+          :required="true"
         />
       </div>
     </div>

--- a/pkg/kubewarden/components/Policies/Create.vue
+++ b/pkg/kubewarden/components/Policies/Create.vue
@@ -146,6 +146,7 @@ export default ({
 
         const requiredRules = ['apiVersions', 'operations', 'resources'];
         const acceptedRules = this.acceptedValues(rules, requiredRules);
+        const acceptedName = this.chartValues.policy.metadata.name;
 
         const requiredQuestions = this.chartValues?.questions?.questions?.map((q) => {
           if ( q.required ) {
@@ -154,7 +155,7 @@ export default ({
         }).filter(Boolean);
         const acceptedQuestions = this.acceptedValues(settings, requiredQuestions);
 
-        if ( !isEmpty(acceptedRules) && (isEmpty(requiredQuestions) || !isEmpty(acceptedQuestions)) ) {
+        if ( !!acceptedName && !isEmpty(acceptedRules) && (isEmpty(requiredQuestions) || !isEmpty(acceptedQuestions)) ) {
           return true;
         }
       }

--- a/pkg/kubewarden/edit/policies.kubewarden.io.policyserver.vue
+++ b/pkg/kubewarden/edit/policies.kubewarden.io.policyserver.vue
@@ -59,14 +59,14 @@ export default {
   computed: {
     isCreate() {
       return this.realMode === _CREATE;
+    },
+
+    validationPassed() {
+      return !!this.chartValues?.metadata?.name;
     }
   },
 
   methods: {
-    handleValidationPassed(val) {
-      this.validationPassed = val;
-    },
-
     async finish(event) {
       // Clean up the securityContexts "seccompProfile" property if there are no keys set on the object
       const securityContexts = this.chartValues?.spec?.securityContexts;
@@ -82,7 +82,8 @@ export default {
       }
 
       try {
-        await this.save(event);
+        // await this.save(event);
+        console.log('# woudl save', event);
       } catch (e) {
         this.errors.push(e);
       }
@@ -108,7 +109,6 @@ export default {
       :value="value"
       :chart-values="chartValues"
       :mode="mode"
-      @validation-passed="handleValidationPassed"
     />
   </CruResource>
 </template>


### PR DESCRIPTION
Fix #898 

This will require the `name` fields to be filled out when creating either a policy server or policy.