### PR TITLE
Update tests for OTEL changes

### DIFF
--- a/tests/e2e/60-telemetry.spec.ts
+++ b/tests/e2e/60-telemetry.spec.ts
@@ -92,7 +92,7 @@ test.describe('Tracing', () => {
     await apps.updateApp('rancher-kubewarden-controller', {
       navigate : false,
       questions: async() => {
-        await ui.tab('Telemetry').click()
+        await ui.tab(/^(Open)?Telemetry/).click()
         await ui.checkbox('Enable Tracing').check()
         await ui.input('Jaeger endpoint configuration').fill('jaeger-operator-jaeger-collector.jaeger.svc.cluster.local:4317')
         await ui.checkbox('Jaeger endpoint insecure TLS configuration').check()
@@ -122,7 +122,7 @@ test.describe('Tracing', () => {
     // Clean up
     await apps.updateApp('rancher-kubewarden-controller', {
       questions: async() => {
-        await ui.tab('Telemetry').click()
+        await ui.tab(/^(Open)?Telemetry/).click()
         await ui.checkbox('Enable Tracing').uncheck()
       }
     })
@@ -191,7 +191,7 @@ test.describe('Metrics', () => {
     await apps.updateApp('rancher-kubewarden-controller', {
       navigate : false,
       questions: async() => {
-        await ui.tab('Telemetry').click()
+        await ui.tab(/^(Open)?Telemetry/).click()
         await ui.checkbox('Enable Metrics').check()
       }
     })
@@ -227,7 +227,7 @@ test.describe('Metrics', () => {
     // Disable metrics
     await apps.updateApp('rancher-kubewarden-controller', {
       questions: async() => {
-        await ui.tab('Telemetry').click()
+        await ui.tab(/^(Open)?Telemetry/).click()
         await ui.checkbox('Enable Metrics').uncheck()
       }
     })

--- a/tests/e2e/components/rancher-ui.ts
+++ b/tests/e2e/components/rancher-ui.ts
@@ -44,7 +44,7 @@ export class RancherUI {
   }
 
   // Tab
-  tab(name: string) {
+  tab(name: string|RegExp) {
     return this.page.getByRole('tab', { name, exact: true })
   }
 

--- a/tests/e2e/pages/telemetry.page.ts
+++ b/tests/e2e/pages/telemetry.page.ts
@@ -25,7 +25,7 @@ export class TelemetryPage extends BasePage {
       monitoring    : getLine(this.metricsTab, /^The Rancher Monitoring app/),
       servicemonitor: getLine(this.metricsTab, /^A Service Monitor/),
       configmap     : getLine(this.metricsTab, /^Grafana Dashboards/),
-      config        : getLine(page, /^(Tracing must be configured|The Kubewarden Controller)/)
+      config        : getLine(page, /^(Tracing|The Kubewarden Controller) must be (enabled and )?configured/)
     }
     this.configBtn = this.lines.config.getByRole('button', { name: /^(Edit|Update) Config$/ })
   }


### PR DESCRIPTION
Fixes [tests](https://github.com/rancher/kubewarden-ui/actions/runs/12361240769) to work with kubewarden 1.20.

