### PR TITLE
Authenticate k3d registry to dockerhub

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -201,7 +201,9 @@ jobs:
     - name: "Create kubernetes cluster"
       run: |
         TAG=${{ env.K3D_VERSION }} sudo --preserve-env=TAG k3d-install
-        k3d cluster create ${{ env.K3D_CLUSTER_NAME }} --agents 1 --image rancher/k3s:${{ env.K3S_VERSION }}
+
+        # Registry config with docker auth https://k3d.io/v5.4.7/faq/faq/#dockerhub-pull-rate-limit
+        k3d cluster create ${{ env.K3D_CLUSTER_NAME }} --agents 1 --image rancher/k3s:${{ env.K3S_VERSION }} --registry-config <(echo "${{secrets.K3D_REGISTRY_CONFIG}}")
 
         # Wait for kube-system
         for i in {1..20}; do
@@ -209,17 +211,6 @@ jobs:
             grep -vE '([0-9]+)/\1 +Running' <<< $output || break
             [ $i -ne 20 ] && sleep 10 || { echo "Godot: pods not running"; exit 1; }
         done
-
-    - name: Login to Docker Hub
-      run: |
-        # 429 Too Many Requests - You have reached your pull rate limit
-        if [ -n "${{secrets.DOCKER_USERNAME}}" ]; then
-          kubectl create secret docker-registry regcred --docker-server=https://index.docker.io/v1/ --docker-username=${{ secrets.DOCKER_USERNAME }} --docker-password="${{ secrets.DOCKER_PASSWORD }}"
-          kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "regcred"}]}'
-
-          kubectl create ns jaeger
-          kubectl create secret docker-registry regcred --docker-server=https://index.docker.io/v1/ --docker-username=${{ secrets.DOCKER_USERNAME }} --docker-password="${{ secrets.DOCKER_PASSWORD }}" -n jaeger
-        fi
 
     - name: Install Rancher
       run: |

--- a/tests/e2e/60-telemetry.spec.ts
+++ b/tests/e2e/60-telemetry.spec.ts
@@ -74,7 +74,6 @@ test.describe('Tracing', () => {
         yamlPatch: {
           'jaeger.create'   : true,
           'rbac.clusterRole': true,
-          'image.imagePullSecrets': ["regcred"]
         }
       })
     }

--- a/tests/e2e/fleet/jaeger-operator/fleet.yaml
+++ b/tests/e2e/fleet/jaeger-operator/fleet.yaml
@@ -10,8 +10,6 @@ helm:
       clusterRole: true
     jaeger:
       create: true
-    image:
-      imagePullSecrets: ["regcred"]
 
 labels:
   name: jaeger-operator


### PR DESCRIPTION
Nightly tests show that patching default service account was only partial solution.
We would need to patch every new namespace this way, provide imagePullSecret to every app.

This fix is recommended by K3d - we authenticate it's registry.
https://k3d.io/v5.4.7/faq/faq/#dockerhub-pull-rate-limit