### PR TITLE
Lock opentelemetry-operator to 0.80.2

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -202,7 +202,7 @@ jobs:
       run: |
         TAG=${{ env.K3D_VERSION }} sudo --preserve-env=TAG k3d-install
 
-        # Registry config with docker auth https://k3d.io/v5.4.7/faq/faq/#dockerhub-pull-rate-limit
+        # Registry config with docker auth https://k3d.io/v5.8.2/faq/faq/#dockerhub-pull-rate-limit
         k3d cluster create ${{ env.K3D_CLUSTER_NAME }} --agents 1 --image rancher/k3s:${{ env.K3S_VERSION }} --registry-config <(echo "${{secrets.K3D_REGISTRY_CONFIG}}")
 
         # Wait for kube-system

--- a/tests/e2e/60-telemetry.spec.ts
+++ b/tests/e2e/60-telemetry.spec.ts
@@ -8,7 +8,8 @@ const cmanRepo: ChartRepo = { name: 'jetstack', url: 'https://charts.jetstack.io
 const cmanChart: Chart = { title: 'cert-manager', name: 'cert-manager', namespace: 'cert-manager', check: 'cert-manager' }
 // OpenTelemetry
 const otelRepo: ChartRepo = { name: 'open-telemetry', url: 'https://open-telemetry.github.io/opentelemetry-helm-charts' }
-const otelChart: Chart = { title: 'opentelemetry-operator', name: 'opentelemetry-operator', namespace: 'open-telemetry', check: 'opentelemetry-operator' }
+// Locked to v0.80.2: https://github.com/kubewarden/kubewarden-controller/issues/1026
+const otelChart: Chart = { title: 'opentelemetry-operator', name: 'opentelemetry-operator', namespace: 'open-telemetry', check: 'opentelemetry-operator', version: '0.80.2' }
 // Jaeger Tracing
 const jaegerRepo: ChartRepo = { name: 'jaegertracing', url: 'https://jaegertracing.github.io/helm-charts' }
 const jaegerChart: Chart = { title: 'jaeger-operator', name: 'jaeger-operator', namespace: 'jaeger', check: 'jaeger-operator' }
@@ -237,7 +238,7 @@ test.describe('Metrics', () => {
     await shell.run('kubectl delete cm -n cattle-dashboards kubewarden-dashboard-policy kubewarden-dashboard-policyserver')
     // Check
     await nav.pserver('default', 'Metrics')
-    await ui.retry(async()=> {
+    await ui.retry(async() => {
       await telPage.toBeIncomplete('config')
       await telPage.toBeIncomplete('monitoring')
       await telPage.toBeIncomplete('servicemonitor')

--- a/tests/e2e/components/table-row.ts
+++ b/tests/e2e/components/table-row.ts
@@ -106,8 +106,10 @@ export class TableRow {
 
     @step
     async action(name: string) {
-      await this.row.locator('button.actions').click()
-      await this.ui.page.getByRole('listitem').getByText(name, { exact: true }).click()
+      await this.row.getByTestId(/^sortable-table-\d+-action-button$/).click()
+      // Rancher 2.11+ uses both menuitem & listitem
+      await this.ui.page.getByRole('listitem').or(this.ui.page.getByRole('menuitem'))
+        .getByText(name, { exact: true }).click()
     }
 
     @step

--- a/tests/e2e/fleet/open-telemetry/fleet.yaml
+++ b/tests/e2e/fleet/open-telemetry/fleet.yaml
@@ -2,7 +2,7 @@ defaultNamespace: opentelemetry
 helm:
   releaseName: opentelemetry
   chart: opentelemetry-operator
-  version: "*" # 0.68.1
+  version: "0.80.2" # 0.68.1
   repo: https://open-telemetry.github.io/opentelemetry-helm-charts
   values:
     manager:


### PR DESCRIPTION
[Nightly tests](https://github.com/rancher/kubewarden-ui/actions/runs/13575816885/job/37970223904) fail on metrics issue with otel-operator 0.81.0. I opened [new issue](https://github.com/kubewarden/kubewarden-controller/issues/1026) on kubewarden-controller.
This is temporary workaround until issue is fixed so e2e won't fail.

- Lock opentelemetry-operator to 0.80.2
- Fixes for Rancher 2.11 action menu
