### PR TITLE
Add 302 redirect to successful whitelist domain fetch

### DIFF
--- a/pkg/kubewarden/utils/determine-airgap.ts
+++ b/pkg/kubewarden/utils/determine-airgap.ts
@@ -27,26 +27,28 @@ export async function isAirgap(context: AirgapConfig): Promise<Boolean> {
         redirectUnauthorized: false,
       });
 
-      if ( res._status !== 200 ) {
-        store.dispatch('kubewarden/updateAirGapped', true);
+      const status = res?._status
 
-        return true;
+      if (status === 200 || status === 302) {
+        store.dispatch('kubewarden/updateAirGapped', false);
+
+        return false;
       }
 
-      store.dispatch('kubewarden/updateAirGapped', false);
+      store.dispatch('kubewarden/updateAirGapped', true);
 
-      return false;
+      return true;
     }
   } catch (e) {
     if ( !store.getters['kubewarden/airGapped'] ) {
       console.log('Unable to determine management.cattle.io.settings/whitelist-domain value.', e); // eslint-disable-line no-console
-      store.dispatch('kubewarden/updateAirGapped', true);
+      store.dispatch('kubewarden/updateAirGapped', false);
     }
 
-    return true;
+    return false;
   }
 
-  store.dispatch('kubewarden/updateAirGapped', true);
+  store.dispatch('kubewarden/updateAirGapped', false);
 
-  return true;
+  return false;
 }


### PR DESCRIPTION
Fix #1042 

The default value that is added to the `management.cattle.io.setting/whitelist-domain` setting is `forums.rancher.com`. This site will now redirect to `https://forums.suse.com`. Since we were only checking for a status of `200` to determine if the cluster is not air-gapped, we would receive a `302` and thus would cause the condition to fail.

I have added the `302` as an acceptable status code to the air-gapped determination utility.