### PR TITLE
Update telemetry configuration conditions for tracing and metrics

### DIFF
--- a/pkg/kubewarden/components/MetricsChecklist.vue
+++ b/pkg/kubewarden/components/MetricsChecklist.vue
@@ -41,6 +41,10 @@ export default {
       type:    Array,
       default: null
     },
+    metricsConfiguration: {
+      type:    Object,
+      default: null
+    },
     monitoringApp: {
       type:    Object,
       default: null
@@ -60,6 +64,14 @@ export default {
     policyServerObj: {
       type:    Object,
       default: null
+    },
+    outdatedTelemetrySpec: {
+      type:    Boolean,
+      default: false
+    },
+    unsupportedTelemetrySpec: {
+      type:    Boolean,
+      default: false
     }
   },
 
@@ -68,14 +80,6 @@ export default {
   computed: {
     ...mapGetters(['currentCluster']),
     ...mapGetters({ t: 'i18n/t' }),
-
-    controllerMetricsConfig() {
-      if ( this.controllerApp ) {
-        return this.controllerApp.spec?.values?.telemetry?.metrics;
-      }
-
-      return null;
-    },
 
     controllerLinkDisabled() {
       return (!this.openTelSvc || !this.monitoringApp || !this.hasKubewardenDashboards || !this.controllerChart || !this.controllerApp);
@@ -114,14 +118,6 @@ export default {
 
     hasKubewardenDashboards() {
       return !isEmpty(this.kubewardenDashboards);
-    },
-
-    metricsEnabled() {
-      if ( this.controllerMetricsConfig ) {
-        return this.controllerMetricsConfig.enabled;
-      }
-
-      return null;
     },
 
     monitoringChartLink() {
@@ -344,12 +340,26 @@ export default {
         </div>
       </Banner>
 
+      <!-- Telemetry banners -->
+      <div>
+        <Banner
+          v-if="outdatedTelemetrySpec"
+          color="error"
+          :label="t('kubewarden.monitoring.prerequisites.outdated')"
+        />
+        <Banner
+          v-if="unsupportedTelemetrySpec"
+          color="error"
+          :label="t('kubewarden.monitoring.prerequisites.unsupported')"
+        />
+      </div>
+
       <div class="checklist__step mb-20" data-testid="kw-monitoring-checklist-step-controller-config">
-        <i class="icon mr-10" :class="badgeIcon(metricsEnabled)" />
+        <i class="icon mr-10" :class="badgeIcon(metricsConfiguration)" />
         <div class="checklist__config">
           <p v-clean-html="t('kubewarden.monitoring.prerequisites.controllerConfig.label', {}, true)" p />
           <button
-            v-if="!metricsEnabled"
+            v-if="!metricsConfiguration"
             v-clean-tooltip="controllerLinkTooltip"
             data-testid="kw-monitoring-checklist-step-config-button"
             class="btn role-primary ml-10"

--- a/pkg/kubewarden/components/MetricsTab.vue
+++ b/pkg/kubewarden/components/MetricsTab.vue
@@ -2,6 +2,7 @@
 import { mapGetters } from 'vuex';
 import isEmpty from 'lodash/isEmpty';
 import debounce from 'lodash/debounce';
+import semver from 'semver';
 
 import {
   CATALOG, CONFIG_MAP, MONITORING, NAMESPACE, SERVICE
@@ -139,7 +140,9 @@ export default {
       [SERVICE]:                   null,
       metricsProxy:                null,
       metricsService:              null,
-      debouncedRefreshCharts:      null
+      debouncedRefreshCharts:      null,
+      outdatedTelemetrySpec:       false,
+      unsupportedTelemetrySpec:    false,
     };
   },
 
@@ -233,6 +236,49 @@ export default {
       });
     },
 
+    metricsConfiguration() {
+      if (!this.controllerApp) {
+        console.log('# 0')
+        return null;
+      }
+
+      const version = this.controllerApp?.spec?.chart?.metadata?.version;
+      const telemetry = this.controllerApp?.values?.telemetry;
+
+      if (semver.gte(version, '4.0.0-0')) {
+        // In version 4+, telemetry.metrics should be boolean or undefined (treated as false).
+        // sidecar.metrics is only meaningful if telemetry.metrics === true.
+        const metricsIsUndefinedOrBoolean = telemetry?.metrics === undefined || typeof telemetry?.metrics === 'boolean';
+        
+        // Check for unsupported 'custom' section
+        if (telemetry?.custom) {
+          this.unsupportedTelemetrySpec = true;
+
+          return null;
+        }
+
+        // If metrics is not undefined or boolean, it's outdated
+        if (!metricsIsUndefinedOrBoolean) {
+          this.outdatedTelemetrySpec = true;
+
+          return null;
+        }
+
+        // If telemetry.metrics is undefined or false, treat it as false.
+        // sidecar config is irrelevant in that case, and not considered outdated.
+        if (telemetry?.metrics !== true) {
+          // metrics is off, no sidecar config needed
+          return null;
+        }
+
+        // If we get here, telemetry.metrics === true and portIsDefined === true
+        return telemetry?.metrics;
+      } else {
+        // Old schema: just return telemetry.metrics.enabled
+        return telemetry?.metrics?.enabled;
+      }
+    },
+
     monitoringApp() {
       return this.allApps?.find(app => app?.spec?.chart?.metadata?.name === 'rancher-monitoring');
     },
@@ -279,10 +325,9 @@ export default {
     },
 
     showChecklist() {
-      const monitoringEnabled = this.controllerApp?.values?.telemetry?.metrics?.enabled;
       const grafanaDashboardsInstalled = !isEmpty(this.kubewardenGrafanaDashboards);
 
-      return !this.openTelSvc || !this.monitoringApp || !this.kubewardenServiceMonitor || !monitoringEnabled || !grafanaDashboardsInstalled;
+      return !this.openTelSvc || !this.monitoringApp || !this.kubewardenServiceMonitor || !this.metricsConfiguration || !grafanaDashboardsInstalled;
     }
   },
 
@@ -305,11 +350,14 @@ export default {
       :controller-chart="controllerChart"
       :kubewarden-service-monitor="kubewardenServiceMonitor"
       :kubewarden-dashboards="kubewardenGrafanaDashboards"
+      :metrics-configuration="metricsConfiguration"
       :monitoring-app="monitoringApp"
       :monitoring-chart="monitoringChart"
       :open-tel-svc="openTelSvc"
       :policy-obj="policyObj"
       :policy-server-obj="policyServerObj"
+      :outdated-telemetry-spec="outdatedTelemetrySpec"
+      :unsupported-telemetry-spec="unsupportedTelemetrySpec"
       @updateServiceMonitors="updateServiceMonitors"
     />
 

--- a/pkg/kubewarden/components/MetricsTab.vue
+++ b/pkg/kubewarden/components/MetricsTab.vue
@@ -250,8 +250,8 @@ export default {
         // sidecar.metrics is only meaningful if telemetry.metrics === true.
         const metricsIsUndefinedOrBoolean = telemetry?.metrics === undefined || typeof telemetry?.metrics === 'boolean';
         
-        // Check for unsupported 'custom' section
-        if (telemetry?.custom) {
+        // Check for unsupported 'custom' mode
+        if (telemetry?.mode === 'custom') {
           this.unsupportedTelemetrySpec = true;
 
           return null;

--- a/pkg/kubewarden/components/TraceChecklist.vue
+++ b/pkg/kubewarden/components/TraceChecklist.vue
@@ -29,6 +29,18 @@ export default {
     openTelSvc: {
       type:    Object,
       default: null
+    },
+    outdatedTelemetrySpec: {
+      type:    Boolean,
+      default: false
+    },
+    unsupportedTelemetrySpec: {
+      type:    Boolean,
+      default: false
+    },
+    incompleteTelemetrySpec: {
+      type:    Boolean,
+      default: false
     }
   },
 
@@ -115,6 +127,26 @@ export default {
         <i class="icon mr-10" :class="badgeIcon(jaegerQuerySvc)" />
         <p v-clean-html="t('kubewarden.tracing.jaeger', {}, true)" p />
       </div>
+
+      <!-- Telemetry banners -->
+      <div>
+        <Banner
+          v-if="outdatedTelemetrySpec"
+          color="error"
+          :label="t('kubewarden.tracing.prerequisites.outdated')"
+        />
+        <Banner
+          v-if="unsupportedTelemetrySpec"
+          color="error"
+          :label="t('kubewarden.tracing.prerequisites.unsupported')"
+        />
+        <Banner
+          v-if="incompleteTelemetrySpec"
+          color="error"
+          :label="t('kubewarden.tracing.prerequisites.incomplete')"
+        />
+      </div>
+
       <div class="checklist__step mb-20" data-testid="kw-tracing-checklist-step-config">
         <i class="icon mr-10" :class="badgeIcon(tracingEnabled)" />
         <div class="checklist__config">

--- a/pkg/kubewarden/components/TraceTable.vue
+++ b/pkg/kubewarden/components/TraceTable.vue
@@ -1,6 +1,7 @@
 <script>
 import { mapGetters } from 'vuex';
 import isEmpty from 'lodash/isEmpty';
+import semver from 'semver';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 
@@ -86,7 +87,10 @@ export default {
       TRACE_HEADERS,
       OPERATION_MAP,
 
-      specificValidations: null
+      specificValidations: null,
+      outdatedTelemetrySpec: false,
+      unsupportedTelemetrySpec: false,
+      incompleteTelemetrySpec: false
     };
   },
 
@@ -151,19 +155,54 @@ export default {
     },
 
     tracingConfiguration() {
-      if ( this.controllerApp ) {
-        return this.controllerApp?.values?.telemetry?.tracing;
+      if (!this.controllerApp) {
+        return null;
       }
 
-      return null;
-    },
+      const version = this.controllerApp?.spec?.chart?.metadata?.version;
+      const telemetry = this.controllerApp?.values?.telemetry;
 
-    tracingEnabled() {
-      if ( this.tracingConfiguration ) {
-        return this.tracingConfiguration.enabled;
+      if (semver.gte(version, '4.0.0-0')) {
+        // In version 4+, telemetry.tracing should be boolean or undefined (treated as false).
+        // sidecar.tracing is only meaningful if telemetry.tracing === true.
+
+        const tracingIsUndefinedOrBoolean = telemetry?.tracing === undefined || typeof telemetry?.tracing === 'boolean';
+        const endpointIsDefined = !!telemetry?.sidecar?.tracing?.jaeger?.endpoint;
+        
+        // Check for unsupported 'custom' section
+        if (telemetry?.custom) {
+          this.unsupportedTelemetrySpec = true;
+
+          return null;
+        }
+
+        // If tracing is not undefined or boolean, it's outdated
+        if (!tracingIsUndefinedOrBoolean) {
+          this.outdatedTelemetrySpec = true;
+
+          return null;
+        }
+
+        // If telemetry.tracing is true, ensure sidecar.tracing is defined
+        if (telemetry?.tracing === true && !endpointIsDefined) {
+          this.incompleteTelemetrySpec = true;
+
+          return null;
+        }
+
+        // If telemetry.tracing is undefined or false, treat it as false.
+        // sidecar config is irrelevant in that case, and not considered outdated.
+        if (telemetry?.tracing !== true) {
+          // tracing is off, no sidecar config needed
+          return null;
+        }
+
+        // If we get here, telemetry.tracing === true and endpointIsDefined === true
+        return telemetry?.sidecar?.tracing;
+      } else {
+        // Old schema: just return telemetry.tracing.enabled
+        return telemetry?.tracing?.enabled;
       }
-
-      return null;
     },
 
     jaegerServices() {
@@ -203,7 +242,7 @@ export default {
     },
 
     showChecklist() {
-      return (!this.openTelSvc || !this.jaegerQuerySvc || !this.tracingConfiguration?.enabled);
+      return (!this.openTelSvc || !this.jaegerQuerySvc || !this.tracingConfiguration);
     },
 
     showTable() {
@@ -255,6 +294,9 @@ export default {
       :tracing-configuration="tracingConfiguration"
       :jaeger-query-svc="jaegerQuerySvc"
       :open-tel-svc="openTelSvc"
+      :outdated-telemetry-spec="outdatedTelemetrySpec"
+      :unsupported-telemetry-spec="unsupportedTelemetrySpec"
+      :incomplete-telemetry-spec="incompleteTelemetrySpec"
     />
 
     <Banner

--- a/pkg/kubewarden/components/TraceTable.vue
+++ b/pkg/kubewarden/components/TraceTable.vue
@@ -169,8 +169,8 @@ export default {
         const tracingIsUndefinedOrBoolean = telemetry?.tracing === undefined || typeof telemetry?.tracing === 'boolean';
         const endpointIsDefined = !!telemetry?.sidecar?.tracing?.jaeger?.endpoint;
         
-        // Check for unsupported 'custom' section
-        if (telemetry?.custom) {
+        // Check for unsupported 'custom' mode
+        if (telemetry?.mode === 'custom') {
           this.unsupportedTelemetrySpec = true;
 
           return null;

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -173,6 +173,9 @@ kubewarden:
       label: Prerequisites
       description: There are a few resources which need to be installed for tracing to work correctly with the Kubewarden Controller.
       warning: The deployments of these resources can take a few minutes to become active.
+      outdated: The tracing configuration is outdated, please update the configuration.
+      unsupported: The custom tracing configuration is unsupported, please update the configuration to use the sidecar.
+      incomplete: The tracing configuration is incomplete, please update the configuration.
     certService: |
       <a href="https://github.com/cert-manager/cert-manager" target="_blank" rel="noopener noreferrer nofollow" >Cert-Manager</a> must be installed inside the cluster, follow the <a href="https://docs.kubewarden.io/next/howtos/telemetry/opentelemetry-qs#install-opentelemetry" target="_blank" rel="noopener noreferrer nofollow">documentation</a> to setup cert-manager.
     installOpenTelemetry: |
@@ -186,7 +189,7 @@ kubewarden:
     noTraces: No tracing data exists for this policy.
     config:
       label: |
-        Tracing must be <a href="https://docs.kubewarden.io/next/howtos/ui-extension/tracing#update-rancher-kubewarden-controller-with-jaeger-endpoint" target="_blank" rel="noopener noreferrer nofollow">configured</a> with a Jaeger endpoint in the "Telemetry" tab of the Kubewarden Controller chart settings.
+        Tracing must be <a href="https://docs.kubewarden.io/next/howtos/ui-extension/tracing#update-rancher-kubewarden-controller-with-jaeger-endpoint" target="_blank" rel="noopener noreferrer nofollow">enabled and configured</a> with a Jaeger endpoint in the "Telemetry" tab of the Kubewarden Controller chart settings.
       link: Update Config
   monitoring:
     notInstalled: |
@@ -196,6 +199,9 @@ kubewarden:
       label: Prerequisites
       description: There are a few resources which need to be installed and configured correctly for monitoring to be available.
       warning: The deployments of these resources can take a few minutes to become active.
+      outdated: The metrics configuration is outdated, please update the configuration.
+      unsupported: The custom metrics configuration is unsupported, please update the configuration to use the sidecar.
+      incomplete: The metrics configuration is incomplete, please update the configuration.
       tooltips:
         prerequisites: The prerequisite steps have not been completed.
         appNotInstalled: The { app } app is not yet installed.

--- a/tests/e2e/pages/telemetry.page.ts
+++ b/tests/e2e/pages/telemetry.page.ts
@@ -25,7 +25,7 @@ export class TelemetryPage extends BasePage {
       monitoring    : getLine(this.metricsTab, /^The Rancher Monitoring app/),
       servicemonitor: getLine(this.metricsTab, /^A Service Monitor/),
       configmap     : getLine(this.metricsTab, /^Grafana Dashboards/),
-      config        : getLine(page, /^(Tracing must be configured|The Kubewarden Controller)/)
+      config        : getLine(page, /^(Tracing must be enabled and configured|The Kubewarden Controller)/)
     }
     this.configBtn = this.lines.config.getByRole('button', { name: /^(Edit|Update) Config$/ })
   }


### PR DESCRIPTION
Fix #1006 

This updates the checklists for both tracing and metrics to account for the new sidecar configuration with kubewarden-controller v4.

We will now display a banner above the bullet for checking the controller configuration to warn the user when the chart config is incorrect either due to an upgrade or just misconfiguration.

We also will not support custom configs for now.

__Outdated tracing config__

![outdated-tracing](https://github.com/user-attachments/assets/65526906-f940-4e05-a844-aa9a718336ec)

__Incomplete tracing config__

![incomplete-tracing](https://github.com/user-attachments/assets/64a2399c-2959-4d3e-8b9f-315116e406ec)


__Oudated metrics config__

![outdated-metrics](https://github.com/user-attachments/assets/b0f147ee-1e8f-48bf-8656-8de4394bc69d)
