### PR TITLE
Fix upgrade path on rancher >=2.10

### DIFF
--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -25,14 +25,12 @@ const upMap: AppVersion[] = [
   { app: 'v1.16.0', controller: '2.4.0', crds: '1.8.0', defaults: '2.3.1' },
   { app: 'v1.17.0', controller: '3.0.1', crds: '1.9.0', defaults: '2.4.0' },
   { app: 'v1.18.0', controller: '3.1.0', crds: '1.10.0', defaults: '2.5.0' },
-].splice(-3) // Limit upgrade path to last 5 versions
+  { app: 'v1.19.0', controller: '3.2.0', crds: '1.11.0', defaults: '2.6.0' },
+].splice(-3) // Limit upgrade path to last 3 versions
 
 // Support for Rancher 2.9 was added in KW 1.13.0
-if (RancherUI.isVersion('>=2.9')) {
-  upMap.splice(0, upMap.findIndex((v) => v.app === 'v1.13.0'))
-} else if (RancherUI.isVersion('>=2.10')) {
-  upMap.splice(0, upMap.findIndex((v) => v.app === 'v1.18.0'))
-}
+if (RancherUI.isVersion('>=2.9')) upMap.splice(0, upMap.findIndex((v) => v.app === 'v1.13.0'))
+if (RancherUI.isVersion('>=2.10')) upMap.splice(0, upMap.findIndex((v) => v.app === 'v1.18.0'))
 
 test('Initial rancher setup', async({ page, ui, nav }) => {
   const rancher = new RancherCommonPage(page)


### PR DESCRIPTION
Condition `>=2.9` is true for both 2.9 & 2.10 and prevents `else` block to execute.

Fix for upgrade test: https://github.com/rancher/kubewarden-ui/actions/runs/12277584441/job/34306194907