### PR TITLE
Add rancher 2.10 and kubewarden 1.20 to test matrix

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -18,12 +18,10 @@ on:
         default: 'released'
         options:
         - 'released' # released versions
-        - '~ 2.7'
         - '~ 2.8'
         - '~ 2.9'
         - '~ 2.10'
         - 'rc'       # rc versions
-        - '~ 2.7-0'
         - '~ 2.8-0'
         - '~ 2.9-0'
         - '~ 2.10-0'
@@ -40,6 +38,7 @@ on:
         - v1.29
         - v1.30
         - v1.31
+        - v1.32
       mode:
         description: Installation mode
         type: choice
@@ -103,14 +102,14 @@ jobs:
         rancher: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && fromJSON('["2.8", "2.9", "2.10"]') || fromJSON(format('["{0}"]', inputs.rancher || 'released')) }}
         mode: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && fromJSON('["base", "upgrade", "fleet"]') || fromJSON(format('["{0}"]', inputs.mode || 'base')) }}
         exclude:
-          # Run all modes on 2.9 since it's latest prime version
+          # Run all modes on 2.10 since it's latest prime version
           - rancher: ${{ github.event_name == 'schedule' && '2.8' }}
             mode: upgrade
           - rancher: ${{ github.event_name == 'schedule' && '2.8' }}
             mode: fleet
-          - rancher: ${{ github.event_name == 'schedule' && '2.10' }}
+          - rancher: ${{ github.event_name == 'schedule' && '2.9' }}
             mode: upgrade
-          - rancher: ${{ github.event_name == 'schedule' && '2.10' }}
+          - rancher: ${{ github.event_name == 'schedule' && '2.9' }}
             mode: fleet
           # Exclude unrelated Rancher versions from release jobs # head_branch = tag (kubewarden-2.1.0-rc.1)
           - rancher: ${{ startsWith(github.event.workflow_run.head_branch, 'kubewarden-1.') && '2.9' }}
@@ -154,17 +153,24 @@ jobs:
         # Override KUBEWARDEN for automated triggers
         case ${{github.event_name}} in
           pull_request)
-            KUBEWARDEN=source
             # Override RANCHER for maintenance PRs
             [[ "${{ github.event.pull_request.base.ref }}" == "release-1.6" ]] && RANCHER="2.8"
             [[ "${{ github.event.pull_request.base.ref }}" == "release-2.1" ]] && RANCHER="2.9"
-            ;;
+            KUBEWARDEN=source;;
           schedule)
-            # Rancher 2.10 is not prime = UI is not available from official charts
-            [[ "$RANCHER" == *2.10* ]] && KUBEWARDEN=rc || KUBEWARDEN=released;;
+            KUBEWARDEN=released;;
           workflow_run)
             KUBEWARDEN=rc;;
         esac
+
+        # Select repository
+        helm repo add --force-update rancher-prime https://charts.rancher.com/server-charts/prime
+        helm repo add --force-update rancher-community https://releases.rancher.com/server-charts/latest
+        [[ "$RANCHER" == "rc" || "$RANCHER" == *"-0" ]] && REPO=rancher-community || REPO=rancher-prime
+
+        # Translate to sematic version
+        [ "$RANCHER" == "rc" ] && RANCHER='*-0'
+        [ "$RANCHER" == "released" ] && RANCHER='*'
 
         # Rancher 2.7 chart requires kubeVersion: < 1.28.0-0
         [[ "$RANCHER" == *2.7* ]] && K3S_VERSION="v1.27"
@@ -172,9 +178,6 @@ jobs:
         [[ "$RANCHER" == *2.8* ]] && K3S_VERSION="v1.28"
         # Rancher 2.9 chart requires kubeVersion: < 1.31.0-0
         [[ "$RANCHER" == *2.9* ]] && K3S_VERSION="v1.30"
-
-        # KW extension is prime since 2.8.3
-        [[ "$RANCHER" == *2.[789]* ]] && REPO=rancher-prime || REPO=rancher-latest
 
         # Complete partial K3S version from dockerhub v1.30 -> v1.30.5-k3s1
         if [[ ! $K3S_VERSION =~ ^v[0-9.]+-k3s[0-9]$ ]]; then
@@ -213,14 +216,7 @@ jobs:
         helm repo add jetstack https://charts.jetstack.io --force-update
         helm upgrade -i --wait cert-manager jetstack/cert-manager -n cert-manager --create-namespace --set crds.enabled=true
 
-        # Translate to sematic version
-        [ "$RANCHER" == "rc" ] && RANCHER='*-0'
-        [ "$RANCHER" == "released" ] && RANCHER='*'
-
-        helm repo add --force-update rancher-latest https://releases.rancher.com/server-charts/latest
-        helm repo add --force-update rancher-alpha https://releases.rancher.com/server-charts/alpha
-        helm repo add --force-update rancher-prime https://charts.rancher.com/server-charts/prime
-
+        # Install Rancher
         helm search repo $REPO/rancher ${RANCHER:+--version "$RANCHER"}
         helm upgrade --install rancher $REPO/rancher --wait \
             --namespace cattle-system --create-namespace \
@@ -229,7 +225,7 @@ jobs:
             --set replicas=1 \
             ${RANCHER:+--version "$RANCHER"}
 
-        # Wait for rancher
+        # Wait for Rancher
         for i in {1..20}; do
             output=$(kubectl get pods --no-headers -o wide -n cattle-system -l app=rancher-webhook | grep -vw Completed || echo 'Wait: cattle-system')$'\n'
             output+=$(kubectl get pods --no-headers -o wide -n cattle-system | grep -vw Completed || echo 'Wait: cattle-system')$'\n'

--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -26,6 +26,7 @@ const upMap: AppVersion[] = [
   { app: 'v1.17.0', controller: '3.0.1', crds: '1.9.0', defaults: '2.4.0' },
   { app: 'v1.18.0', controller: '3.1.0', crds: '1.10.0', defaults: '2.5.0' },
   { app: 'v1.19.0', controller: '3.2.0', crds: '1.11.0', defaults: '2.6.0' },
+  { app: 'v1.20.0', controller: '4.0.1', crds: '1.12.1', defaults: '2.7.1' },
 ].splice(-3) // Limit upgrade path to last 3 versions
 
 // Support for Rancher 2.9 was added in KW 1.13.0

--- a/tests/e2e/rancher/rancher-apps.page.ts
+++ b/tests/e2e/rancher/rancher-apps.page.ts
@@ -124,7 +124,7 @@ export class RancherAppsPage extends BasePage {
      * SUCCESS: helm [install|upgrade] [--generate-name=true|name]  /home/shell/helm/opentelemetry-operator-0.38.0.tgz
      */
     async waitHelmSuccess(text: string, options?: { timeout?: number, keepLog?: boolean }) {
-      const timeout = options?.timeout || 60_000
+      const timeout = options?.timeout || 2 * 60_000
       const keepLog = options?.keepLog || false
 
       // Can't match ^..$ because output is sometimes mixed up


### PR DESCRIPTION
- Use rancher 2.10 as default (for extra upgrade & fleet tests)
- Add kubewarden 1.20 to upgrade matrix
- Remove EOL rancher 2.7
- Clean up rancher chart selection