### PR TITLE
Filter out Rego policies - update store for managing AH packages - cache packages with TTL

### DIFF
--- a/pkg/kubewarden/modules/artifacthub.ts
+++ b/pkg/kubewarden/modules/artifacthub.ts
@@ -1,11 +1,11 @@
-import { ArtifactHubPackage } from '../types';
+import { ArtifactHubPackageDetails } from '../types';
 
 /**
  * Extracts resource kinds from a list of ArtifactHub packages with the `kubewarden/resources` annotation.
  * @param artifactHubPackages
  * @returns `string[]` | Resource kinds
  */
-export function resourcesFromAnnotation(artifactHubPackages: ArtifactHubPackage[]): string[] | void {
+export function resourcesFromAnnotation(artifactHubPackages: ArtifactHubPackageDetails[]): string[] | void {
   const out: string[] = [];
 
   const resources = artifactHubPackages?.flatMap((artifactHubPackage) => {
@@ -43,7 +43,7 @@ export function resourcesFromAnnotation(artifactHubPackages: ArtifactHubPackage[
  * @param artifactHubPackage `schemas`
  * @returns Boolean
  */
-export function isGlobalPolicy(artifactHubPackage: ArtifactHubPackage, schemas: any): Boolean {
+export function isGlobalPolicy(artifactHubPackage: ArtifactHubPackageDetails, schemas: any): Boolean {
   if ( artifactHubPackage ) {
     const resources: string[] | undefined = artifactHubPackage.data?.['kubewarden/resources']?.split(',');
     let targetsNonNamespaced: Boolean = false;

--- a/pkg/kubewarden/store/kubewarden/actions.ts
+++ b/pkg/kubewarden/store/kubewarden/actions.ts
@@ -1,6 +1,16 @@
 import {
-  CatalogApp, CustomResourceDefinition, PolicyReport, ClusterPolicyReport, PolicyTraceConfig, PolicyTrace
+  CatalogApp,
+  CustomResourceDefinition,
+  PolicyReport,
+  ClusterPolicyReport,
+  PolicyTraceConfig,
+  PolicyTrace,
+  REGO_POLICIES_REPO,
+  ArtifactHubPackage,
+  ArtifactHubPackageDetails
 } from '../../types';
+
+const PACKAGES_TTL = 5 * 60 * 1000; // 5 minutes
 
 export default {
   updateAirGapped({ commit }: any, val: Boolean) {
@@ -53,5 +63,76 @@ export default {
   },
   removeKubewardenCrds({ commit }: any, val: CustomResourceDefinition) {
     commit('removeKubewardenCrds', val);
-  }
+  },
+
+  /**
+   * Fetch all packages from the provided repository and store them in Vuex.
+   *
+   * @param {Object} param0 The Vuex context
+   * @param {Object} param1 The object containing:
+   *   - repository: The repository object returned by `value.artifactHubRepo()`
+   *   - value: The CR resource containing the method to fetch package details (artifactHubPackage)
+   *   - force: Boolean to force a fetch regardless of TTL (default: false)
+   */
+  async fetchPackages({ state, commit, dispatch }: any, { repository, value, force = false }: any) {
+    try {
+      // Check if we have a packageCacheTime, and if TTL is still valid
+      const now = Date.now();
+      const isCacheValid = state.packageCacheTime && (now - state.packageCacheTime < PACKAGES_TTL);
+
+      // If not forcing a refresh and the cache is still valid, return immediately
+      if (!force && isCacheValid) {
+        return;
+      }
+
+      if (!repository?.packages?.length) {
+        return;
+      }
+
+      commit('updateLoadingPackages', true);
+
+      // Filter out Rego-based packages
+      const packagesByRepo: ArtifactHubPackage[] = repository.packages.filter(
+        (pkg: ArtifactHubPackage) => !pkg?.repository?.url?.includes(REGO_POLICIES_REPO)
+      );
+
+      // Store all package details keyed by package_id
+      const packageDetailsMap: Record<string, ArtifactHubPackageDetails> = {};
+
+      const results = await Promise.all(
+        packagesByRepo.map(async(pkg) => {
+          const details = await dispatch('fetchPackageDetails', { pkg, value });
+          const key: string = pkg.package_id;
+
+          packageDetailsMap[key] = details;
+
+          return details;
+        })
+      );
+
+      // Filter out any hidden UI packages
+      const filtered = results.filter(pkg => pkg?.data?.['kubewarden/hidden-ui'] !== 'true');
+
+      commit('updatePackages', filtered);
+      commit('updatePackageDetails', packageDetailsMap);
+      commit('updatePackageCacheTime', Date.now());
+    } catch (err) {
+      console.warn('Error fetching packages', err); // eslint-disable-line no-console
+    } finally {
+      commit('updateLoadingPackages', false);
+    }
+  },
+
+  /**
+     * Fetch details for a single package.
+     */
+  async fetchPackageDetails(context: any, { pkg, value }: any) {
+    try {
+      return await value.artifactHubPackage(pkg);
+    } catch (err) {
+      console.warn('Error fetching package details:', err); // eslint-disable-line no-console
+
+      return null;
+    }
+  },
 };

--- a/pkg/kubewarden/store/kubewarden/getters.ts
+++ b/pkg/kubewarden/store/kubewarden/getters.ts
@@ -1,17 +1,25 @@
 import {
-  CatalogApp, CustomResourceDefinition, PolicyReport, ClusterPolicyReport, PolicyTraceConfig
+  CatalogApp,
+  CustomResourceDefinition,
+  PolicyReport,
+  ClusterPolicyReport,
+  PolicyTraceConfig,
+  ArtifactHubPackageDetails,
 } from '../../types';
 import { StateConfig } from './index';
 
 export default {
-  airGapped:               (state: StateConfig): Boolean => state.airGapped,
-  hideBannerDefaults:      (state: StateConfig): Boolean => state.hideBannerDefaults,
-  hideBannerArtifactHub:   (state: StateConfig): Boolean => state.hideBannerArtifactHub,
-  hideBannerAirgapPolicy:  (state: StateConfig): Boolean => state.hideBannerAirgapPolicy,
-  controllerApp:           (state: StateConfig): CatalogApp | null => state.controllerApp,
-  kubewardenCrds:          (state: StateConfig): CustomResourceDefinition[] => state.kubewardenCrds,
-  policyReports:           (state: StateConfig): PolicyReport[] => state.policyReports,
-  clusterPolicyReports:    (state: StateConfig): ClusterPolicyReport[] => state.clusterPolicyReports,
-  policyTraces:            (state: StateConfig): PolicyTraceConfig[] => state.policyTraces,
-  refreshingCharts:        (state: StateConfig): Boolean => state.refreshingCharts,
+  airGapped:              (state: StateConfig): Boolean => state.airGapped,
+  hideBannerDefaults:     (state: StateConfig): Boolean => state.hideBannerDefaults,
+  hideBannerArtifactHub:  (state: StateConfig): Boolean => state.hideBannerArtifactHub,
+  hideBannerAirgapPolicy: (state: StateConfig): Boolean => state.hideBannerAirgapPolicy,
+  controllerApp:          (state: StateConfig): CatalogApp | null => state.controllerApp,
+  kubewardenCrds:         (state: StateConfig): CustomResourceDefinition[] => state.kubewardenCrds,
+  policyReports:          (state: StateConfig): PolicyReport[] => state.policyReports,
+  clusterPolicyReports:   (state: StateConfig): ClusterPolicyReport[] => state.clusterPolicyReports,
+  policyTraces:           (state: StateConfig): PolicyTraceConfig[] => state.policyTraces,
+  refreshingCharts:       (state: StateConfig): Boolean => state.refreshingCharts,
+  packages:               (state: StateConfig): any[] => state.packages,
+  loadingPackages:        (state: StateConfig): boolean => state.loadingPackages,
+  packageDetailsByKey:    (state: StateConfig) => (key: string): ArtifactHubPackageDetails => state.packageDetails[key],
 };

--- a/pkg/kubewarden/store/kubewarden/index.ts
+++ b/pkg/kubewarden/store/kubewarden/index.ts
@@ -7,7 +7,9 @@ import {
   FleetGitRepo,
   PolicyReport,
   PolicyTraceConfig,
-  ClusterPolicyReport
+  ClusterPolicyReport,
+  ArtifactHubPackage,
+  ArtifactHubPackageDetails,
 } from '../../types';
 
 import getters from './getters';
@@ -26,6 +28,10 @@ export interface StateConfig {
   clusterPolicyReports: ClusterPolicyReport[];
   policyTraces: PolicyTraceConfig[];
   refreshingCharts: Boolean;
+  packages: ArtifactHubPackage[];
+  packageDetails: Record<string, ArtifactHubPackageDetails>
+  loadingPackages: boolean;
+  packageCacheTime: number;
 }
 
 const kubewardenFactory = (config: StateConfig): CoreStoreSpecifics => {
@@ -42,7 +48,11 @@ const kubewardenFactory = (config: StateConfig): CoreStoreSpecifics => {
         policyReports:          config.policyReports,
         clusterPolicyReports:   config.clusterPolicyReports,
         policyTraces:           config.policyTraces,
-        refreshingCharts:       config.refreshingCharts
+        refreshingCharts:       config.refreshingCharts,
+        packages:               config.packages,
+        packageDetails:         config.packageDetails,
+        loadingPackages:        config.loadingPackages,
+        packageCacheTime:       config.packageCacheTime,
       };
     },
 
@@ -66,7 +76,11 @@ export default {
     policyReports:          [],
     clusterPolicyReports:   [],
     policyTraces:           [],
-    refreshingCharts:       false
+    refreshingCharts:       false,
+    packages:               [],
+    packageDetails:         {},
+    loadingPackages:        false,
+    packageCacheTime:       0,
   }),
   config
 };

--- a/pkg/kubewarden/store/kubewarden/mutations.ts
+++ b/pkg/kubewarden/store/kubewarden/mutations.ts
@@ -1,5 +1,12 @@
 import {
-  CatalogApp, ClusterPolicyReport, CustomResourceDefinition, PolicyReport, PolicyTrace, PolicyTraceConfig
+  ArtifactHubPackageDetails,
+  ArtifactHubPackage,
+  CatalogApp,
+  ClusterPolicyReport,
+  CustomResourceDefinition,
+  PolicyReport,
+  PolicyTrace,
+  PolicyTraceConfig
 } from '../../types';
 import { StateConfig } from './index';
 
@@ -152,5 +159,23 @@ export default {
 
   updateRefreshingCharts(state: StateConfig, val: Boolean) {
     state.refreshingCharts = val;
-  }
+  },
+
+  updatePackages(state: StateConfig, packages: ArtifactHubPackage[]) {
+    state.packages = packages;
+  },
+
+  updatePackageDetails(state: StateConfig, payload: Record<string, ArtifactHubPackageDetails>) {
+    for (const key in payload) {
+      state.packageDetails[key] = payload[key];
+    }
+  },
+
+  updateLoadingPackages(state: StateConfig, value: boolean) {
+    state.loadingPackages = value;
+  },
+
+  updatePackageCacheTime(state: StateConfig, time: number) {
+    state.packageCacheTime = time;
+  },
 };

--- a/pkg/kubewarden/types/artifacthub.ts
+++ b/pkg/kubewarden/types/artifacthub.ts
@@ -9,86 +9,114 @@ export enum DATA_ANNOTATIONS {
 /* eslint-enable no-unused-vars */
 
 /* eslint-disable camelcase */
+export interface Link {
+  url: string
+  name: string
+}
+
+export interface Data {
+  'kubewarden/rules': string
+  'kubewarden/mutation'?: string
+  'kubewarden/contextAwareResources'?: string
+  'kubewarden/resources': string
+  'kubewarden/questions-ui': string
+}
+
+export interface AvailableVersion {
+  version: string
+  contains_security_updates: boolean
+  prerelease: boolean
+  ts: number
+}
+
+export interface ContainersImage {
+  name: string
+  image: string
+  whitelisted: boolean
+}
+
+export interface Maintainer {
+  name: string
+  email: string
+}
+
+export interface Recommendation {
+  url: string
+}
+
+export interface Repository {
+  repository_id: string
+  name: string
+  display_name: string
+  url: string
+  branch?: string
+  private?: boolean
+  kind: number
+  verified_publisher: boolean
+  official: boolean
+  cncf: boolean
+  scanner_disabled: boolean
+  organization_name: string
+  organization_display_name: string
+}
+
+export interface Stats {
+  subscriptions: number
+  webhooks: number
+}
+
 export interface ArtifactHubPackage {
-  package_id: string;
-  name: string;
-  normalized_name: string;
-  category?: number;
-  is_operator?: boolean;
-  display_name: string;
-  description: string;
-  keywords?: string[];
-  home_url: string;
-  readme: string;
-  install: string;
-  links: [
-    {
-      url: string;
-      name: string;
-    }
-  ];
-  data?: {
-    [DATA_ANNOTATIONS.CONTEXT_AWARE]?: string
-    [DATA_ANNOTATIONS.RULES]?: string;
-    [DATA_ANNOTATIONS.MUTATION]?: string;
-    [DATA_ANNOTATIONS.RESOURCES]?: string;
-    [DATA_ANNOTATIONS.QUESTIONS]?: string;
-  };
-  version: string;
-  available_versions: [
-    {
-      version: string;
-      contains_security_updates?: boolean;
-      prerelease?: boolean;
-    }
-  ];
-  deprecated?: boolean;
-  contains_security_updates?: boolean;
-  prerelease?: boolean;
-  license: string;
-  signed?: boolean;
-  signatures?: string[];
-  containers_images?: [
-    {
-      name: string;
-      image: string;
-      whitelisted: boolean;
-    }
-  ];
-  all_containers_images_whitelisted?: boolean;
-  provider?: string;
-  has_values_schema?: boolean;
-  has_changelog?: boolean;
-  maintainers?: [
-    {
-      name: string;
-      email: string;
-    }
-  ];
-  recommendations?: [
-    {
-      url: string;
-    }
-  ];
-  repository: {
-    repository_id: string;
-    name: string;
-    display_name: string;
-    url: string;
-    branch: string;
-    private?: boolean;
-    kind: number;
-    verified_publisher?: boolean;
-    official?: boolean;
-    cncf?: boolean;
-    scanner_disabled?: boolean;
-    organization_name?: string;
-    organization_display_name?: string;
-  };
-  stats?: {
-    subscriptions: number;
-    webhooks: number;
-  };
-  production_organizations_count?: number;
+  package_id: string
+  name: string
+  normalized_name: string
+  category: number
+  stars: number
+  display_name: string
+  description: string
+  version: string
+  license: string
+  deprecated: boolean
+  has_values_schema: boolean
+  signed: boolean
+  signatures: string[]
+  all_containers_images_whitelisted: boolean
+  production_organizations_count: number
+  ts: number
+  repository: Repository
+}
+
+export interface ArtifactHubPackageDetails {
+  package_id: string
+  name: string
+  normalized_name: string
+  category: number
+  is_operator: boolean
+  display_name: string
+  description: string
+  keywords: string[]
+  home_url: string
+  readme: string
+  install: string
+  links: Link[]
+  data: Data
+  version: string
+  available_versions: AvailableVersion[]
+  deprecated: boolean
+  contains_security_updates: boolean
+  prerelease: boolean
+  license: string
+  signed: boolean
+  signatures: string[]
+  containers_images: ContainersImage[]
+  all_containers_images_whitelisted: boolean
+  provider: string
+  has_values_schema: boolean
+  has_changelog: boolean
+  ts: number
+  maintainers: Maintainer[]
+  recommendations: Recommendation[]
+  repository: Repository
+  stats: Stats
+  production_organizations_count: number
 }
 /* eslint-enable camelcase */

--- a/pkg/kubewarden/types/kubewarden.ts
+++ b/pkg/kubewarden/types/kubewarden.ts
@@ -10,6 +10,7 @@ export const CHART_NAME = 'rancher-kubewarden';
 
 export const KUBEWARDEN_DASHBOARD = 'dashboard';
 export const KUBEWARDEN_REPO = 'https://charts.kubewarden.io';
+export const REGO_POLICIES_REPO = 'https://github.com/kubewarden/rego-policies-library';
 
 export const KUBEWARDEN_CHARTS = {
   CONTROLLER:       'kubewarden-controller',


### PR DESCRIPTION
Fix #1043 

This will filter out policies within the Rego repository as well as several enhancements and refactors around how ArtifactHub packages are fetched, cached, and displayed in the UI.

- **Create.vue:** 
  - Updated to dispatch the new `fetchPackages` action from the store.
  - Removed legacy local state (`loadingPackages`, `packages`, `repository`) in favor of Vuex getters.
  - Improved package filtering to exclude packages from the REGO policies repository.
- **Store Actions:**
  - **New State Properties and Getters:** Added `packages`, `packageDetails`, `loadingPackages`, and `packageCacheTime` to the Vuex store.
  - **Actions:**
    - **`fetchPackages`:** Fetches all packages from the provided ArtifactHub repository. It now includes TTL-based caching (5 minutes) to prevent unnecessary re-fetches.
    - **`fetchPackageDetails`:** Fetches detailed package information for a single package.
- **ArtifactHub Types:**
  - Introduced new types (e.g., `Link`, `Data`, `AvailableVersion`, etc.) for better clarity and structure.

