### PR TITLE
Add kubewarden 1.22 to upgrade path

### DIFF
--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -28,6 +28,7 @@ const upMap: AppVersion[] = [
   { app: 'v1.19.0', controller: '3.2.0', crds: '1.11.0', defaults: '2.6.0' },
   { app: 'v1.20.0', controller: '4.0.1', crds: '1.12.1', defaults: '2.7.1' },
   { app: 'v1.21.0', controller: '4.1.0', crds: '1.13.0', defaults: '2.8.1' },
+  { app: 'v1.22.0', controller: '4.2.0', crds: '1.14.0', defaults: '2.9.0' },
 ].splice(-3) // Limit upgrade path to last 3 versions
 
 // Support for Rancher 2.9 was added in KW 1.13.0
@@ -74,7 +75,7 @@ test('Install UI extension', async({ page, ui }) => {
       }
       await ui.retry(async() => {
         await extensions.selectTab('All')
-        await expect(page.locator('.plugin', { hasText: 'Kubewarden' })).toBeVisible({timeout: 30_000})
+        await expect(page.locator('.plugin', { hasText: 'Kubewarden' })).toBeVisible({ timeout: 30_000 })
       }, 'Not showing kubewarden extension')
     }
   })
@@ -234,14 +235,6 @@ test('Upgrade Kubewarden', async({ page, nav }) => {
     // Check there are no more upgrades
     await expect(kwPage.currentApp).toContainText(`App Version: ${last.app}`)
     await expect(kwPage.upgradeApp).not.toBeVisible()
-  })
-
-  await test.step('Upgrade Policy Server', async() => {
-    // Update to last known version or latest one
-    await apps.updateApp('rancher-kubewarden-defaults', { version: last.defaults || 0 })
-    // Check resources are online and with right versions
-    await nav.explorer('Apps', 'Installed Apps')
-    await apps.checkChart('rancher-kubewarden-defaults', last.defaults)
   })
 })
 

--- a/tests/e2e/pages/kubewarden.page.ts
+++ b/tests/e2e/pages/kubewarden.page.ts
@@ -161,7 +161,11 @@ export class KubewardenPage extends BasePage {
         await expect(apps.stepTitle).toContainText(`${from?.controller || ''} > ${to?.controller || ''}`)
       }
       await apps.updateApp('rancher-kubewarden-controller', { navigate: false, timeout: 4 * 60_000 })
-      await shell.waitPods()
+      // 4.1.0 Error: error while loading policies from "/config/policies.yml": data did not match any variant of untagged enum PolicyOrPolicyGroup
+      // 4.2.0 Probe port change from https to http
+      if (!to?.controller?.startsWith('4.1') && !to?.controller?.startsWith('4.2')) {
+        await shell.waitPods()
+      }
 
       // Defaults upgrade
       await this.nav.kubewarden()


### PR DESCRIPTION
Fixes upgrade test https://github.com/rancher/kubewarden-ui/actions/runs/13519937360/job/37795843703

- add kubewarden 1.22 to upgrade path
- removed obsolete policy server upgrade, now it's part of kw upgrade
- skip controller upgrade wait because of breaking changes of defaults
