### PR TITLE
Ensure resource is determined in PolicyReporter tabs

### DIFF
--- a/pkg/kubewarden/components/PolicyReporter/ResourceTab.vue
+++ b/pkg/kubewarden/components/PolicyReporter/ResourceTab.vue
@@ -18,13 +18,6 @@ import { splitGroupKind } from '../../modules/core';
 import * as coreTypes from '../../core/core-resources';
 
 export default {
-  props: {
-    resource: {
-      type:     Object,
-      required: true
-    }
-  },
-
   components: {
     BadgeState, Banner, Loading, SortableTable
   },
@@ -32,6 +25,7 @@ export default {
   mixins: [ResourceFetch],
 
   async fetch() {
+    this.determineResource();
     const fetchedReports = await getFilteredReports(this.$store, this.resource);
 
     this.reports = fetchedReports || [];
@@ -50,6 +44,7 @@ export default {
     return {
       colorForResult,
       reports:          [],
+      resource:         null,
       resourceHeaders:  POLICY_REPORTER_HEADERS.RESOURCE,
       namespaceHeaders: POLICY_REPORTER_HEADERS.NAMESPACE
     };
@@ -107,6 +102,16 @@ export default {
       }
 
       return null;
+    },
+
+    determineResource() {
+      const route = this.$route;
+
+      if (route?.params?.resource && route?.params?.id) {
+        const id = route?.params.namespace ? `${ route?.params.namespace }/${ route?.params.id }` : route?.params.id;
+
+        this.resource = this.$store.getters['cluster/byId'](route?.params.resource, id);
+      }
     },
 
     getResourceValue(row, val, needScope = false) {


### PR DESCRIPTION
Fix #1059 

The `resource` prop was not being supplied to the ResourceTab which was causing the required prop error to be thrown.

This includes the addition of a method to determine the resource based on route parameters, the removal of the `resource` prop, and the initialization of the `resource` data property.

Initialization and data handling:

* [`pkg/kubewarden/components/PolicyReporter/ResourceTab.vue`](diffhunk://#diff-38c7f92a32bb0b1ade38c31fc160b7cba337ef17a098b3e1937a51f0445e5778R107-R116): Added the `determineResource` method to set the `resource` based on route parameters.
* [`pkg/kubewarden/components/PolicyReporter/ResourceTab.vue`](diffhunk://#diff-38c7f92a32bb0b1ade38c31fc160b7cba337ef17a098b3e1937a51f0445e5778R47): Initialized the `resource` data property to `null`.

Prop removal:

* [`pkg/kubewarden/components/PolicyReporter/ResourceTab.vue`](diffhunk://#diff-38c7f92a32bb0b1ade38c31fc160b7cba337ef17a098b3e1937a51f0445e5778L21-R28): Removed the `resource` prop definition from the component.