### PR TITLE
Bump kubewarden to 1.21.0

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -21,10 +21,12 @@ on:
         - '~ 2.8'
         - '~ 2.9'
         - '~ 2.10'
+        - '~ 2.11'
         - 'rc'       # rc versions
         - '~ 2.8-0'
         - '~ 2.9-0'
         - '~ 2.10-0'
+        - '~ 2.11-0'
       k3s:
         description: Kubernetes version
         type: choice

--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -27,6 +27,7 @@ const upMap: AppVersion[] = [
   { app: 'v1.18.0', controller: '3.1.0', crds: '1.10.0', defaults: '2.5.0' },
   { app: 'v1.19.0', controller: '3.2.0', crds: '1.11.0', defaults: '2.6.0' },
   { app: 'v1.20.0', controller: '4.0.1', crds: '1.12.1', defaults: '2.7.1' },
+  { app: 'v1.21.0', controller: '4.1.0', crds: '1.13.0', defaults: '2.8.0' },
 ].splice(-3) // Limit upgrade path to last 3 versions
 
 // Support for Rancher 2.9 was added in KW 1.13.0

--- a/tests/e2e/60-telemetry.spec.ts
+++ b/tests/e2e/60-telemetry.spec.ts
@@ -237,10 +237,12 @@ test.describe('Metrics', () => {
     await shell.run('kubectl delete cm -n cattle-dashboards kubewarden-dashboard-policy kubewarden-dashboard-policyserver')
     // Check
     await nav.pserver('default', 'Metrics')
-    await telPage.toBeIncomplete('config')
-    await telPage.toBeIncomplete('monitoring')
-    await telPage.toBeIncomplete('servicemonitor')
-    await telPage.toBeIncomplete('configmap')
+    await ui.retry(async()=> {
+      await telPage.toBeIncomplete('config')
+      await telPage.toBeIncomplete('monitoring')
+      await telPage.toBeIncomplete('servicemonitor')
+      await telPage.toBeIncomplete('configmap')
+    }, 'Service monitor shows as installed')
     await expect(telPage.configBtn).toBeDisabled()
   })
 })


### PR DESCRIPTION
Add workaround for uninstall metrics error