### PR TITLE
Prevent test failures from dockerhub rate limit

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -203,6 +203,15 @@ jobs:
         TAG=${{ env.K3D_VERSION }} sudo --preserve-env=TAG k3d-install
         k3d cluster create ${{ env.K3D_CLUSTER_NAME }} --agents 1 --image rancher/k3s:${{ env.K3S_VERSION }}
 
+        # 429 Too Many Requests - You have reached your pull rate limit
+        if [ -n "${{secrets.DOCKER_USERNAME}}" ]; then
+          kubectl create secret docker-registry regcred --docker-server=https://index.docker.io/v1/ --docker-username=${{ secrets.DOCKER_USERNAME }} --docker-password="${{ secrets.DOCKER_PASSWORD }}"
+          kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "regcred"}]}'
+
+          kubectl create ns jaeger
+          kubectl create secret docker-registry regcred --docker-server=https://index.docker.io/v1/ --docker-username=${{ secrets.DOCKER_USERNAME }} --docker-password="${{ secrets.DOCKER_PASSWORD }}" -n jaeger
+        fi
+
     - name: Install Rancher
       run: |
         RANCHER_FQDN=$(k3d cluster list ${{ env.K3D_CLUSTER_NAME }} -o json | jq -r '[.[].nodes[] | select(.role == "server").IP.IP] | first').nip.io

--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -74,7 +74,7 @@ test('Install UI extension', async({ page, ui }) => {
       }
       await ui.retry(async() => {
         await extensions.selectTab('All')
-        await expect(page.locator('.plugin', { hasText: 'Kubewarden' })).toBeVisible()
+        await expect(page.locator('.plugin', { hasText: 'Kubewarden' })).toBeVisible({timeout: 30_000})
       }, 'Not showing kubewarden extension')
     }
   })

--- a/tests/e2e/60-telemetry.spec.ts
+++ b/tests/e2e/60-telemetry.spec.ts
@@ -74,6 +74,7 @@ test.describe('Tracing', () => {
         yamlPatch: {
           'jaeger.create'   : true,
           'rbac.clusterRole': true,
+          'image.imagePullSecrets': ["regcred"]
         }
       })
     }

--- a/tests/e2e/components/navigation.ts
+++ b/tests/e2e/components/navigation.ts
@@ -122,7 +122,7 @@ export class Navigation {
       await this.explorer('Kubewarden', 'PolicyServers')
       if (name) {
         await this.ui.tableRow(name).open()
-        await expect(this.page.getByRole('heading', { name: `PolicyServer: ${name}` })).toBeVisible()
+        await expect(this.page.getByRole('heading', { name: new RegExp(`PolicyServer:? ${name}`) })).toBeVisible()
       }
       if (tab) await this.ui.tab(tab).click()
     }

--- a/tests/e2e/fleet/jaeger-operator/fleet.yaml
+++ b/tests/e2e/fleet/jaeger-operator/fleet.yaml
@@ -10,6 +10,8 @@ helm:
       clusterRole: true
     jaeger:
       create: true
+    image:
+      imagePullSecrets: ["regcred"]
 
 labels:
   name: jaeger-operator

--- a/tests/e2e/rancher/rancher-common.page.ts
+++ b/tests/e2e/rancher/rancher-common.page.ts
@@ -1,5 +1,6 @@
 import { expect } from '@playwright/test'
 import { BasePage } from './basepage'
+import { RancherUI } from '../components/rancher-ui'
 
 export class RancherCommonPage extends BasePage {
   goto(): Promise<void> {
@@ -18,7 +19,7 @@ export class RancherCommonPage extends BasePage {
     await this.ui.input('Password').fill(password)
     await this.ui.button('Log in with Local User').click()
     // End user agreement
-    await this.ui.checkbox('Allow collection of anonymous statistics').uncheck()
+    if (RancherUI.isVersion('<2.11')) await this.ui.checkbox('Allow collection of anonymous statistics').uncheck()
     await this.ui.checkbox('End User License Agreement').check()
     await this.ui.button('Continue').click()
     // User menu should be visible


### PR DESCRIPTION
Last few weeks we started to hit docker rate limits.

I added few workarounds:
 - created RO token as github actions secret on kubewarden-ui repository.  Personal auth increase pull rate limit [to 40 per hour](https://docs.docker.com/docker-hub/usage/)
 - switched to busybox image from ghcr.io kubewarden test project
 - added few minor fixes for rancher 2.11

This is targeting issues in https://github.com/rancher/kubewarden-ui/actions/runs/13207989084