### PR TITLE
Update policy-reporter-ui lookup with v3 selectors

### DIFF
--- a/pkg/kubewarden/components/PolicyReporter/index.vue
+++ b/pkg/kubewarden/components/PolicyReporter/index.vue
@@ -103,7 +103,10 @@ export default {
     },
 
     reporterDeployment() {
-      return this.controllerDeployments?.find(deploy => deploy?.metadata?.labels?.['app.kubernetes.io/component'] === 'ui');
+      // Policy Reporter UI labels: ui (kubewarden < v1.22.0), policy-reporter-ui (kubewarden >= v1.22.0)
+      return this.controllerDeployments?.find(deploy =>
+        ['ui', 'policy-reporter-ui'].includes(deploy?.metadata?.labels?.['app.kubernetes.io/name'])
+      );
     },
 
     reporterDeploymentState() {
@@ -161,7 +164,7 @@ export default {
               {
                 var:         'reporterUIService',
                 parsingFunc: (data) => {
-                  return data.find(service => service?.metadata?.labels?.['app.kubernetes.io/name'] === 'ui');
+                  return data.find(service => ['policy-reporter-ui', 'ui'].includes(service?.metadata?.labels?.['app.kubernetes.io/name']));
                 }
               }
             ]


### PR DESCRIPTION
Update policy reporter ui to handle both v2 and v3. Related issue: https://github.com/rancher/kubewarden-ui/issues/1055

I am wondering if I should limit to 1 result with `.first()`...