### PR TITLE
Add rancher 2.10 to test matrix

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -21,10 +21,12 @@ on:
         - '~ 2.7'
         - '~ 2.8'
         - '~ 2.9'
+        - '~ 2.10'
         - 'rc'       # rc versions
         - '~ 2.7-0'
         - '~ 2.8-0'
         - '~ 2.9-0'
+        - '~ 2.10-0'
       k3s:
         description: Kubernetes version
         type: choice
@@ -95,17 +97,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rancher: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && fromJSON('["2.7", "2.8", "2.9"]') || fromJSON(format('["{0}"]', inputs.rancher || 'released')) }}
+        rancher: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && fromJSON('["2.8", "2.9", "2.10"]') || fromJSON(format('["{0}"]', inputs.rancher || 'released')) }}
         mode: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && fromJSON('["base", "upgrade", "fleet"]') || fromJSON(format('["{0}"]', inputs.mode || 'base')) }}
         exclude:
           # Run full tests on 2.9 since it's latest prime version
-          - rancher: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && '2.7' }}
+          - rancher: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && '2.8' }}
             mode: upgrade
-          - rancher: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && '2.7' }}
+          - rancher: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && '2.8' }}
             mode: fleet
-          - rancher: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && '2.8' }}
+          - rancher: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && '2.10' }}
             mode: upgrade
-          - rancher: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && '2.8' }}
+          - rancher: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && '2.10' }}
             mode: fleet
 
 
@@ -124,9 +126,9 @@ jobs:
       id: set-ref
       run: |
         case "${{ matrix.rancher }}" in
-          *2.[78]*) ref='release-1.6';;
-          *2.9*)    ref='release-2.1';;
-          *)        ref='';;
+          *2.8*) ref='release-1.6';;
+          *2.9*) ref='release-2.1';;
+          *)     ref='';;
         esac
         echo "ref=$ref" | tee -a $GITHUB_OUTPUT
 
@@ -153,9 +155,11 @@ jobs:
         [[ "${{ matrix.rancher }}" == *2.7* ]] && K3S_VERSION="v1.27"
         # Rancher 2.8 chart requires kubeVersion: < 1.29.0-0
         [[ "${{ matrix.rancher }}" == *2.8* ]] && K3S_VERSION="v1.28"
+        # Rancher 2.9 chart requires kubeVersion: < 1.31.0-0
+        [[ "${{ matrix.rancher }}" == *2.9* ]] && K3S_VERSION="v1.30"
 
         # KW extension is prime since 2.8.3
-        [[ "${{ matrix.rancher }}" == *2.[789]* ]] && REPO=rancher-prime || REPO=rancher-latest
+        [[ "${{ matrix.rancher }}" == *2.[789]* ]] && REPO=rancher-prime || REPO=rancher-alpha
 
         # Complete partial K3S version from dockerhub v1.30 -> v1.30.5-k3s1
         if [[ ! $K3S_VERSION =~ ^v[0-9.]+-k3s[0-9]$ ]]; then

--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -17,21 +17,12 @@ expect(MODE).toMatch(/^(base|fleet|upgrade)$/)
 
 // Known Kubewarden versions for upgrade test, start at [0]
 const upMap: AppVersion[] = [
-  // { app: 'v1.8.0', controller: '2.0.0', crds: '1.4.2', defaults: '1.8.0' },
-  // { app: 'v1.9.0', controller: '2.0.5', crds: '1.4.4', defaults: '1.9.2' },
-  // { app: 'v1.10.0', controller: '2.0.8', crds: '1.4.5', defaults: '1.9.3' },
-  // { app: 'v1.11.0', controller: '2.0.10', crds: '1.4.6', defaults: '1.9.4' },
-  { app: 'v1.12.0', controller: '2.0.11', crds: '1.5.0', defaults: '2.0.0' },
-  { app: 'v1.13.0', controller: '2.1.0', crds: '1.5.1', defaults: '2.0.3' },
-  { app: 'v1.14.0', controller: '2.2.1', crds: '1.6.0', defaults: '2.1.0' },
-  { app: 'v1.15.0', controller: '2.3.1', crds: '1.7.0', defaults: '2.2.1' },
-  { app: 'v1.16.0', controller: '2.4.0', crds: '1.8.0', defaults: '2.3.1' },
-  { app: 'v1.17.0', controller: '3.0.1', crds: '1.9.0', defaults: '2.4.0' },
+  { app: 'v1.18.0', controller: '3.1.0', crds: '1.10.0', defaults: '2.5.0' },
 ]
 
 // Support for Rancher 2.9 was added in KW 1.13.0
 if (RancherUI.isVersion('>=2.9')) {
-  upMap.splice(0, upMap.findIndex(v => v.app === 'v1.13.0'))
+  upMap.splice(0, upMap.findIndex((v) => v.app === 'v1.13.0'))
 }
 
 test('Initial rancher setup', async({ page, ui, nav }) => {
@@ -267,7 +258,7 @@ test('Check kubewarden resources', async({ page, nav, shell }) => {
 
     // Check for ERROR text in logs
     await shell.runBatch(...labels.map(
-      label => `k logs -n cattle-kubewarden-system -l '${label}' --tail -1
+      (label) => `k logs -n cattle-kubewarden-system -l '${label}' --tail -1
      | grep ERROR | grep -vE '${ignore}'
      | tee /dev/stderr | wc -l | grep -x 0`))
   })


### PR DESCRIPTION
- add rancher 2.10 to test matrix
- remove old kubewarden versions from upgrade test, [kubewarden < 1.18 is not available on rancher 2.10](https://github.com/kubewarden/helm-charts/blob/kubewarden-controller-3.0.1/charts/kubewarden-controller/Chart.yaml#L44)
