### PR TITLE
Add missing unit tests following Vue 3 refactor

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -9,6 +9,7 @@ import i18n from '@shell/plugins/i18n';
 import { floatingVueOptions } from '@shell/plugins/floating-vue';
 import cleanTooltipDirective from '@shell/directives/clean-tooltip';
 import cleanHtmlDirective from '@shell/directives/clean-html';
+import trimWhitespaceDirective from '@shell/directives/trim-whitespace';
 import '@shell/plugins/replaceall';
 
 // Create a Vue application instance
@@ -22,6 +23,7 @@ vueApp.use(i18n, { store: { dispatch() {} } });
 vueApp.use(FloatingVue, floatingVueOptions);
 vueApp.directive('clean-html', cleanHtmlDirective);
 vueApp.directive('clean-tooltip', cleanTooltipDirective);
+vueApp.directive('trim-whitespace', trimWhitespaceDirective);
 vueApp.component('v-select', vSelect);
 
 // Extend global config for @vue/test-utils

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-jest": "^28.11.0",
     "eslint-plugin-vue": "^9.33.0",
     "file-loader": "^6.2.0",
+    "flush-promises": "^1.0.2",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "sass-loader": "12.6.0",

--- a/pkg/kubewarden/components/Dashboard/__tests__/DashboardView.spec.ts
+++ b/pkg/kubewarden/components/Dashboard/__tests__/DashboardView.spec.ts
@@ -13,13 +13,13 @@ import Masthead from '@kubewarden/components/Dashboard/Masthead.vue';
 
 import mockControllerChart from '@tests/unit/mocks/controllerChart';
 import mockPolicyServers from '@tests/unit/mocks/policyServers';
-import { mockControllerApp } from '@tests/unit/mocks/controllerApp';
+import { mockControllerAppLegacy } from '@tests/unit/mocks/controllerApp';
 
 // Create a mock for the 'cluster/all' getter that returns different values based on the input.
 const clusterAllMock = jest.fn((resourceType) => {
   switch (resourceType) {
   case CATALOG.APP:
-    return [mockControllerApp];
+    return [mockControllerAppLegacy];
   case POD:
     return [{
       metadata: {

--- a/pkg/kubewarden/components/Dashboard/__tests__/Masthead.spec.ts
+++ b/pkg/kubewarden/components/Dashboard/__tests__/Masthead.spec.ts
@@ -4,7 +4,7 @@ import { SHOW_PRE_RELEASE } from '@shell/store/prefs';
 import Masthead from '@kubewarden/components/Dashboard/Masthead.vue';
 import DefaultsBanner from '@kubewarden/components/DefaultsBanner';
 
-import controllerCharts from '~/tests/unit/mocks/controllerChart';
+import controllerCharts from '@/tests/unit/mocks/controllerChart';
 
 describe('component: Masthead', () => {
   const commonMocks = {

--- a/pkg/kubewarden/components/Dashboard/__tests__/ReportsGauge.spec.ts
+++ b/pkg/kubewarden/components/Dashboard/__tests__/ReportsGauge.spec.ts
@@ -1,0 +1,145 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { h } from 'vue';
+
+import ReportsGauge from '@kubewarden/components/Dashboard/ReportsGauge.vue';
+
+const BarStub = {
+  name:  'Bar',
+  props: ['percentage', 'primaryColor', 'secondaryColor'],
+  render() {
+    return h('div', { class: 'bar-stub' });
+  }
+};
+
+const createWrapper = (overrides: any = {}) => {
+  const defaultProps = {
+    reports: {
+      total:  100,
+      status: {
+        success: 70,
+        fail:    30
+      }
+    }
+  };
+
+  return mount(ReportsGauge, {
+    props:  {
+      ...defaultProps,
+      ...overrides.props
+    },
+    global: {
+      stubs: {
+        Bar: BarStub,
+        ...overrides.global?.stubs
+      },
+      ...overrides.global
+    },
+    ...overrides
+  });
+};
+
+describe('ReportsGauge.vue', () => {
+  it('renders correct numbers and percentages when total is non-zero', async() => {
+    const reports = {
+      total:  100,
+      status: {
+        success: 70,
+        fail:    30
+      }
+    };
+
+    const wrapper = createWrapper({ props: { reports } });
+
+    await flushPromises();
+
+    const successStats = wrapper.find('.numbers-stats.success');
+
+    expect(successStats.text()).toContain('70'); // reports.status.success
+    expect(successStats.text()).toContain('Success');
+    expect(successStats.text()).toContain('70%'); // formatted percentage
+
+    const failStats = wrapper.find('.numbers-stats.fail');
+
+    expect(failStats.text()).toContain('30'); // reports.status.fail
+    expect(failStats.text()).toContain('Fail');
+    expect(failStats.text()).toContain('30%');
+  });
+
+  it('computes percentageBarValue and secondaryColor correctly when total is non-zero', async() => {
+    const reports = {
+      total:  100,
+      status: {
+        success: 70,
+        fail:    30
+      }
+    };
+
+    const wrapper = createWrapper({ props: { reports } });
+
+    await flushPromises();
+
+    expect(wrapper.vm.percentageBarValue).toBe('70');
+
+    // Since total is not 0, secondaryColor should be '--error'
+    expect(wrapper.vm.secondaryColor).toBe('--error');
+
+    expect(wrapper.vm.formattedPercentage('success')).toBe('70%');
+    expect(wrapper.vm.formattedPercentage('fail')).toBe('30%');
+  });
+
+  it('passes the correct props to the Bar component', async() => {
+    const reports = {
+      total:  100,
+      status: {
+        success: 70,
+        fail:    30
+      }
+    };
+
+    const wrapper = createWrapper({ props: { reports } });
+
+    await flushPromises();
+
+    const barStub = wrapper.findComponent({ name: 'Bar' });
+
+    expect(barStub.exists()).toBe(true);
+    expect(barStub.props('percentage')).toBe('70');
+    expect(barStub.props('primaryColor')).toBe('--success');
+    expect(barStub.props('secondaryColor')).toBe('--error');
+  });
+
+  it('computes correct values and passes correct props when total is zero', async() => {
+    const reports = {
+      total:  0,
+      status: {
+        success: 0,
+        fail:    0
+      }
+    };
+
+    const wrapper = createWrapper({ props: { reports } });
+
+    await flushPromises();
+
+    // With total === 0, percentageBarValue should be 0 (as a number) and secondaryColor should be '--border'
+    expect(wrapper.vm.percentageBarValue).toBe(0);
+    expect(wrapper.vm.secondaryColor).toBe('--border');
+
+    // The formattedPercentage method should return "0%" for any type.
+    expect(wrapper.vm.formattedPercentage('success')).toBe('0%');
+    expect(wrapper.vm.formattedPercentage('fail')).toBe('0%');
+
+    const successStats = wrapper.find('.numbers-stats.success');
+
+    expect(successStats.text()).toContain('0%');
+
+    const failStats = wrapper.find('.numbers-stats.fail');
+
+    expect(failStats.text()).toContain('0%');
+
+    const barStub = wrapper.findComponent({ name: 'Bar' });
+
+    expect(barStub.props('percentage')).toBe(0);
+    expect(barStub.props('secondaryColor')).toBe('--border');
+  });
+});

--- a/pkg/kubewarden/components/MetricsChecklist.vue
+++ b/pkg/kubewarden/components/MetricsChecklist.vue
@@ -42,7 +42,7 @@ export default {
       default: null
     },
     metricsConfiguration: {
-      type:    Object,
+      type:    Boolean,
       default: null
     },
     monitoringApp: {

--- a/pkg/kubewarden/components/MetricsTab.vue
+++ b/pkg/kubewarden/components/MetricsTab.vue
@@ -252,8 +252,6 @@ export default {
 
     metricsConfiguration() {
       if (!this.controllerApp) {
-        console.log('# 0');
-
         return null;
       }
 

--- a/pkg/kubewarden/components/PolicyReporter/__tests__/PolicyReporter.spec.ts
+++ b/pkg/kubewarden/components/PolicyReporter/__tests__/PolicyReporter.spec.ts
@@ -3,7 +3,7 @@ import { mount } from '@vue/test-utils';
 import PolicyReporter from '@kubewarden/components/PolicyReporter/index.vue';
 
 import mockControllerDeployment from '@/tests/unit/mocks/controllerDeployment';
-import { mockControllerApp } from '@/tests/unit/mocks/controllerApp';
+import { mockControllerAppLegacy } from '@/tests/unit/mocks/controllerApp';
 import { KUBEWARDEN, WG_POLICY_K8S } from '@kubewarden/types';
 
 // Create a mock for the 'cluster/schemaFor' getter that returns different values based on the input.
@@ -29,7 +29,7 @@ const commonMocks = {
       'cluster/all':                () => [mockControllerDeployment],
       'cluster/canList':            jest.fn,
       'cluster/schemaFor':          clusterSchemaFor,
-      'kubewarden/controllerApp':   mockControllerApp,
+      'kubewarden/controllerApp':   mockControllerAppLegacy,
       'i18n/t':                     jest.fn(),
       'management/byId':            () => 'local',
       'resource-fetch/refreshFlag': jest.fn()
@@ -115,7 +115,7 @@ describe('component: PolicyReporter', () => {
   });
 
   it('Should show incompatible banner with old version', () => {
-    const mockCloneAppWithOldVersion = { ...mockControllerApp };
+    const mockCloneAppWithOldVersion = { ...mockControllerAppLegacy };
 
     mockCloneAppWithOldVersion.spec.chart.metadata.appVersion = kwVersions.old;
 
@@ -144,7 +144,7 @@ describe('component: PolicyReporter', () => {
 
   it('Should show CRDs warning banner when not installed', () => {
     // Re-clone the controller app with a new version.
-    const mockCloneAppWithNewVersion = { ...mockControllerApp };
+    const mockCloneAppWithNewVersion = { ...mockControllerAppLegacy };
 
     mockCloneAppWithNewVersion.spec.chart.metadata.appVersion = kwVersions.new;
 

--- a/pkg/kubewarden/components/PolicyReporter/__tests__/ReporterPanel.spec.ts
+++ b/pkg/kubewarden/components/PolicyReporter/__tests__/ReporterPanel.spec.ts
@@ -1,0 +1,129 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { nextTick } from 'vue';
+
+import ReporterPanel from '@kubewarden/components/PolicyReporter/ReporterPanel.vue';
+import { getReports } from '@kubewarden/modules/policyReporter';
+
+// Mock the getReports function so we can spy on its calls.
+jest.mock('@kubewarden/modules/policyReporter', () => ({ getReports: jest.fn(() => Promise.resolve([])) }));
+
+describe('ReporterPanel.vue', () => {
+  let storeMock: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    storeMock = { commit: jest.fn() };
+  });
+
+  it('renders the reporter panel', () => {
+    const wrapper = mount(ReporterPanel, {
+      global: {
+        provide: { store: storeMock },
+        mocks:   {
+          $route: {
+            params: {},
+            path:   '/somepath'
+          }
+        }
+      }
+    });
+
+    expect(wrapper.find('.reporter-panel').exists()).toBe(true);
+  });
+
+  it('fetches cluster policy reports when no resource param is provided', async() => {
+    const $route = {
+      params: {},
+      path:   '/somepath'
+    };
+
+    mount(ReporterPanel, {
+      global: {
+        provide: { store: storeMock },
+        mocks:   { $route }
+      }
+    });
+
+    // Wait for onMounted and async tasks to finish.
+    await flushPromises();
+    await nextTick();
+
+    // For a route with no "resource" parameter and a path not including "projectsnamespaces":
+    // - The first condition (cluster level) should trigger a call to getReports with clusterLevel true.
+    // - The second condition is false because there is no resource param and the path does not include "projectsnamespaces".
+    expect(getReports).toHaveBeenCalledTimes(1);
+    expect(getReports).toHaveBeenCalledWith(storeMock, true);
+    // Verify that loading is turned on then off.
+    expect(storeMock.commit).toHaveBeenCalledWith('kubewarden/updateLoadingReports', true);
+    expect(storeMock.commit).toHaveBeenCalledWith('kubewarden/updateLoadingReports', false);
+  });
+
+  it('fetches resource-specific policy reports when resource param is provided', async() => {
+    const $route = {
+      params: { resource: 'pod' },
+      path:   '/pods'
+    };
+
+    mount(ReporterPanel, {
+      global: {
+        provide: { store: storeMock },
+        mocks:   { $route }
+      }
+    });
+
+    await flushPromises();
+    await nextTick();
+
+    // With a resource parameter, the first condition is false and the second condition triggers.
+    expect(getReports).toHaveBeenCalledTimes(1);
+    expect(getReports).toHaveBeenCalledWith(storeMock, false, 'pod');
+    expect(storeMock.commit).toHaveBeenCalledWith('kubewarden/updateLoadingReports', true);
+    expect(storeMock.commit).toHaveBeenCalledWith('kubewarden/updateLoadingReports', false);
+  });
+
+  it('fetches both cluster and resource-specific policy reports when path includes "projectsnamespaces"', async() => {
+    const $route = {
+      params: {},
+      path:   '/projectsnamespaces'
+    };
+
+    mount(ReporterPanel, {
+      global: {
+        provide: { store: storeMock },
+        mocks:   { $route }
+      }
+    });
+
+    await flushPromises();
+    await nextTick();
+
+    // When the path includes "projectsnamespaces", both conditions are met:
+    // - The cluster-level call.
+    // - The resource-specific call (with resourceType undefined).
+    expect(getReports).toHaveBeenCalledTimes(2);
+    expect(getReports).toHaveBeenNthCalledWith(1, storeMock, true);
+    expect(getReports).toHaveBeenNthCalledWith(2, storeMock, false, undefined);
+    expect(storeMock.commit).toHaveBeenCalledWith('kubewarden/updateLoadingReports', true);
+    expect(storeMock.commit).toHaveBeenCalledWith('kubewarden/updateLoadingReports', false);
+  });
+
+  it('does not fetch policies if $route is not available', async() => {
+    // Simulate absence of $route by providing undefined.
+    mount(ReporterPanel, {
+      global: {
+        provide: { store: storeMock },
+        mocks:   { $route: undefined }
+      }
+    });
+
+    await flushPromises();
+    await nextTick();
+
+    // In this case, onMounted should exit early because no $route was found.
+    expect(getReports).not.toHaveBeenCalled();
+    // updateLoadingReports(true) is still called at the start but updateLoadingReports(false) is not committed.
+    expect(storeMock.commit).toHaveBeenCalledWith('kubewarden/updateLoadingReports', true);
+    expect(storeMock.commit).not.toHaveBeenCalledWith('kubewarden/updateLoadingReports', false);
+  });
+});

--- a/pkg/kubewarden/components/PolicyReporter/__tests__/ResourceTab.spec.ts
+++ b/pkg/kubewarden/components/PolicyReporter/__tests__/ResourceTab.spec.ts
@@ -1,0 +1,362 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { createStore } from 'vuex';
+import { nextTick, h } from 'vue';
+
+import ResourceTab from '@kubewarden/components/PolicyReporter/ResourceTab.vue';
+
+import {
+  getFilteredReport,
+  getLinkForPolicy
+} from '@kubewarden/modules/policyReporter';
+
+jest.mock('@kubewarden/modules/policyReporter', () => ({
+  getFilteredReport: jest.fn(),
+  getLinkForPolicy:  jest.fn(),
+  colorForResult:    jest.fn((result) => `text-${ result }`),
+  colorForSeverity:  jest.fn((severity) => `bg-${ severity }`)
+}));
+
+const commonMocks = {
+  $route: {
+    params: {
+      resource:  'pod',
+      id:        '123',
+      namespace: 'default'
+    },
+    path: '/pod/123'
+  }
+};
+
+const RouterLinkStub = {
+  name:  'router-link',
+  props: ['to'],
+  render() {
+    return h('a', {}, this.$slots.default ? this.$slots.default() : '');
+  }
+};
+
+const createSortableTableStub = (slotName: string, className: string) => ({
+  name:  'SortableTable',
+  props: {
+    rows:              {
+      type:    Array,
+      default: () => []
+    },
+    headers:           {
+      type:    Array,
+      default: () => []
+    },
+    tableActions:      Boolean,
+    rowActions:        Boolean,
+    keyField:          String,
+    subExpandable:     Boolean,
+    subExpandColumn:   Boolean,
+    subRows:           Boolean,
+    paging:            Boolean,
+    rowsPerPage:       Number,
+    extraSearchFields: {
+      type:    Array,
+      default: () => []
+    },
+    defaultSortBy: String
+  },
+  setup(props, { slots }) {
+    return () => h('div', { class: className }, slots[slotName] ? slots[slotName]({
+      row:         props.rows[0],
+      fullColspan: 1
+    }) : null);
+  }
+});
+
+const BadgeStateStub = {
+  name:  'BadgeState',
+  props: ['label', 'color'],
+  render() {
+    // Here we simply return a span with the expected classes and text.
+    return h('span', { class: ['badge-state', this.color] }, this.label);
+  }
+};
+
+
+// Reusable Banner stub that renders its default slot.
+const BannerStub = {
+  name:  'Banner',
+  props: ['color'],
+  render() {
+    return h('div', { class: 'banner-stub' }, this.$slots.default ? this.$slots.default() : '');
+  }
+};
+
+describe('ResourceTab.vue', () => {
+  let store: ReturnType<typeof createStore>;
+  let getters: Record<string, any>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    getters = {
+      'i18n/t':       (key: string) => key,
+      'cluster/byId': () => (resource: string, id: string) => ({
+        resource,
+        id,
+        type: resource
+      }),
+      'cluster/schemaFor': () => () => {
+        return true;
+      }
+    };
+
+    store = createStore({ getters });
+  });
+
+  const createWrapper = (overrides: any = {}) => {
+    return mount(ResourceTab, {
+      global: {
+        mocks:   commonMocks,
+        stubs:   {
+          SortableTable: true,
+          'router-link': RouterLinkStub
+        },
+        plugins: [store],
+      },
+      ...overrides
+    });
+  };
+
+  it('shows a loading indicator initially then renders the table when reports are fetched', async() => {
+    // Simulate getFilteredReport resolving with an empty results array.
+    (getFilteredReport as jest.Mock).mockResolvedValue({ results: [] });
+
+    const wrapper = createWrapper();
+
+    // Loading indicator should be visible immediately.
+    expect(wrapper.find('[data-testid="resource-tab-loading"]').exists()).toBe(true);
+
+    await flushPromises();
+    await nextTick();
+
+    expect(wrapper.find('[data-testid="resource-tab-loading"]').exists()).toBe(false);
+    expect(wrapper.findComponent({ name: 'SortableTable' }).exists()).toBe(true);
+  });
+
+  it('calls determineResource when $route has resource and id', async() => {
+    (getFilteredReport as jest.Mock).mockResolvedValue({ results: [] });
+    createWrapper();
+
+    await flushPromises();
+    await nextTick();
+
+    // The determineResource function should have used the cluster/byId getter.
+    const resource = store.getters['cluster/byId']('pod', 'default/123');
+
+    expect(resource).toEqual({
+      resource: 'pod',
+      id:       'default/123',
+      type:     'pod'
+    });
+  });
+
+
+  it('renders the policy column with a router-link when canGetKubewardenLinks is true', async() => {
+    const mockLink = { name: 'mock-route' };
+
+    (getLinkForPolicy as jest.Mock).mockReturnValue(mockLink);
+
+    (getFilteredReport as jest.Mock).mockResolvedValue({
+      results: [
+        {
+          policy:     'clusterwide-my-policy',
+          result:     'PASS',
+          severity:   'high',
+          properties: {},
+          scope:      {}
+        }
+      ]
+    });
+
+    const wrapper = createWrapper({
+      global: {
+        plugins: [store],
+        mocks:   commonMocks,
+        stubs:   {
+          SortableTable: createSortableTableStub('col:policy', 'sortable-table-stub'),
+          'router-link': RouterLinkStub
+        }
+      }
+    });
+
+    await flushPromises();
+    await nextTick();
+
+    const routerLink = wrapper.findComponent(RouterLinkStub);
+
+    expect(routerLink.exists()).toBe(true);
+    expect(routerLink.props('to')).toEqual(mockLink);
+    // The formattedDisplayName function should remove the "clusterwide-" prefix.
+    // So "clusterwide-my-policy" becomes "my-policy".
+    expect(routerLink.text()).toBe('my-policy');
+  });
+
+  it('renders the policy column as plain text when canGetKubewardenLinks is false', async() => {
+    const storeWithoutLinks = createStore({
+      getters: {
+        'i18n/t':       (key: string) => key,
+        'cluster/byId': () => (resource: string, id: string) => ({
+          resource,
+          id,
+          type: resource
+        }),
+        'cluster/schemaFor': () => () => {
+          return false;
+        }
+      }
+    });
+
+    (getFilteredReport as jest.Mock).mockResolvedValue({
+      results: [
+        {
+          policy:     'clusterwide-my-policy',
+          result:     'PASS',
+          severity:   'high',
+          properties: {},
+          scope:      {}
+        }
+      ]
+    });
+
+    const wrapper = createWrapper({
+      global: {
+        plugins: [storeWithoutLinks],
+        mocks:   commonMocks,
+        stubs:   {
+          SortableTable: createSortableTableStub('col:policy', 'sortable-table-stub'),
+          'router-link': RouterLinkStub
+        }
+      }
+    });
+
+    await flushPromises();
+    await nextTick();
+
+    const stubEl = wrapper.find('.sortable-table-stub');
+
+    expect(stubEl.text()).toBe('my-policy');
+  });
+
+  it('renders BadgeState for severity with correct label and color', async() => {
+    (getFilteredReport as jest.Mock).mockResolvedValue({
+      results: [
+        {
+          policy:     'policy-name',
+          result:     'PASS',
+          severity:   'high',
+          properties: {},
+          scope:      {}
+        }
+      ]
+    });
+
+    const wrapper = createWrapper({
+      global: {
+        plugins: [store],
+        mocks:   commonMocks,
+        stubs:   {
+          SortableTable: createSortableTableStub('col:severity', 'status-slot'),
+          BadgeState:    BadgeStateStub,
+          'router-link': RouterLinkStub
+        }
+      }
+    });
+
+    await flushPromises();
+    await nextTick();
+
+    const badge = wrapper.find('.badge-state');
+
+    expect(badge.text()).toBe('high');
+    expect(badge.classes()).toContain('bg-high');
+  });
+
+  it('renders BadgeState for status with correct label and color', async() => {
+    (getFilteredReport as jest.Mock).mockResolvedValue({
+      results: [
+        {
+          policy:     'policy-name',
+          result:     'PASS',
+          severity:   'high',
+          properties: {},
+          scope:      {}
+        }
+      ]
+    });
+
+    const wrapper = createWrapper({
+      global: {
+        plugins: [store],
+        mocks:   commonMocks,
+        stubs:   {
+          SortableTable: createSortableTableStub('col:status', 'status-slot'),
+          BadgeState:    BadgeStateStub,
+          'router-link': RouterLinkStub
+        }
+      }
+    });
+
+    await flushPromises();
+    await nextTick();
+
+    const badge = wrapper.find('.badge-state');
+
+    expect(badge.text()).toBe('PASS');
+    expect(badge.classes()).toContain('bg-PASS');
+  });
+
+  it('renders sub-row details when a row has a message', async() => {
+    (getFilteredReport as jest.Mock).mockResolvedValue({
+      results: [
+        {
+          policy:     'policy-name',
+          result:     'PASS',
+          severity:   'high',
+          message:    'Warning message',
+          category:   'Category A',
+          properties: {
+            mutating:   'Yes',
+            validating: 'No'
+          },
+          scope: {}
+        }
+      ]
+    });
+
+    const wrapper = createWrapper({
+      global: {
+        plugins: [store],
+        mocks:   commonMocks,
+        stubs:   {
+          SortableTable: createSortableTableStub('sub-row', 'details'),
+          'router-link': RouterLinkStub,
+          Banner:        BannerStub
+        }
+      }
+    });
+
+    await flushPromises();
+    await nextTick();
+
+    const banner = wrapper.find('[data-testid="banner-content"]');
+
+    expect(banner.exists()).toBe(true);
+    expect(banner.text()).toContain('%kubewarden.policyReporter.headers.policyReportsTab.message.title%:');
+    expect(banner.text()).toContain('Warning message');
+
+    const details = wrapper.find('.details');
+
+    expect(details.text()).toContain('kubewarden.policyReporter.headers.policyReportsTab.category');
+    expect(details.text()).toContain('Category A');
+    expect(details.text()).toContain('kubewarden.policyReporter.headers.policyReportsTab.properties.mutating');
+    expect(details.text()).toContain('Yes');
+    expect(details.text()).toContain('kubewarden.policyReporter.headers.policyReportsTab.properties.validating');
+    expect(details.text()).toContain('No');
+  });
+});

--- a/pkg/kubewarden/components/__tests__/DefaultsBanner.spec.ts
+++ b/pkg/kubewarden/components/__tests__/DefaultsBanner.spec.ts
@@ -1,0 +1,296 @@
+import { mount } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+import DefaultsBanner from '@kubewarden/components/DefaultsBanner.vue';
+import { CATALOG } from '@shell/config/types';
+import { REPO_TYPE, REPO, CHART, VERSION } from '@shell/config/query-params';
+import { KUBEWARDEN_CHARTS } from '@kubewarden/types';
+
+import { getLatestVersion } from '@kubewarden/plugins/kubewarden-class';
+import { refreshCharts, findCompatibleDefaultsChart } from '@kubewarden/utils/chart';
+import { fetchControllerApp } from '@kubewarden/modules/kubewardenController';
+import { handleGrowl } from '@kubewarden/utils/handle-growl';
+
+jest.mock('lodash/debounce', () => (fn: any) => fn);
+jest.mock('@kubewarden/utils/chart', () => ({
+  refreshCharts:               jest.fn(),
+  findCompatibleDefaultsChart: jest.fn(() => ({ version: 'compatible-version' }))
+}));
+jest.mock('@kubewarden/modules/kubewardenController', () => ({ fetchControllerApp: jest.fn().mockResolvedValue({ fetched: true }) }));
+jest.mock('@kubewarden/utils/handle-growl', () => ({ handleGrowl: jest.fn() }));
+jest.mock('@kubewarden/plugins/kubewarden-class', () => ({ getLatestVersion: jest.fn(() => 'latest-version') }));
+
+describe('DefaultsBanner.vue', () => {
+  let store: any;
+  let router: any;
+  let fetchTypeMock: jest.Mock;
+  let $fetchState: any;
+  const tFn = jest.fn((key: string) => key);
+
+  beforeEach(() => {
+    store = {
+      getters: {
+        'cluster/canList':          jest.fn(() => ({ a: true })), // permissions object
+        'catalog/charts':           [],
+        'i18n/t':                   tFn,
+        'kubewarden/controllerApp': null,
+        'catalog/chart':            jest.fn(() => null),
+        currentCluster:             { id: 'test-cluster' }
+      },
+      dispatch: jest.fn()
+    };
+    router = { push: jest.fn() };
+    $fetchState = { pending: false };
+    fetchTypeMock = jest.fn().mockResolvedValue({});
+
+    // Clear mocks on external modules
+    (refreshCharts as jest.Mock).mockClear();
+    (fetchControllerApp as jest.Mock).mockClear();
+    (handleGrowl as jest.Mock).mockClear();
+    (getLatestVersion as jest.Mock).mockClear();
+    (findCompatibleDefaultsChart as jest.Mock).mockClear();
+  });
+
+  const factory = (propsData = {}) => {
+    return mount(DefaultsBanner, {
+      props:  propsData,
+      global: {
+        mocks: {
+          $store:      store,
+          $router:     router,
+          $fetchState,
+          $fetchType:  fetchTypeMock
+        }
+      }
+    });
+  };
+
+  describe('fetch method', () => {
+    it('calls debouncedRefreshCharts and fetchControllerApp when hasPermission is true and defaultsChart and controllerApp are falsy', async() => {
+      // Set permissions and ensure defaultsChart and controllerApp are falsy.
+      store.getters['cluster/canList'] = jest.fn(() => ({ a: true }));
+      store.getters['catalog/charts'] = []; // so kubewardenRepo is undefined → defaultsChart is null.
+      store.getters['kubewarden/controllerApp'] = null;
+      const wrapper = factory({ mode: 'install' });
+
+      await (wrapper.vm as any).$options.fetch.call(wrapper.vm);
+      await flushPromises();
+
+      // Expect refreshCharts to have been called with init true.
+      expect(refreshCharts).toHaveBeenCalledWith({
+        store,
+        chartName: KUBEWARDEN_CHARTS.CONTROLLER,
+        init:      true
+      });
+      // And fetchControllerApp should be called.
+      expect(fetchControllerApp).toHaveBeenCalledWith(store);
+    });
+  });
+
+  describe('computed properties', () => {
+    it('controllerAppVersion returns the appVersion from controllerApp', () => {
+      store.getters['kubewarden/controllerApp'] = { spec: { chart: { metadata: { appVersion: '1.0.0' } } } };
+      const wrapper = factory({ mode: 'install' });
+
+      expect(wrapper.vm.controllerAppVersion).toBe('1.0.0');
+    });
+
+    it('defaultsChart returns chart from store when kubewardenRepo exists', () => {
+      const fakeChart = {
+        repoName:  'repo1',
+        repoType:  'type1',
+        chartName: KUBEWARDEN_CHARTS.DEFAULTS,
+        versions:  []
+      };
+
+      store.getters['catalog/charts'] = [fakeChart];
+      store.getters['catalog/chart'] = jest.fn(() => fakeChart);
+      const wrapper = factory({ mode: 'install' });
+
+      expect(wrapper.vm.defaultsChart).toEqual(fakeChart);
+    });
+
+    it('hasPermission returns true when all permissions are true', async() => {
+      store.getters['cluster/canList'] = jest.fn(() => ({
+        a: true,
+        b: true
+      }));
+      const wrapper = factory({ mode: 'install' });
+
+      await (wrapper.vm as any).$options.fetch.call(wrapper.vm);
+      await flushPromises();
+
+      expect(wrapper.vm.hasPermission).toBe(true);
+    });
+
+    it('highestCompatibleDefaultsChart returns value from findCompatibleDefaultsChart when conditions are met', () => {
+      store.getters['kubewarden/controllerApp'] = { spec: { chart: { metadata: { appVersion: '1.0.0' } } } };
+      const fakeDefaultsChart = { versions: [] };
+
+      store.getters['catalog/chart'] = jest.fn(() => fakeDefaultsChart);
+      store.getters['catalog/charts'] = [{ chartName: KUBEWARDEN_CHARTS.DEFAULTS }];
+      const wrapper = factory({ mode: 'install' });
+
+      expect(wrapper.vm.highestCompatibleDefaultsChart).toEqual({ version: 'compatible-version' });
+    });
+
+    it('kubewardenRepo returns chart from charts matching DEFAULTS', () => {
+      const fakeChart = { chartName: KUBEWARDEN_CHARTS.DEFAULTS };
+
+      store.getters['catalog/charts'] = [fakeChart];
+      const wrapper = factory({ mode: 'install' });
+
+      expect(wrapper.vm.kubewardenRepo).toEqual(fakeChart);
+    });
+
+    it('bannerCopy returns the correct translation key based on mode', () => {
+      const wrapperUpgrade = factory({ mode: 'upgrade' });
+
+      expect(wrapperUpgrade.vm.bannerCopy).toBe('kubewarden.clusterAdmissionPolicy.kwDefaultsSettingsCompatibility');
+      const wrapperInstall = factory({ mode: 'install' });
+
+      expect(wrapperInstall.vm.bannerCopy).toBe('kubewarden.policyServer.noDefaultsInstalled.description');
+    });
+
+    it('btnText returns the correct translation key based on mode', () => {
+      const wrapperUpgrade = factory({ mode: 'upgrade' });
+
+      expect(wrapperUpgrade.vm.btnText).toBe('kubewarden.clusterAdmissionPolicy.defaultsUpdateBtn');
+      const wrapperInstall = factory({ mode: 'install' });
+
+      expect(wrapperInstall.vm.btnText).toBe('kubewarden.policyServer.noDefaultsInstalled.button');
+    });
+
+    it('isClosable returns false due to the logic', () => {
+      const wrapper = factory({ mode: 'upgrade' });
+
+      expect(wrapper.vm.isClosable).toBe(false);
+      const wrapper2 = factory({ mode: 'install' });
+
+      expect(wrapper2.vm.isClosable).toBe(false);
+    });
+
+    it('colorMode returns "warning" for upgrade mode and "info" for install mode', () => {
+      const wrapperUpgrade = factory({ mode: 'upgrade' });
+
+      expect(wrapperUpgrade.vm.colorMode).toBe('warning');
+      const wrapperInstall = factory({ mode: 'install' });
+
+      expect(wrapperInstall.vm.colorMode).toBe('info');
+    });
+  });
+
+  describe('methods', () => {
+    it('closeDefaultsBanner retries on error and calls store.dispatch twice', async() => {
+      store.dispatch.mockReset();
+      store.dispatch.mockResolvedValueOnce({
+        type:   'error',
+        status: 500
+      });
+      store.dispatch.mockResolvedValueOnce({ type: 'success' });
+      const wrapper = factory({ mode: 'install' });
+
+      await wrapper.vm.closeDefaultsBanner();
+      expect(store.dispatch).toHaveBeenCalledTimes(2);
+      expect(store.dispatch).toHaveBeenCalledWith('kubewarden/updateHideBannerDefaults', true);
+    });
+
+    it('refreshCharts dispatches catalog/refresh and calls $fetchType and debouncedRefreshCharts when defaultsChart is falsy', async() => {
+      store.dispatch.mockResolvedValue();
+      store.getters['catalog/chart'] = jest.fn(() => null);
+      const wrapper = factory({ mode: 'install' });
+
+      await (wrapper.vm as any).$options.fetch.call(wrapper.vm);
+      await flushPromises();
+
+      await wrapper.vm.refreshCharts(0);
+      expect(store.dispatch).toHaveBeenCalledWith('catalog/refresh');
+      expect(fetchTypeMock).toHaveBeenCalledWith(CATALOG.CLUSTER_REPO);
+      expect(refreshCharts).toHaveBeenCalled();
+    });
+
+    it('chartRoute pushes a route when latestVersion exists', async() => {
+      const fakeDefaultsChart = {
+        repoType:  'type1',
+        repoName:  'repo1',
+        chartName: 'chart1',
+        versions:  []
+      };
+
+      store.getters['catalog/chart'] = jest.fn(() => fakeDefaultsChart);
+      store.getters['catalog/charts'] = [{ chartName: KUBEWARDEN_CHARTS.DEFAULTS }];
+      store.getters['kubewarden/controllerApp'] = { spec: { chart: { metadata: { appVersion: '1.0.0' } } } };
+      const wrapper = factory({ mode: 'install' });
+
+      await (wrapper.vm as any).$options.fetch.call(wrapper.vm);
+      await flushPromises();
+
+      await wrapper.vm.chartRoute();
+      expect(router.push).toHaveBeenCalledWith({
+        name:   'c-cluster-apps-charts-install',
+        params: { cluster: store.getters.currentCluster?.id || '_' },
+        query:  {
+          [REPO_TYPE]: fakeDefaultsChart.repoType,
+          [REPO]:      fakeDefaultsChart.repoName,
+          [CHART]:     fakeDefaultsChart.chartName,
+          [VERSION]:   'compatible-version'
+        }
+      });
+    });
+
+    it('chartRoute calls handleGrowl when latestVersion is falsy', async() => {
+      (getLatestVersion as jest.Mock).mockReturnValueOnce(null);
+      const fakeDefaultsChart = {
+        repoType:  'type1',
+        repoName:  'repo1',
+        chartName: 'chart1',
+        versions:  []
+      };
+
+      store.getters['catalog/chart'] = jest.fn(() => fakeDefaultsChart);
+      store.getters['catalog/charts'] = [{ chartName: KUBEWARDEN_CHARTS.DEFAULTS }];
+      store.getters['kubewarden/controllerApp'] = { spec: { chart: { metadata: { appVersion: '1.0.0' } } } };
+      const wrapper = factory({ mode: 'install' });
+
+      await wrapper.vm.chartRoute();
+      expect(handleGrowl).toHaveBeenCalled();
+    });
+  });
+
+  describe('template', () => {
+    it('renders Banner component with data-testid "kw-defaults-banner" when $fetchState.pending is false and hasPermission is true', async() => {
+      store.getters['cluster/canList'] = jest.fn(() => ({ a: true }));
+      const wrapper = factory({ mode: 'install' });
+
+
+      await (wrapper.vm as any).$options.fetch.call(wrapper.vm);
+      await flushPromises();
+
+      await wrapper.vm.$nextTick();
+      const banner = wrapper.find('[data-testid="kw-defaults-banner"]');
+
+      expect(banner.exists()).toBe(true);
+    });
+
+    it('renders a button with data-testid "kw-defaults-banner-button" when highestCompatibleDefaultsChart exists', async() => {
+      store.getters['kubewarden/controllerApp'] = { spec: { chart: { metadata: { appVersion: '1.0.0' } } } };
+      const fakeDefaultsChart = {
+        repoType:  'type1',
+        repoName:  'repo1',
+        chartName: 'chart1',
+        versions:  []
+      };
+
+      store.getters['catalog/chart'] = jest.fn(() => fakeDefaultsChart);
+      store.getters['catalog/charts'] = [{ chartName: KUBEWARDEN_CHARTS.DEFAULTS }];
+      const wrapper = factory({ mode: 'install' });
+
+      await (wrapper.vm as any).$options.fetch.call(wrapper.vm);
+      await flushPromises();
+
+      await wrapper.vm.$nextTick();
+      const button = wrapper.find('[data-testid="kw-defaults-banner-button"]');
+
+      expect(button.exists()).toBe(true);
+    });
+  });
+});

--- a/pkg/kubewarden/components/__tests__/InstallWizard.spec.ts
+++ b/pkg/kubewarden/components/__tests__/InstallWizard.spec.ts
@@ -1,0 +1,233 @@
+import { mount } from '@vue/test-utils';
+import { h } from 'vue';
+
+import InstallWizard from '@kubewarden/components/InstallWizard.vue';
+
+describe('InstallWizard.vue', () => {
+  const steps = [
+    {
+      name:  'step1',
+      label: 'Step 1',
+      ready: true
+    },
+    {
+      name:  'step2',
+      label: 'Step 2',
+      ready: true
+    },
+    {
+      name:  'step3',
+      label: 'Step 3',
+      ready: true
+    },
+    {
+      name:  'step4',
+      label: 'Step 4',
+      ready: true
+    }
+  ];
+
+  const factory = (props = {}, options: any = {}) => {
+    return mount(InstallWizard, {
+      props: {
+        steps,
+        ...props
+      },
+      global: {
+        mocks: { t: (key: string) => key },
+        ...options.global
+      },
+      slots: options.slots || {}
+    });
+  };
+
+  it('sets activeStep to the step at initStepIndex on created', () => {
+    const wrapper = factory({ initStepIndex: 2 });
+
+    expect(wrapper.vm.activeStep).toEqual(steps[2]);
+  });
+
+  it('computed activeStepIndex returns the correct index', async() => {
+    const wrapper = factory({ initStepIndex: 1 });
+
+    expect(wrapper.vm.activeStepIndex).toBe(1);
+    // Change activeStep manually and check update
+    wrapper.vm.activeStep = steps[3];
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.activeStepIndex).toBe(3);
+  });
+
+  describe('methods', () => {
+    describe('isAvailable', () => {
+      it('returns false for the first step', () => {
+        const wrapper = factory();
+
+        expect(wrapper.vm.isAvailable(steps[0])).toBe(false);
+      });
+
+      it('returns false if any previous step is not ready', () => {
+        const modifiedSteps = [
+          {
+            name:  'step1',
+            label: 'Step 1',
+            ready: true
+          },
+          {
+            name:  'step2',
+            label: 'Step 2',
+            ready: false
+          },
+          {
+            name:  'step3',
+            label: 'Step 3',
+            ready: true
+          }
+        ];
+        const wrapper = mount(InstallWizard, {
+          props: {
+            steps:         modifiedSteps,
+            initStepIndex: 0
+          },
+          global: { mocks: { t: (key: string) => key } }
+        });
+
+        // step3 should not be available because step2 is not ready
+        expect(wrapper.vm.isAvailable(modifiedSteps[2])).toBe(false);
+      });
+
+      it('returns true if all previous steps are ready', () => {
+        const wrapper = factory();
+
+        expect(wrapper.vm.isAvailable(steps[2])).toBe(true);
+      });
+    });
+
+    describe('goToStep', () => {
+      let wrapper: any;
+
+      beforeEach(() => {
+        wrapper = factory({ initStepIndex: 0 });
+      });
+
+      it('does nothing if number < 1', () => {
+        wrapper.vm.goToStep(0, false);
+        expect(wrapper.vm.activeStep).toEqual(steps[0]);
+      });
+
+      it('does nothing if number === 1 and fromNav is true', () => {
+        wrapper.vm.goToStep(1, true);
+        expect(wrapper.vm.activeStep).toEqual(steps[0]);
+      });
+
+      it('does nothing if the selected step is not available (not ready) and number !== 1', async() => {
+        const modifiedSteps = [
+          {
+            name:  'step1',
+            label: 'Step 1',
+            ready: false
+          },
+          {
+            name:  'step2',
+            label: 'Step 2',
+            ready: false
+          },
+          {
+            name:  'step3',
+            label: 'Step 3',
+            ready: true
+          }
+        ];
+
+        wrapper.setProps({ steps: modifiedSteps });
+        await wrapper.vm.$nextTick();
+        wrapper.vm.goToStep(2, false); // Attempt to go to step2
+        expect(wrapper.vm.activeStep.name).toEqual(modifiedSteps[0].name); // Remains on first step
+      });
+
+      it('updates activeStep and emits "next" event when a valid step is selected', () => {
+        wrapper.vm.goToStep(2, false); // Should go to step at index 1
+        expect(wrapper.vm.activeStep).toEqual(steps[1]);
+        expect(wrapper.emitted().next).toBeTruthy();
+        expect(wrapper.emitted().next[0][0]).toEqual({ step: steps[1] });
+      });
+    });
+
+    describe('next', () => {
+      it('calls goToStep with activeStepIndex + 2', () => {
+        const wrapper = factory({ initStepIndex: 0 });
+
+        jest.spyOn(wrapper.vm, 'goToStep');
+        wrapper.vm.next();
+        expect(wrapper.vm.goToStep).toHaveBeenCalledWith(2);
+      });
+    });
+  });
+
+  // Template Rendering
+  describe('template rendering', () => {
+    it('renders title block when showTitle is true', () => {
+      const wrapper = factory({ showTitle: true });
+
+      expect(wrapper.find('.product-image img.logo').exists()).toBe(true);
+    });
+
+    it('does not render title block when showTitle is false', () => {
+      const wrapper = factory({ showTitle: false });
+
+      expect(wrapper.find('.product-image img.logo').exists()).toBe(false);
+    });
+
+    it('renders the step-sequence when more than one step is provided', () => {
+      const wrapper = factory();
+
+      expect(wrapper.find('.step-sequence').exists()).toBe(true);
+      const listItems = wrapper.findAll('.steps li.step');
+
+      expect(listItems.length).toBe(steps.length);
+    });
+
+    it('applies "active" class to the active step and "disabled" class to unavailable steps', async() => {
+      // Initially, activeStep is steps[0] (which is always unavailable per isAvailable)
+      const wrapper = factory();
+      const firstStep = wrapper.find(`li#${  steps[0].name }`);
+
+      expect(firstStep.classes()).toContain('active');
+      expect(firstStep.classes()).toContain('disabled');
+      // Simulate clicking on step 2
+      const step2 = wrapper.find(`li#${  steps[1].name }`);
+
+      await step2.find('.controls').trigger('click.prevent');
+      await wrapper.vm.$nextTick();
+      expect(wrapper.vm.activeStep).toEqual(steps[1]);
+    });
+
+    it('renders slot "bannerSubtext" when provided', async() => {
+      const wrapper = factory({}, { slots: { bannerSubtext: `<span class="custom-banner">Custom Banner</span>` } });
+
+      await wrapper.vm.$nextTick();
+      const customBanner = wrapper.find('.custom-banner');
+
+      expect(customBanner.exists()).toBe(true);
+      expect(customBanner.text()).toBe('Custom Banner');
+    });
+
+    it('renders the step-container slot for the active step using a scoped slot function', async() => {
+      const wrapper = factory(
+        { initStepIndex: 0 },
+        {
+          slots: {
+            // Return a VNode instead of a plain string.
+            'stepContainer mt-20': (slotProps: { activeStep: { label: string } }) => h('div', { class: 'step-slot' }, slotProps.activeStep.label)
+          }
+        }
+      );
+
+      await wrapper.vm.$nextTick();
+
+      const slotDiv = wrapper.find('.step-slot');
+
+      expect(slotDiv.exists()).toBe(true);
+      expect(slotDiv.text()).toBe(steps[0].label);
+    });
+  });
+});

--- a/pkg/kubewarden/components/__tests__/MetricsChecklist.spec.ts
+++ b/pkg/kubewarden/components/__tests__/MetricsChecklist.spec.ts
@@ -1,4 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
+
 import MetricsChecklist from '@kubewarden/components/MetricsChecklist.vue';
 
 const commons = {

--- a/pkg/kubewarden/components/__tests__/MetricsTab.spec.ts
+++ b/pkg/kubewarden/components/__tests__/MetricsTab.spec.ts
@@ -1,0 +1,175 @@
+import { shallowMount } from '@vue/test-utils';
+
+import {
+  CATALOG, CONFIG_MAP, MONITORING, NAMESPACE, SERVICE
+} from '@shell/config/types';
+import { KUBEWARDEN, KubewardenDashboardLabels } from '@kubewarden/types';
+import { KUBERNETES } from '@shell/config/labels-annotations';
+
+import KubewardenDashboard from '@kubewarden/components/MetricsTab.vue';
+import mockControllerChart from '@tests/unit/mocks/controllerChart';
+import mockPolicyServers from '@tests/unit/mocks/policyServers';
+import { mockControllerApp } from '@tests/unit/mocks/controllerApp';
+
+// Create a mock for the 'cluster/all' getter that returns different values based on the input.
+const clusterAllMock = jest.fn((resourceType) => {
+  switch (resourceType) {
+  case CATALOG.APP:
+    return [
+      {
+        // Monitoring app: used by monitoringApp computed property
+        spec: {
+          chart: {
+            metadata: {
+              name:    'rancher-monitoring',
+              version: '1.0.0'
+            }
+          }
+        }
+      },
+      { ...mockControllerApp }
+    ];
+  case CATALOG.CLUSTER_REPO:
+    return [];
+  case KUBEWARDEN.POLICY_SERVER:
+    return mockPolicyServers;
+  case CONFIG_MAP:
+    return [{
+      metadata: {
+        name:   'config-map-1',
+        labels: { [KubewardenDashboardLabels.DASHBOARD]: 'true' }
+      }
+    }];
+  case MONITORING.SERVICEMONITOR:
+    return [{
+      metadata: { name: 'service-monitor-1' },
+      spec:     {
+        selector: {
+          matchLabels: {
+            // Match the policy server id passed via props (e.g. 'policy-server-1')
+            app: 'kubewarden-policy-server-policy-server-1'
+          }
+        }
+      }
+    }];
+  case NAMESPACE:
+    return [{ metadata: { name: 'namespace-1' } }];
+  case SERVICE:
+    return [{
+      metadata: {
+        name:   'service-1',
+        labels: { [KUBERNETES.MANAGED_NAME]: 'opentelemetry-operator' }
+      },
+      spec: { ports: [{ port: 8080 }] }
+    }];
+  default:
+    return [];
+  }
+});
+
+const commonMocks = {
+  $fetchState: { pending: false },
+  $store:      {
+    getters: {
+      currentCluster:               () => ({ id: 'cluster-1' }),
+      currentStore:                 () => 'cluster',
+      productId:                    () => 'some-product',
+      'catalog/charts':             [mockControllerChart],
+      'cluster/all':                clusterAllMock,
+      'cluster/canList':            () => true,
+      'i18n/t':                     (key) => key,
+      'management/byId':            () => 'local',
+      'resource-fetch/refreshFlag': jest.fn(),
+      'cluster/schemaFor':          () => ({ attributes: { namespaced: false } })
+    },
+    dispatch: jest.fn()
+  },
+  $route: { params: { cluster: '_' } }
+};
+
+const commonStubs = { 'router-link': { template: '<span />' } };
+const metricsProxy = '/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy/d/kubewarden-dashboard-policyserver?orgId=1&kiosk';
+
+const createWrapper = (options: any = {}) => {
+  return shallowMount(KubewardenDashboard, {
+    global: {
+      mocks: {
+        ...commonMocks,
+        ...options.mocks
+      },
+      stubs: {
+        ...commonStubs,
+        Loading:          true,
+        Banner:           true,
+        DashboardMetrics: true,
+        MetricsChecklist: true,
+        ...options.stubs
+      },
+    },
+    props: { ...options.props }
+  });
+};
+
+describe('KubewardenDashboard Component', () => {
+  it('renders the Loading component when fetch state is pending', () => {
+    const wrapper = createWrapper({ mocks: { $fetchState: { pending: true } } });
+
+    expect(wrapper.findComponent({ name: 'Loading' }).exists()).toBe(true);
+  });
+
+  it('renders MetricsChecklist when showChecklist is true', () => {
+    // With the above data, computed showChecklist should be true if any required condition is missing.
+    // In this test, we let the checklist appear.
+    const wrapper = createWrapper({
+      props: {
+        policyObj:       {},
+        policyServerObj: {} // purposely not setting a valid policy server so that showChecklist is true
+      }
+    });
+
+    expect(wrapper.findComponent({ name: 'MetricsChecklist' }).exists()).toBe(true);
+  });
+
+  it('renders Banner when showChecklist is false, monitoringApp exists, and metricsProxy is null', () => {
+    // To get showChecklist to be false, supply valid data for every computed property.
+    const wrapper = createWrapper({ props: { policyServerObj: { id: 'policy-server-1' } } });
+
+    // With the above store data:
+    // - openTelSvc exists (from SERVICE)
+    // - monitoringApp exists (from CATALOG.APP with rancher-monitoring)
+    // - kubewardenServiceMonitor is truthy (because the service monitor selector matches the policy server id)
+    // - metricsConfiguration returns true (from the controller app telemetry setup)
+    // - kubewardenGrafanaDashboards is truthy (from CONFIG_MAP)
+    // So, showChecklist should be false and the template should render the Banner.
+    expect(wrapper.findComponent({ name: 'Banner' }).exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'DashboardMetrics' }).exists()).toBe(false);
+  });
+
+  it('renders DashboardMetrics when showChecklist is false, metricsProxy exists, and active prop is true', async() => {
+    const wrapper = createWrapper({
+      props: {
+        active:          true,
+        policyServerObj: { id: 'policy-server-1' }
+      }
+    });
+
+    wrapper.setData({ metricsProxy });
+
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findComponent({ name: 'DashboardMetrics' }).exists()).toBe(true);
+  });
+
+  it('updates data properties via handleMetricsChecklist method', () => {
+    const wrapper = createWrapper();
+
+    // Verify initial values
+    expect(wrapper.vm.outdatedTelemetrySpec).toBe(false);
+    expect(wrapper.vm.unsupportedTelemetrySpec).toBe(false);
+    // Call the method and check that the corresponding data property is updated
+    wrapper.vm.handleMetricsChecklist('outdatedTelemetrySpec', true);
+    expect(wrapper.vm.outdatedTelemetrySpec).toBe(true);
+    wrapper.vm.handleMetricsChecklist('unsupportedTelemetrySpec', true);
+    expect(wrapper.vm.unsupportedTelemetrySpec).toBe(true);
+  });
+});

--- a/pkg/kubewarden/components/__tests__/TraceChecklist.spec.ts
+++ b/pkg/kubewarden/components/__tests__/TraceChecklist.spec.ts
@@ -1,0 +1,186 @@
+import { shallowMount } from '@vue/test-utils';
+
+import TraceChecklist from '@kubewarden/components/TraceChecklist.vue';
+
+describe('TraceChecklist.vue', () => {
+  const commonMocks = {
+    $fetchState: { pending: false },
+    $store:      { getters: { currentCluster: () => 'current_cluster' } },
+    $router:     { push: jest.fn() },
+    $route:      { params: { cluster: '_' } }
+  };
+
+  const commonStubs = { Banner: false };
+
+  const commonProps = {
+    controllerApp:            null,
+    controllerChart:          null,
+    tracingConfiguration:     null,
+    jaegerQuerySvc:           null,
+    openTelSvc:               null,
+    outdatedTelemetrySpec:    false,
+    unsupportedTelemetrySpec: false,
+    incompleteTelemetrySpec:  false
+  };
+
+  const createWrapper = (overrides: any = {}) => {
+    return shallowMount(TraceChecklist, {
+      global: {
+        mocks: {
+          ...commonMocks,
+          ...overrides.mocks
+        },
+        stubs: {
+          ...commonStubs,
+          ...overrides.stubs
+        },
+      },
+      props: {
+        ...commonProps,
+        ...overrides.props
+      },
+      ...overrides,
+    });
+  };
+
+  it('computes controllerLinkTooltip when missing services', () => {
+    const wrapper = createWrapper();
+
+    expect(wrapper.vm.controllerLinkTooltip)
+      .toBe('%kubewarden.monitoring.prerequisites.tooltips.prerequisites%');
+  });
+
+  it('computes controllerLinkTooltip when chart dependencies are missing', () => {
+    const wrapper = createWrapper({
+      props: {
+        jaegerQuerySvc: {},
+        openTelSvc:     {}
+      }
+    });
+
+    expect(wrapper.vm.controllerLinkTooltip)
+      .toBe('%kubewarden.monitoring.prerequisites.tooltips.chartError%');
+  });
+
+  it('computes controllerLinkTooltip as null when all dependencies are provided', () => {
+    const wrapper = createWrapper({
+      props: {
+        controllerApp:   { spec: { chart: { metadata: {} } } },
+        controllerChart: {},
+        jaegerQuerySvc:  {},
+        openTelSvc:      {}
+      }
+    });
+
+    expect(wrapper.vm.controllerLinkTooltip).toBeNull();
+  });
+
+  it('computes controllerLinkDisabled correctly', () => {
+    const wrapper = createWrapper();
+
+    expect(wrapper.vm.controllerLinkDisabled).toBe(true);
+
+    const wrapper2 = createWrapper({
+      props: {
+        controllerApp:   { spec: { chart: { metadata: {} } } },
+        controllerChart: {},
+        jaegerQuerySvc:  {},
+        openTelSvc:      {}
+      }
+    });
+
+    expect(wrapper2.vm.controllerLinkDisabled).toBe(false);
+  });
+
+  it('computes tracingEnabled correctly', () => {
+    const wrapper = createWrapper({ props: { tracingConfiguration: { enabled: true } } });
+
+    expect(wrapper.vm.tracingEnabled).toBe(true);
+
+    const wrapper2 = createWrapper({ props: { tracingConfiguration: null } });
+
+    expect(wrapper2.vm.tracingEnabled).toBeNull();
+  });
+
+  it('returns correct classes from badgeIcon', () => {
+    const wrapper = createWrapper();
+
+    const resultTrue = wrapper.vm.badgeIcon(true);
+
+    expect(resultTrue).toEqual({
+      'icon-dot-open':  false,
+      'icon-checkmark': true,
+      'text-success':   true
+    });
+
+    const resultFalse = wrapper.vm.badgeIcon(false);
+
+    expect(resultFalse).toEqual({
+      'icon-dot-open':  true,
+      'icon-checkmark': false,
+      'text-success':   false
+    });
+  });
+
+  it('does not navigate via controllerAppRoute when controllerApp is not provided', () => {
+    const wrapper = createWrapper({ props: { controllerApp: null } });
+
+    wrapper.vm.controllerAppRoute();
+
+    const routerPushSpy = jest.spyOn(wrapper.vm.$router, 'push');
+
+    expect(routerPushSpy).not.toHaveBeenCalled();
+  });
+
+  it('navigates correctly via controllerAppRoute when controllerApp is provided', async() => {
+    const mockAnnotations = {
+      'catalog.cattle.io/catalog-namespace': 'mockNamespace',
+      'catalog.cattle.io/release-name':      'mockReleaseName',
+      'catalog.cattle.io/upstream-version':  'mockVersion',
+      'catalog.cattle.io/source-repo-name':  'mockRepoName',
+      'catalog.cattle.io/source-repo-type':  'mockRepoType'
+    };
+    const mockMetadata = {
+      annotations: mockAnnotations,
+      name:        'mockChartName'
+    };
+    const mockControllerApp = { spec: { chart: { metadata: mockMetadata } } };
+
+    const wrapper = createWrapper({ props: { controllerApp: mockControllerApp } });
+
+    wrapper.vm.controllerAppRoute();
+
+    await wrapper.vm.$nextTick();
+
+    const routerPushSpy = jest.spyOn(wrapper.vm.$router, 'push');
+
+    expect(routerPushSpy).toHaveBeenCalled();
+    const pushArg = routerPushSpy.mock.calls[0][0];
+
+    expect(pushArg.name).toBe('c-cluster-apps-charts-install');
+    expect(pushArg.params).toEqual({ cluster: '_' });
+
+    expect(pushArg.query).toEqual({
+      'chart':     'mockChartName',
+      'name':      'mockReleaseName',
+      'namespace': undefined,
+      'repo':      undefined,
+      'repo-type': undefined,
+      'version':   'mockVersion',
+    });
+  });
+
+  it('conditionally renders telemetry banners based on telemetry spec props', () => {
+    const wrapper = createWrapper({
+      props: {
+        outdatedTelemetrySpec:    true,
+        unsupportedTelemetrySpec: true,
+        incompleteTelemetrySpec:  true
+      }
+    });
+
+    const banners = wrapper.findAllComponents({ name: 'Banner' });
+
+    expect(banners.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/pkg/kubewarden/components/__tests__/TraceTable.spec.ts
+++ b/pkg/kubewarden/components/__tests__/TraceTable.spec.ts
@@ -1,0 +1,202 @@
+import { shallowMount, flushPromises } from '@vue/test-utils';
+
+import { KUBEWARDEN } from '@kubewarden/types';
+import { CATALOG, SERVICE } from '@shell/config/types';
+import { KUBERNETES } from '@shell/config/labels-annotations';
+
+import TraceTable from '@kubewarden/components/TraceTable.vue';
+
+import mockControllerChart from '@tests/unit/mocks/controllerChart';
+import mockTraces from '@tests/unit/mocks/policyTraces';
+import { mockControllerApp, mockControllerValues } from '@tests/unit/mocks/controllerApp';
+
+// Create a mock for the 'cluster/all' getter so that it returns different values based on resource type.
+const clusterAllMock = (resourceType: string) => {
+  switch (resourceType) {
+  case CATALOG.APP:
+    // Return a controller app so that computed "controllerApp" and tracingConfiguration can resolve.
+    return [{
+      ...mockControllerApp,
+      fetchValues: jest.fn().mockResolvedValue(mockControllerValues)
+    }];
+  case SERVICE:
+    // Return two services: one qualifies as jaeger and one as openTelemetry.
+    return [
+      {
+        name:     'jaeger-query-svc',
+        links: {
+          remove: '/k8s/clusters/c-6r6r2/v1/services/jaeger/my-open-telemetry-query',
+          self:   '/k8s/clusters/c-6r6r2/v1/services/jaeger/my-open-telemetry-query',
+          update: '/k8s/clusters/c-6r6r2/v1/services/jaeger/my-open-telemetry-query',
+          view:   '/k8s/clusters/c-6r6r2/api/v1/namespaces/jaeger/services/my-open-telemetry-query'
+        },
+        metadata: { labels: { 'app.kubernetes.io/part-of': 'jaeger' } },
+        spec:     { ports: [{ port: 16685 }] }
+      },
+      {
+        name:     'open-tel-svc',
+        metadata: {
+          labels: {
+            'opentelemetry-operator':  'opentelemetry-operator',
+            [KUBERNETES.MANAGED_NAME]: 'opentelemetry-operator'
+          }
+        },
+        spec: { ports: [{ port: 8080 }] }
+      }
+    ];
+  default:
+    return [];
+  }
+};
+
+// This mock for dispatch will allow Jaeger fetch calls to succeed
+// and any other calls to just return an empty object
+const dispatchMock = jest.fn(async(payload) => {
+  if (typeof payload.url === 'string' && payload.url.includes('api/traces')) {
+    return { data: mockTraces };
+  }
+
+  return { data: [] };
+});
+
+
+const commonMocks = {
+  $fetchState: { pending: false },
+  $store:      {
+    getters: {
+      currentCluster:                { id: 'current_cluster' },
+      currentStore:                  () => 'cluster',
+      productId:                     () => 'some-product',
+      'catalog/charts':              [mockControllerChart],
+      'cluster/all':                 jest.fn((type: string) => clusterAllMock(type)),
+      'cluster/canList':             () => true,
+      'i18n/t':                      (key) => key,
+      'management/byId':             () => 'local',
+      'resource-fetch/refreshFlag':  jest.fn(),
+      'cluster/schemaFor':           () => ({ attributes: { namespaced: false } }),
+      'kubewarden/refreshingCharts': false
+    },
+    dispatch: dispatchMock
+  },
+  $route: { params: { cluster: '_' } }
+};
+
+const commonStubs = {
+  Loading:        true,
+  Banner:         true,
+  SortableTable:  true,
+  TraceChecklist: true,
+  BadgeState:     true,
+  'router-link':  true
+};
+
+// Helper to create a mounted wrapper.
+const createWrapper = (options: any = {}) => {
+  return shallowMount(TraceTable, {
+    global: {
+      mocks: {
+        ...commonMocks,
+        ...options.mocks
+      },
+      stubs: {
+        ...commonStubs,
+        ...options.stubs
+      }
+    },
+    props: { ...options.props }
+  });
+};
+
+describe('TraceTable.vue', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(jest.fn());
+  });
+
+  it('renders Loading component when fetch is pending', () => {
+    const wrapper = createWrapper({ mocks: { $fetchState: { pending: true } } });
+
+    expect(wrapper.findComponent({ name: 'Loading' }).exists()).toBe(true);
+  });
+
+  it('renders TraceChecklist when showChecklist is true', () => {
+    // To force showChecklist to be true we simulate missing required services by making SERVICE getter return an empty array.
+    const wrapper = createWrapper({
+      props: { resource: 'non-policy-resource' },
+      mocks: {
+        $store: {
+          getters: {
+            ...commonMocks.$store.getters,
+            'cluster/all': () => []
+          }
+        }
+      }
+    });
+
+    // With no SERVICE data, computed "jaegerQuerySvc" and "openTelSvc" will be null,
+    // so "showChecklist" (which is computed as: (!openTelSvc || !jaegerQuerySvc || !tracingConfiguration)) is true.
+    expect(wrapper.findComponent({ name: 'TraceChecklist' }).exists()).toBe(true);
+  });
+
+  it('renders error Banner when showChecklist is false and emptyPolicies is true', async() => {
+    const wrapper = createWrapper({
+      props: {
+        resource:        KUBEWARDEN.POLICY_SERVER,
+        relatedPolicies: [] // Empty array so that emptyPolicies is true
+      }
+    });
+
+    await (wrapper.vm as any).$options.fetch.call(wrapper.vm);
+    await flushPromises();
+
+    const banner = wrapper.findComponent({ name: 'Banner' });
+
+    expect(banner.exists()).toBe(true);
+    expect(banner.props('label')).toBe('%kubewarden.tracing.noRelatedPolicies%');
+  });
+
+  it('renders SortableTable when showTable is true', async() => {
+    const policies = [
+      {
+        kind:     'ClusterAdmissionPolicy',
+        metadata: { name: 'disallow-np' }
+      },
+      {
+        kind:     'AdmissionPolicy',
+        metadata: {
+          name:      'ap1',
+          namespace: 'ns1'
+        }
+      }
+    ];
+
+    const wrapper = createWrapper({
+      props: {
+        resource:        KUBEWARDEN.POLICY_SERVER,
+        relatedPolicies: policies
+      }
+    });
+
+    // Here, we *do not* call fetch if we plan to manually set specificValidations,
+    // because fetch might overwrite them with the real Jaeger data (which we’ve mocked as empty).
+    // Instead, we just do:
+    wrapper.setData({ specificValidations: mockTraces });
+
+    await wrapper.vm.$nextTick();
+
+    const checklist = wrapper.findComponent({ name: 'TraceChecklist' });
+
+    expect(checklist.exists()).toBe(false); // showChecklist should be false
+    expect(wrapper.findComponent({ name: 'SortableTable' }).exists()).toBe(true);
+  });
+
+  it('updates data properties via handleTracingChecklist method', () => {
+    const wrapper = createWrapper();
+
+    // Default
+    expect(wrapper.vm.outdatedTelemetrySpec).toBe(false);
+
+    // Update
+    wrapper.vm.handleTracingChecklist('outdatedTelemetrySpec', true);
+    expect(wrapper.vm.outdatedTelemetrySpec).toBe(true);
+  });
+});

--- a/pkg/kubewarden/formatters/PolicyResources.vue
+++ b/pkg/kubewarden/formatters/PolicyResources.vue
@@ -13,7 +13,7 @@ export default {
     }
   },
 
-  fetch() {
+  created() {
     if (this.value) {
       const resourceToShow = this.value.flatMap((r) => r[this.col.name]);
 
@@ -29,7 +29,7 @@ export default {
 
   computed: {
     resourceLabels() {
-      if (this.resourceToShow.length > 1) {
+      if (this.resourceToShow?.length > 1) {
         const out = [];
         const last = this.resourceToShow[this.resourceToShow.length - 1];
 

--- a/pkg/kubewarden/formatters/PolicyServerDeployment.vue
+++ b/pkg/kubewarden/formatters/PolicyServerDeployment.vue
@@ -21,7 +21,7 @@ export default {
     }
   },
 
-  async fetch() {
+  async created() {
     this.deployment = await this.row.matchingDeployment();
   },
 

--- a/pkg/kubewarden/formatters/PolicyServerStatus.vue
+++ b/pkg/kubewarden/formatters/PolicyServerStatus.vue
@@ -16,7 +16,7 @@ export default {
     }
   },
 
-  async fetch() {
+  async created() {
     if (this.$store.getters['cluster/canList'](WORKLOAD_TYPES.DEPLOYMENT)) {
       await this.$store.dispatch('cluster/findAll', { type: WORKLOAD_TYPES.DEPLOYMENT });
     }

--- a/pkg/kubewarden/formatters/PolicySummaryGraph.vue
+++ b/pkg/kubewarden/formatters/PolicySummaryGraph.vue
@@ -25,7 +25,7 @@ export default {
     }
   },
 
-  async fetch() {
+  async created() {
     this.relatedPolicies = await this.row.allRelatedPolicies();
   },
 

--- a/pkg/kubewarden/formatters/__tests__/PolicyReportSummary.spec.ts
+++ b/pkg/kubewarden/formatters/__tests__/PolicyReportSummary.spec.ts
@@ -1,0 +1,95 @@
+import { mount } from '@vue/test-utils';
+import { createStore } from 'vuex';
+import { nextTick } from 'vue';
+
+import PolicyReportSummary from '@kubewarden/formatters/PolicyReportSummary.vue';
+
+jest.mock('@kubewarden/modules/policyReporter', () => ({ colorForResult: (result: string) => `text-${ result }` }));
+
+describe('PolicyReportSummary.vue', () => {
+  let store: ReturnType<typeof createStore>;
+  let getters: Record<string, any>;
+
+  beforeEach(() => {
+    getters = {
+      'kubewarden/loadingReports':      () => false,
+      'kubewarden/summaryByResourceId': () => () => ({})
+    };
+
+    store = createStore({ getters });
+  });
+
+  const factory = (propsData = {}) => {
+    return mount(PolicyReportSummary, {
+      props:  propsData,
+      global: {
+        plugins: [store],
+        stubs:   {
+          VDropdown:         { template: `<div><slot></slot><slot name="popper"></slot></div>` },
+          'v-clean-tooltip': true
+        }
+      }
+    });
+  };
+
+  it('displays a loading spinner when loadingReports is true', () => {
+    getters['kubewarden/loadingReports'] = () => true;
+    store = createStore({ getters });
+
+    const wrapper = mount(PolicyReportSummary, {
+      props:  { value: { id: 'resource1' } },
+      global: {
+        plugins: [store],
+        stubs:   {
+          VDropdown:         true,
+          'v-clean-tooltip': true
+        }
+      }
+    });
+
+    expect(wrapper.find('[data-testid="resource-tab-loading"]').exists()).toBe(true);
+  });
+
+  it('displays "-" when not loading and summary is empty', async() => {
+    getters['kubewarden/loadingReports'] = () => false;
+    getters['kubewarden/summaryByResourceId'] = () => () => ({});
+    store = createStore({ getters });
+
+    const wrapper = factory({ value: { id: 'resource1' } });
+
+    await nextTick();
+
+    // Since there is no summary data, the fallback "-" should be rendered.
+    expect(wrapper.text()).toContain('-');
+  });
+
+  it('displays summary badges when summary is non-empty', async() => {
+    // Provide summary data with truthy counts.
+    const summaryData = {
+      fail:  2,
+      pass:  5,
+      error: 0
+    }; // error is zero so it’s falsy
+
+    getters['kubewarden/loadingReports'] = () => false;
+    getters['kubewarden/summaryByResourceId'] = () => () => summaryData;
+    store = createStore({ getters });
+
+    const wrapper = factory({ value: { id: 'resource1' } });
+
+    await nextTick();
+
+    // The component renders summary badges only when canShow is true.
+    // It loops over computed summaryParts and shows badges for values that exist.
+    const badges = wrapper.findAll('.badge');
+
+    // Expect two badges: one for "fail" (value 2) and one for "pass" (value 5)
+    expect(badges.length).toBe(2);
+
+    // Check that one badge displays the count 2 and the other count 5.
+    const badgeTexts = badges.map((badge) => badge.text());
+
+    expect(badgeTexts.some((text) => text.includes('2'))).toBe(true);
+    expect(badgeTexts.some((text) => text.includes('5'))).toBe(true);
+  });
+});

--- a/pkg/kubewarden/formatters/__tests__/PolicyResources.spec.ts
+++ b/pkg/kubewarden/formatters/__tests__/PolicyResources.spec.ts
@@ -1,0 +1,109 @@
+import { mount } from '@vue/test-utils';
+
+import ResourceDisplayComponent from '@kubewarden/formatters/PolicyResources.vue';
+
+describe('ResourceDisplayComponent', () => {
+  it('renders no labels when the value prop is empty', async() => {
+    const wrapper = mount(ResourceDisplayComponent, {
+      props: {
+        col:   { name: 'field' },
+        value: []
+      }
+    });
+
+    await wrapper.vm.$nextTick();
+
+    expect((wrapper.vm as any).resourceToShow).toEqual([]);
+    expect((wrapper.vm as any).resourceLabels).toEqual([]);
+    expect(wrapper.findAll('span').length).toBe(0);
+  });
+
+  it('sets resourceToShow with unique values from the value prop', async() => {
+    const testValue = [
+      { field: 'A' },
+      { field: 'B' },
+      { field: 'A' },
+      { field: 'C' },
+      { field: 'B' }
+    ];
+
+    const wrapper = mount(ResourceDisplayComponent, {
+      props: {
+        col:   { name: 'field' },
+        value: testValue
+      }
+    });
+
+    await wrapper.vm.$nextTick();
+
+    // Unique values should be ['A', 'B', 'C']
+    expect((wrapper.vm as any).resourceToShow).toEqual(['A', 'B', 'C']);
+  });
+
+  it('computes resourceLabels correctly for a single value', async() => {
+    const testValue = [
+      { field: 'OnlyValue' }
+    ];
+
+    const wrapper = mount(ResourceDisplayComponent, {
+      props: {
+        col:   { name: 'field' },
+        value: testValue
+      }
+    });
+
+    await wrapper.vm.$nextTick();
+
+    // When only one value is present, resourceLabels should equal resourceToShow
+    expect((wrapper.vm as any).resourceToShow).toEqual(['OnlyValue']);
+    expect((wrapper.vm as any).resourceLabels).toEqual(['OnlyValue']);
+
+    // Rendered output should include one span with the text "OnlyValue"
+    const spans = wrapper.findAll('span');
+
+    expect(spans.length).toBe(1);
+    expect(spans[0].text()).toBe('OnlyValue');
+  });
+
+  it('computes resourceLabels correctly for multiple values', async() => {
+    const testValue = [
+      { field: 'A' },
+      { field: 'B' },
+      { field: 'C' }
+    ];
+
+    const wrapper = mount(ResourceDisplayComponent, {
+      props: {
+        col:   { name: 'field' },
+        value: testValue
+      }
+    });
+
+    await wrapper.vm.$nextTick();
+
+    // resourceToShow should be unique values ['A', 'B', 'C']
+    expect((wrapper.vm as any).resourceToShow).toEqual(['A', 'B', 'C']);
+
+    // When more than one value is present, computed resourceLabels adds a comma and space after every value except the last.
+    // Expected: ["A, ", "B, ", "C"]
+    expect((wrapper.vm as any).resourceLabels).toEqual(['A, ', 'B, ', 'C']);
+
+    // Rendered output should include three spans with corresponding text.
+    const spans = wrapper.findAll('span');
+
+    expect(spans.length).toBe(3);
+    expect(spans[0].text()).toBe('A,');
+    expect(spans[1].text()).toBe('B,');
+    expect(spans[2].text()).toBe('C');
+  });
+
+  it('handles missing value prop gracefully', async() => {
+    // When the value prop is omitted, the default is an empty array.
+    const wrapper = mount(ResourceDisplayComponent, { props: { col: { name: 'field' } } });
+
+    await wrapper.vm.$nextTick();
+
+    expect((wrapper.vm as any).resourceToShow).toEqual([]);
+    expect((wrapper.vm as any).resourceLabels).toEqual([]);
+  });
+});

--- a/pkg/kubewarden/formatters/__tests__/PolicyServerDeployment.spec.ts
+++ b/pkg/kubewarden/formatters/__tests__/PolicyServerDeployment.spec.ts
@@ -1,0 +1,213 @@
+import { mount } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+
+import PolicyServerDeployment from '@kubewarden/formatters/PolicyServerDeployment.vue';
+
+const RouterLinkStub = {
+  template: '<a><slot /></a>',
+  props:    ['to']
+};
+
+const cleanTooltipDirective = {
+  mounted() {},
+  updated() {}
+};
+
+describe('PolicyServerDeployment.vue', () => {
+  const createRow = (deployment: any, extra: Record<string, any> = {}) => {
+    return {
+      matchingDeployment: jest.fn().mockResolvedValue(deployment),
+      detailLocation:     'detail/url',
+      ...extra
+    };
+  };
+
+  const factory = (props = {}) => {
+    return mount(PolicyServerDeployment, {
+      props,
+      global: {
+        stubs:      { 'router-link': RouterLinkStub },
+        directives: { 'clean-tooltip': cleanTooltipDirective }
+      }
+    });
+  };
+
+  it('calls row.matchingDeployment on created and sets deployment', async() => {
+    const fakeDeployment = [
+      {
+        status: {
+          conditions: [{
+            error:   false,
+            type:    'Healthy',
+            message: 'All good'
+          }]
+        }
+      }
+    ];
+    const row = createRow(fakeDeployment);
+    const wrapper = factory({
+      row,
+      value: 'Test Value'
+    });
+
+    await flushPromises();
+
+    expect(row.matchingDeployment).toHaveBeenCalled();
+    expect(wrapper.vm.deployment).toEqual(fakeDeployment);
+  });
+
+  describe('computed properties', () => {
+    it('computes flattenedConditions and hasErrors correctly when errors exist', async() => {
+      const conditions = [
+        {
+          error:   true,
+          type:    'Warning',
+          message: 'Something went wrong'
+        },
+        {
+          error:   false,
+          type:    'Info',
+          message: 'All good'
+        }
+      ];
+      const fakeDeployment = [
+        { status: { conditions } }
+      ];
+      const row = createRow(fakeDeployment);
+      const wrapper = factory({
+        row,
+        value: 'Test Value'
+      });
+
+      await flushPromises();
+
+      // flattenedConditions uses flatMap over deployment array
+      expect(wrapper.vm.flattenedConditions).toEqual(conditions);
+      // hasErrors should filter out conditions with error === true
+      expect(wrapper.vm.hasErrors).toBe(true);
+      // formattedConditions creates HTML strings from error conditions.
+      // The implementation pushes `<p><b>${ [c.type] }</b>: ${ c.message }</p>`
+      // then calls .toString().replaceAll(',', '')
+      const expectedFormatted = `<p><b>Warning</b>: Something went wrong</p>`;
+
+      expect(wrapper.vm.formattedConditions).toBe(expectedFormatted);
+    });
+
+    it('computes formattedConditions as false when there are no errors', async() => {
+      const conditions = [
+        {
+          error:   false,
+          type:    'Healthy',
+          message: 'All good'
+        }
+      ];
+      const fakeDeployment = [
+        { status: { conditions } }
+      ];
+      const row = createRow(fakeDeployment);
+      const wrapper = factory({
+        row,
+        value: 'Test Value'
+      });
+
+      await flushPromises();
+
+      expect(wrapper.vm.hasErrors).toBe(false);
+      expect(wrapper.vm.formattedConditions).toBe(false);
+    });
+
+    it('computes "to" based on the reference prop when provided', async() => {
+      // When a reference is provided, the component calls get(row, reference)
+      // Here we simulate that by providing a row with a nested property.
+      const row = createRow([], { nested: { link: '/nested/url' } });
+      const wrapper = factory({
+        row,
+        reference: 'nested.link',
+        value:     'Link Text'
+      });
+
+      await flushPromises();
+
+      // Expect computed "to" to return the value at row.nested.link
+      expect(wrapper.vm.to).toBe('/nested/url');
+    });
+
+    it('computes "to" from row.detailLocation when reference prop is not provided', async() => {
+      const row = createRow([], { detailLocation: '/detail/url' });
+      const wrapper = factory({
+        row,
+        value: 'Link Text'
+      });
+
+      await flushPromises();
+
+      expect(wrapper.vm.to).toBe('/detail/url');
+    });
+  });
+
+  describe('template rendering', () => {
+    it('renders a router-link when "to" is truthy', async() => {
+      const row = createRow([], { detailLocation: '/detail/url' });
+      const wrapper = factory({
+        row,
+        value: 'Click Me'
+      });
+
+      await flushPromises();
+
+      // Since "to" is computed from row.detailLocation, router-link should appear.
+      const routerLink = wrapper.findComponent(RouterLinkStub);
+
+      expect(routerLink.exists()).toBe(true);
+      expect(routerLink.text()).toContain('Click Me');
+      // Also, the :to prop should be set correctly.
+      expect(routerLink.props('to')).toBe('/detail/url');
+    });
+
+    it('renders plain span when "to" is falsy', async() => {
+      // If row does not have detailLocation and no reference is provided,
+      // computed "to" will be undefined.
+      const row = createRow([], { detailLocation: undefined });
+      const wrapper = factory({
+        row,
+        value: 'No Link'
+      });
+
+      await flushPromises();
+
+      // There should be no router-link; instead, a span with the value text.
+      const routerLink = wrapper.findComponent(RouterLinkStub);
+
+      expect(routerLink.exists()).toBe(false);
+      expect(wrapper.find('span').text()).toBe('No Link');
+    });
+
+    it('renders an error icon with tooltip when there are errors', async() => {
+      const conditions = [
+        {
+          error:   true,
+          type:    'Critical',
+          message: 'Failure detected'
+        }
+      ];
+      const fakeDeployment = [
+        { status: { conditions } }
+      ];
+      const row = createRow(fakeDeployment);
+      const wrapper = factory({
+        row,
+        value: 'Error Value'
+      });
+
+      await flushPromises();
+
+      // The <i> element should be rendered if hasErrors is true.
+      const errorIcon = wrapper.find('i.conditions-alert-icon');
+
+      expect(errorIcon.exists()).toBe(true);
+
+      // Since v-clean-tooltip is a directive, we can't directly inspect its content,
+      // but we can check that the element is present.
+    });
+  });
+});

--- a/pkg/kubewarden/formatters/__tests__/PolicyServerStatus.spec.ts
+++ b/pkg/kubewarden/formatters/__tests__/PolicyServerStatus.spec.ts
@@ -1,0 +1,149 @@
+import { mount } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+
+import { WORKLOAD_TYPES } from '@shell/config/types';
+import PolicyServerStatus from '@kubewarden/formatters/PolicyServerStatus.vue';
+
+import mockControllerDeployment from '@tests/unit/mocks/controllerDeployment';
+
+const BadgeStateStub = {
+  template: '<div class="badge-state">{{ label }} - {{ color }}</div>',
+  props:    ['label', 'color']
+};
+
+describe('PolicyServerStatus.vue', () => {
+  let store: any;
+  let dispatchMock: jest.Mock;
+
+  beforeEach(() => {
+    dispatchMock = jest.fn().mockResolvedValue({});
+    store = {
+      getters: {
+        'cluster/canList': () => true,
+        'cluster/all':     () => [mockControllerDeployment]
+      },
+      dispatch: dispatchMock
+    };
+  });
+
+  const factory = (props = {}) => {
+    return mount(PolicyServerStatus, {
+      props,
+      global: {
+        mocks: { $store: store },
+        stubs: { BadgeState: BadgeStateStub }
+      }
+    });
+  };
+
+  it('calls store.dispatch in created hook when canList returns true', async() => {
+    // Ensure canList returns true so that dispatch is called
+    store.getters['cluster/canList'] = () => true;
+    factory({ value: 'server1' });
+    await flushPromises();
+
+    expect(dispatchMock).toHaveBeenCalledWith('cluster/findAll', { type: WORKLOAD_TYPES.DEPLOYMENT });
+  });
+
+  it('does not call store.dispatch in created hook when canList returns false', async() => {
+    store.getters['cluster/canList'] = () => false;
+    factory({ value: 'server1' });
+    await flushPromises();
+
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  it('computed allDeployments returns store getter value', async() => {
+    const wrapper = factory({ value: 'server1' });
+
+    await flushPromises();
+
+    expect(wrapper.vm.allDeployments).toEqual([mockControllerDeployment]);
+  });
+
+  it('computed deployment returns matching deployment from allDeployments', async() => {
+    const fakeDeployment = {
+      spec:     { template: { metadata: { labels: { 'kubewarden/policy-server': 'server1' } } } },
+      metadata: { state: { name: 'running' } }
+    };
+
+    store.getters['cluster/all'] = () => [fakeDeployment];
+    const wrapper = factory({ value: 'server1' });
+
+    await flushPromises();
+
+    expect(wrapper.vm.deployment).toEqual(fakeDeployment);
+  });
+
+  it('computed stateDisplay returns deployment.metadata.state.name if deployment exists', async() => {
+    const fakeDeployment = {
+      spec:     { template: { metadata: { labels: { 'kubewarden/policy-server': 'server1' } } } },
+      metadata: { state: { name: 'running' } }
+    };
+
+    store.getters['cluster/all'] = () => [fakeDeployment];
+    const wrapper = factory({ value: 'server1' });
+
+    await flushPromises();
+
+    expect(wrapper.vm.stateDisplay).toBe('running');
+  });
+
+  it('computed stateDisplay returns "pending" if no deployment exists', async() => {
+    store.getters['cluster/all'] = () => [];
+    const wrapper = factory({ value: 'server1' });
+
+    await flushPromises();
+
+    expect(wrapper.vm.stateDisplay).toBe('pending');
+  });
+
+  it('computed stateBackground returns "bg-" concatenated with colorForPolicyServerState(stateDisplay)', async() => {
+    // Stub colorForPolicyServerState so that regardless of input it returns "info"
+    const spy = jest.spyOn(require('@kubewarden/plugins/kubewarden-class'), 'colorForPolicyServerState')
+      .mockImplementation(() => 'info');
+
+    // Provide a deployment so that stateDisplay is not "pending"
+    const fakeDeployment = {
+      spec:     { template: { metadata: { labels: { 'kubewarden/policy-server': 'server1' } } } },
+      metadata: { state: { name: 'running' } }
+    };
+
+    store.getters['cluster/all'] = () => [fakeDeployment];
+    const wrapper = factory({ value: 'server1' });
+
+    await flushPromises();
+
+    expect(wrapper.vm.stateBackground).toBe('bg-info');
+    spy.mockRestore();
+  });
+
+  it('capitalizeMessage method capitalizes a given string', () => {
+    const wrapper = factory({ value: 'server1' });
+
+    expect(wrapper.vm.capitalizeMessage('pending')).toBe('Pending');
+    expect(wrapper.vm.capitalizeMessage('error')).toBe('Error');
+  });
+
+  it('renders BadgeState component with correct props', async() => {
+    // Use a fake deployment so that stateDisplay is not "pending"
+    const fakeDeployment = {
+      spec:     { template: { metadata: { labels: { 'kubewarden/policy-server': 'server1' } } } },
+      metadata: { state: { name: 'running' } }
+    };
+
+    store.getters['cluster/all'] = () => [fakeDeployment];
+    const wrapper = factory({ value: 'server1' });
+
+    await flushPromises();
+
+    // BadgeState should be rendered because stateDisplay is truthy
+    const badgeState = wrapper.find('.badge-state');
+
+    expect(badgeState.exists()).toBe(true);
+    // capitalizeMessage('running') should yield "Running"
+    expect(badgeState.text()).toContain('Running');
+    // Also, the color prop is rendered as part of the text (stub displays " - {color}")
+    expect(badgeState.text()).toContain('bg-');
+  });
+});

--- a/pkg/kubewarden/formatters/__tests__/PolicySummaryGraph.spec.ts
+++ b/pkg/kubewarden/formatters/__tests__/PolicySummaryGraph.spec.ts
@@ -1,0 +1,225 @@
+import { mount } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+
+import PolicySummaryGraph from '@kubewarden/formatters/PolicySummaryGraph.vue';
+
+import * as kubewarden from '@kubewarden/plugins/kubewarden-class';
+
+describe('PolicySummaryGraph.vue', () => {
+  let row: any;
+  let fakePolicies: any[];
+  let colorForStatusSpy: jest.SpyInstance; // eslint-disable-line
+  let stateSortSpy: jest.SpyInstance; // eslint-disable-line
+
+  beforeEach(() => {
+    // Stub colorForStatus: returns "text-<state>"
+    colorForStatusSpy = jest.spyOn(kubewarden, 'colorForStatus')
+      .mockImplementation((...args: unknown[]) => {
+        const state = args[0] as string;
+
+        return `text-${ state }`;
+      });
+    // Stub stateSort: for simplicity, return numeric values based on the state
+    stateSortSpy = jest.spyOn(kubewarden, 'stateSort')
+      .mockImplementation((...args: unknown[]) => {
+        const state = args[1] as string;
+
+        // For example: "pass" -> 2, "fail" -> 1, others 0
+        if (state === 'pass') {
+          return 2;
+        }
+        if (state === 'fail') {
+          return 1;
+        }
+
+        return 0;
+      });
+
+    // Fake policies array returned by row.allRelatedPolicies()
+    fakePolicies = [
+      { status: { policyStatus: 'fail' } },
+      { status: { policyStatus: 'fail' } },
+      { status: { policyStatus: 'pass' } }
+    ];
+
+    // Fake row object with an id and an allRelatedPolicies() method
+    row = {
+      id:                 'row1',
+      allRelatedPolicies: jest.fn().mockResolvedValue(fakePolicies)
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // Factory helper to mount the component with necessary stubs
+  const factory = (propsData = {}) => {
+    return mount(PolicySummaryGraph, {
+      props:  {
+        row,
+        ...propsData
+      },
+      global: {
+        stubs: {
+          // Stub VDropdown: render default and popper slots
+          VDropdown: {
+            template: `<div class="vdropdown">
+              <slot></slot>
+              <slot name="popper"></slot>
+            </div>`
+          },
+          // Stub ProgressBarMulti: render its "values" prop as JSON for testing
+          ProgressBarMulti: {
+            template: '<div class="progress-bar-multi">{{ JSON.stringify(values) }}</div>',
+            props:    ['values']
+          },
+          // Stub router-link to render an <a> element with its content
+          'router-link': {
+            template: '<a class="router-link"><slot /></a>',
+            props:    ['to']
+          }
+        }
+      }
+    });
+  };
+
+  it('calls row.allRelatedPolicies in created() and sets relatedPolicies', async() => {
+    const wrapper = factory();
+
+    await flushPromises();
+
+    expect((wrapper.vm as any).relatedPolicies).toEqual(fakePolicies);
+  });
+
+  it('computed "show" returns true if stateParts is non-empty', async() => {
+    const wrapper = factory();
+
+    await flushPromises();
+    expect(wrapper.vm.show).toBe(true);
+  });
+
+  it('computed "show" returns false if stateParts is empty', async() => {
+    const wrapper = factory();
+
+    await flushPromises();
+
+    await wrapper.setData({ relatedPolicies: [] });
+
+    expect(wrapper.vm.show).toBe(false);
+  });
+
+  it('computed "stateParts" groups policies by state correctly', async() => {
+    const wrapper = factory();
+
+    await flushPromises();
+
+    const stateParts = wrapper.vm.stateParts;
+
+    // Expect two groups: one for "fail" (value 2) and one for "pass" (value 1)
+    // Expected groups:
+    // For "fail": colorForStatus returns "text-fail" → key "text-fail/fail",
+    //   value should be 2, color becomes "bg-fail", sort returns 1.
+    // For "pass": key "text-pass/pass", value 1, color "bg-pass", sort returns 2.
+    const failGroup = stateParts.find((item: any) => item.label === 'fail');
+    const passGroup = stateParts.find((item: any) => item.label === 'pass');
+
+    expect(failGroup).toBeDefined();
+    expect(failGroup.value).toBe(2);
+    expect(failGroup.color).toBe('bg-fail');
+    expect(failGroup.textColor).toBe('text-fail');
+    expect(failGroup.sort).toBe(1);
+
+    expect(passGroup).toBeDefined();
+    expect(passGroup.value).toBe(1);
+    expect(passGroup.color).toBe('bg-pass');
+    expect(passGroup.textColor).toBe('text-pass');
+    expect(passGroup.sort).toBe(2);
+  });
+
+  it('computed "colorParts" groups stateParts by color correctly', async() => {
+    const wrapper = factory();
+
+    await flushPromises();
+
+    const colorParts = wrapper.vm.colorParts;
+    // Expect two groups: one for "bg-fail" (value 2) and one for "bg-pass" (value 1)
+    const failColor = colorParts.find((item: any) => item.color === 'bg-fail');
+    const passColor = colorParts.find((item: any) => item.color === 'bg-pass');
+
+    expect(failColor).toBeDefined();
+    expect(failColor.value).toBe(2);
+    expect(passColor).toBeDefined();
+    expect(passColor.value).toBe(1);
+  });
+
+  it('computed "displayLabel" returns label with count when label prop is provided', async() => {
+    const wrapper = factory({ label: 'Test Label' });
+
+    await flushPromises();
+
+    // fakePolicies.length is 3, so displayLabel should be "Test Label, 3"
+    expect(wrapper.vm.displayLabel).toBe('Test Label, 3');
+  });
+
+  it('computed "displayLabel" returns count as string when no label prop is provided', async() => {
+    const wrapper = factory();
+
+    await flushPromises();
+
+    expect(wrapper.vm.displayLabel).toBe('3');
+  });
+
+  describe('template rendering', () => {
+    it('renders VDropdown with ProgressBarMulti and a router-link when linkTo prop is provided', async() => {
+      const linkTo = { name: 'detail' };
+      const wrapper = factory({
+        label: 'Test Label',
+        linkTo
+      });
+
+      await flushPromises();
+
+      // Check that VDropdown is rendered (stubbed as element with class "vdropdown")
+      expect(wrapper.find('.vdropdown').exists()).toBe(true);
+      const progressBar = wrapper.find('.progress-bar-multi');
+
+      expect(progressBar.exists()).toBe(true);
+      expect(progressBar.text()).toEqual(JSON.stringify(wrapper.vm.colorParts));
+
+      // Check that router-link is rendered with the correct "to" prop and displays displayLabel text
+      const routerLink = wrapper.findComponent('.router-link') as any;
+
+      expect(routerLink.exists()).toBe(true);
+      expect(routerLink.props('to')).toEqual(linkTo);
+      expect(routerLink.text()).toContain(wrapper.vm.displayLabel);
+    });
+
+    it('renders a span with displayLabel when linkTo prop is not provided', async() => {
+      const wrapper = factory({ label: 'Test Label' });
+
+      await flushPromises();
+
+      // router-link should not exist; a span should display displayLabel
+      expect(wrapper.findComponent({ name: 'router-link' }).exists()).toBe(false);
+      const span = wrapper.find('span');
+
+      expect(span.exists()).toBe(true);
+      expect(span.text()).toBe(wrapper.vm.displayLabel);
+    });
+
+    it('renders fallback div when "show" is false', async() => {
+      // Set relatedPolicies to empty so that stateParts (and thus show) is empty.
+      const wrapper = factory({ label: 'Test Label' });
+
+      await flushPromises();
+      await wrapper.setData({ relatedPolicies: [] });
+
+      // When show is false, the template renders a div with classes "text-center text-muted" containing an em-dash.
+      const fallback = wrapper.find('div.text-center.text-muted');
+
+      expect(fallback.exists()).toBe(true);
+      expect(fallback.text()).toContain('—'); // or the &mdash; character
+    });
+  });
+});

--- a/pkg/kubewarden/formatters/__tests__/PolicyTableFeatures.spec.ts
+++ b/pkg/kubewarden/formatters/__tests__/PolicyTableFeatures.spec.ts
@@ -1,0 +1,36 @@
+import { mount } from '@vue/test-utils';
+
+import PolicyTableFeatures from '@kubewarden/formatters/PolicyTableFeatures.vue';
+
+describe('PolicyTableFeatures.vue', () => {
+  it('renders nothing when no features are provided', () => {
+    const wrapper = mount(PolicyTableFeatures, { props: { value: {} } });
+
+    expect(wrapper.text()).toBe('');
+  });
+
+  it('renders "Mutation" when "kubewarden/mutation" is "true"', () => {
+    const wrapper = mount(PolicyTableFeatures, { props: { value: { 'kubewarden/mutation': 'true' } } });
+
+    expect(wrapper.text()).toBe('Mutation');
+  });
+
+  it('renders "Context Aware" when "kubewarden/contextAwareResources" is truthy', () => {
+    const wrapper = mount(PolicyTableFeatures, { props: { value: { 'kubewarden/contextAwareResources': 'foo' } } });
+
+    expect(wrapper.text()).toBe('Context Aware');
+  });
+
+  it('renders "Mutation, Context Aware" when both features are provided', () => {
+    const wrapper = mount(PolicyTableFeatures, {
+      props: {
+        value: {
+          'kubewarden/mutation':              'true',
+          'kubewarden/contextAwareResources': true
+        }
+      }
+    });
+
+    expect(wrapper.text()).toBe('Mutation, Context Aware');
+  });
+});

--- a/pkg/kubewarden/formatters/__tests__/PolicyTableResources.spec.ts
+++ b/pkg/kubewarden/formatters/__tests__/PolicyTableResources.spec.ts
@@ -1,0 +1,29 @@
+import { mount } from '@vue/test-utils';
+
+import PolicyTableResources from '@kubewarden/formatters/PolicyTableResources.vue';
+
+describe('PolicyTableResources.vue', () => {
+  it('renders nothing when the "kubewarden/resources" property is missing', () => {
+    const wrapper = mount(PolicyTableResources, { props: { value: {} } });
+
+    expect(wrapper.text()).toBe('');
+  });
+
+  it('renders "Multiple" when the resource list contains more than one resource', () => {
+    const wrapper = mount(PolicyTableResources, { props: { value: { 'kubewarden/resources': 'foo,bar,baz' } } });
+
+    expect(wrapper.text()).toBe('Multiple');
+  });
+
+  it('renders "Global" when the resource list contains a single asterisk ("*")', () => {
+    const wrapper = mount(PolicyTableResources, { props: { value: { 'kubewarden/resources': '*' } } });
+
+    expect(wrapper.text()).toBe('Global');
+  });
+
+  it('renders the resource string when the resource list contains exactly one resource (that is not "*")', () => {
+    const wrapper = mount(PolicyTableResources, { props: { value: { 'kubewarden/resources': 'foo' } } });
+
+    expect(wrapper.text()).toBe('foo');
+  });
+});

--- a/pkg/kubewarden/models/__tests__/policies.kubewarden.io.clusteradmissionpolicy.spec.ts
+++ b/pkg/kubewarden/models/__tests__/policies.kubewarden.io.clusteradmissionpolicy.spec.ts
@@ -1,0 +1,117 @@
+import ClusterAdmissionPolicy from '@kubewarden/models/policies.kubewarden.io.clusteradmissionpolicy';
+import PolicyModel from '@kubewarden/plugins/policy-class';
+
+describe('ClusterAdmissionPolicy', () => {
+  let instance: ClusterAdmissionPolicy;
+  let rootGetters: Record<string, any>;
+  let dispatch: jest.Mock;
+
+  beforeEach(() => {
+    instance = new ClusterAdmissionPolicy({});
+
+    rootGetters = { currentCluster: { id: 'test-cluster' } };
+    dispatch = jest.fn();
+    Object.defineProperty(instance, '$rootGetters', { value: rootGetters });
+    Object.defineProperty(instance, '$dispatch', { value: dispatch });
+
+    instance.metadata = { labels: { 'helm.sh/chart': 'kubewarden-defaults-1.2.3' } };
+  });
+
+  describe('_availableActions getter', () => {
+    it('filters out edit actions and adds editPolicySettings when isKubewardenDefaultPolicy is true and not deployed with fleet', () => {
+      Object.defineProperty(instance, 'isKubewardenDefaultPolicy', { get: () => true });
+      Object.defineProperty(instance, 'isDeployedWithFleet', { get: () => false });
+
+      // Stub the parent (PolicyModel) _availableActions getter.
+      const parentActions = [
+        {
+          action: 'goToEdit',
+          label:  'Edit'
+        },
+        {
+          action: 'goToEditYaml',
+          label:  'Edit YAML'
+        },
+        {
+          action: 'delete',
+          label:  'Delete'
+        }
+      ];
+
+      jest.spyOn(PolicyModel.prototype, '_availableActions', 'get').mockReturnValue(parentActions);
+
+      const actions = instance._availableActions;
+
+      // Verify that the default policy settings action is unshifted at the beginning.
+      expect(actions[0]).toEqual({
+        action: 'editPolicySettings',
+        icon:   'icon icon-edit',
+        label:  'Edit Policy Settings'
+      });
+
+      // And that actions do not include the filtered-out edit actions.
+      actions.slice(1).forEach((action) => {
+        expect(['goToEdit', 'goToEditYaml']).not.toContain(action.action);
+      });
+      // Verify that other actions (like 'delete') remain.
+      expect(actions).toEqual(expect.arrayContaining([{
+        action: 'delete',
+        label:  'Delete'
+      }]));
+    });
+
+    it('returns parent actions unchanged when isKubewardenDefaultPolicy is false', () => {
+      Object.defineProperty(instance, 'isKubewardenDefaultPolicy', { get: () => false });
+      // For this case, the condition isn’t met so we expect the parent's actions to pass through.
+      const parentActions = [
+        {
+          action: 'goToEdit',
+          label:  'Edit'
+        },
+        {
+          action: 'delete',
+          label:  'Delete'
+        }
+      ];
+
+      jest.spyOn(PolicyModel.prototype, '_availableActions', 'get').mockReturnValue(parentActions);
+
+      const actions = instance._availableActions;
+
+      expect(actions).toEqual(parentActions);
+    });
+  });
+
+  describe('editPolicySettings', () => {
+    it('navigates to kubewardenDefaultsRoute if a valid route exists', () => {
+      // Stub the kubewardenDefaultsRoute getter to return a valid route.
+      const route = {
+        name:   'route-name',
+        params: { cluster: 'test-cluster' },
+        query:  {}
+      };
+
+      jest.spyOn(instance, 'kubewardenDefaultsRoute', 'get').mockReturnValue(route);
+
+      // Stub currentRouter to return a fake router with a push method.
+      const push = jest.fn();
+
+      instance.currentRouter = () => ({ push });
+
+      instance.editPolicySettings();
+      expect(push).toHaveBeenCalledWith(route);
+    });
+
+    it('logs an error if kubewardenDefaultsRoute is null', () => {
+      // Stub the kubewardenDefaultsRoute getter to return null.
+      jest.spyOn(instance, 'kubewardenDefaultsRoute', 'get').mockReturnValue(null);
+
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      instance.editPolicySettings();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Could not determine the route to the Kubewarden Defaults chart.');
+      consoleErrorSpy.mockRestore();
+    });
+  });
+});

--- a/pkg/kubewarden/modules/__tests__/core.spec.ts
+++ b/pkg/kubewarden/modules/__tests__/core.spec.ts
@@ -1,0 +1,210 @@
+import {
+  splitGroupKind,
+  schemasForGroup,
+  namespacedGroups,
+  namespacedSchemas,
+  isResourceNamespaced
+} from '@kubewarden/modules/core';
+
+describe('splitGroupKind', () => {
+  it('should return "apps.deployment" when given a Deployment resource with apiVersion "apps/v1"', () => {
+    const resource = {
+      kind:       'Deployment',
+      apiVersion: 'apps/v1'
+    };
+
+    expect(splitGroupKind(resource)).toBe('apps.deployment');
+  });
+
+  it('should return undefined if kind is missing', () => {
+    const resource = { apiVersion: 'apps/v1' };
+
+    expect(splitGroupKind(resource)).toBeUndefined();
+  });
+
+  it('should return undefined if apiVersion is missing', () => {
+    const resource = { kind: 'Deployment' };
+
+    expect(splitGroupKind(resource)).toBeUndefined();
+  });
+});
+
+describe('schemasForGroup', () => {
+  const fakeSchemas = [
+    {
+      _group:     'apps',
+      name:       'Deployment',
+      attributes: {}
+    },
+    {
+      _group:     'batch',
+      name:       'Job',
+      attributes: {}
+    },
+    {
+      _group:     'apps',
+      name:       'StatefulSet',
+      attributes: {}
+    }
+  ];
+  const mockStore = { getters: { 'cluster/all': jest.fn().mockReturnValue(fakeSchemas) } };
+
+  it('should return an empty array if schemas are empty', () => {
+    mockStore.getters['cluster/all'].mockReturnValueOnce([]);
+    expect(schemasForGroup(mockStore, 'apps')).toEqual([]);
+  });
+
+  it('should return an empty array if group is empty', () => {
+    expect(schemasForGroup(mockStore, '')).toEqual([]);
+  });
+
+  it('should filter schemas based on a group string', () => {
+    const result = schemasForGroup(mockStore, 'apps');
+
+    expect(result).toEqual([
+      {
+        _group:     'apps',
+        name:       'Deployment',
+        attributes: {}
+      },
+      {
+        _group:     'apps',
+        name:       'StatefulSet',
+        attributes: {}
+      }
+    ]);
+  });
+
+  it('should filter schemas based on a group object with an id', () => {
+    const result = schemasForGroup(mockStore, { id: 'batch' });
+
+    expect(result).toEqual([{
+      _group:     'batch',
+      name:       'Job',
+      attributes: {}
+    }]);
+  });
+});
+
+describe('namespacedGroups', () => {
+  const fakeSchemas = [
+    {
+      _group:     'apps',
+      name:       'Deployment',
+      attributes: { namespaced: true }
+    },
+    {
+      _group:     'batch',
+      name:       'Job',
+      attributes: { namespaced: false }
+    },
+    {
+      _group:     'extensions',
+      name:       'Ingress',
+      attributes: {}
+    } // namespaced undefined -> include
+  ];
+  const mockStore = { getters: { 'cluster/all': jest.fn().mockReturnValue(fakeSchemas) } };
+
+  const apiGroups = [
+    {
+      id:          'apps',
+      displayName: 'Apps'
+    },
+    {
+      id:          'batch',
+      displayName: 'Batch'
+    },
+    {
+      id:          'core',
+      displayName: 'Core'
+    },
+    {
+      id:          'extensions',
+      displayName: 'Extensions'
+    }
+  ];
+
+  it('should return undefined if schemas are empty', () => {
+    const emptyStore = { getters: { 'cluster/all': jest.fn().mockReturnValue([]) } };
+
+    expect(namespacedGroups(emptyStore, apiGroups)).toBeUndefined();
+  });
+
+  it('should return undefined if apiGroups is empty', () => {
+    expect(namespacedGroups(mockStore, [])).toBeUndefined();
+  });
+
+  it('should filter groups based on namespaced schemas, including "core"', () => {
+    const result = namespacedGroups(mockStore, apiGroups);
+
+    // "apps": namespaced true -> include
+    // "batch": namespaced false -> exclude
+    // "extensions": namespaced undefined -> include
+    // "core": always included
+    expect(result).toEqual([
+      {
+        id:          'apps',
+        displayName: 'Apps'
+      },
+      {
+        id:          'core',
+        displayName: 'Core'
+      },
+      {
+        id:          'extensions',
+        displayName: 'Extensions'
+      }
+    ]);
+  });
+});
+
+describe('namespacedSchemas', () => {
+  it('should filter out schemas with namespaced explicitly false', () => {
+    const schemas = [
+      {
+        name:       'Deployment',
+        attributes: { namespaced: true }
+      },
+      {
+        name:       'Job',
+        attributes: { namespaced: false }
+      },
+      {
+        name:       'Service',
+        attributes: {}
+      } // undefined -> include
+    ];
+    const result = namespacedSchemas(schemas);
+
+    expect(result).toEqual([
+      {
+        name:       'Deployment',
+        attributes: { namespaced: true }
+      },
+      {
+        name:       'Service',
+        attributes: {}
+      }
+    ]);
+  });
+});
+
+describe('isResourceNamespaced', () => {
+  it('should return true when resource.metadata has a namespace property', () => {
+    const resource = {
+      metadata: {
+        namespace: 'default',
+        name:      'my-resource'
+      }
+    };
+
+    expect(isResourceNamespaced(resource)).toBe(true);
+  });
+
+  it('should return false when resource.metadata does not have a namespace property', () => {
+    const resource = { metadata: { name: 'my-resource' } };
+
+    expect(isResourceNamespaced(resource)).toBe(false);
+  });
+});

--- a/pkg/kubewarden/modules/__tests__/fleet.spec.ts
+++ b/pkg/kubewarden/modules/__tests__/fleet.spec.ts
@@ -1,0 +1,179 @@
+import { FLEET } from '@shell/config/labels-annotations';
+
+import {
+  isFleetDeployment,
+  findFleetContent,
+  getPolicyServerModule
+} from '@kubewarden/modules/fleet';
+
+
+describe('isFleetDeployment', () => {
+  it('should return false if app is null', () => {
+    expect(isFleetDeployment(null)).toBe(false);
+  });
+
+  it('should return false if the app does not have the fleet bundle annotation', () => {
+    const appWithoutAnnotation = { spec: { chart: { metadata: { annotations: {} } } } };
+
+    expect(isFleetDeployment(appWithoutAnnotation)).toBe(false);
+  });
+
+  it('should return true if the app contains the fleet bundle annotation', () => {
+    const appWithAnnotation = { spec: { chart: { metadata: { annotations: { [FLEET.BUNDLE_ID]: 'bundle-123' } } } } };
+
+    expect(isFleetDeployment(appWithAnnotation)).toBe(true);
+  });
+});
+
+describe('findFleetContent', () => {
+  it('should return null if fleetBundles array is empty', () => {
+    expect(findFleetContent('PolicyServer', [])).toBeNull();
+  });
+
+  it('should return null if no resource content includes the specified context', () => {
+    const bundles = [
+      {
+        spec: {
+          helm:      { chart: 'chart1' },
+          resources: [{
+            name:    'file.txt',
+            content: 'some content'
+          }]
+        }
+      },
+      {
+        spec: {
+          helm:      { chart: 'chart2' },
+          resources: [{
+            name:    'file.yaml',
+            content: 'other content'
+          }]
+        }
+      }
+    ];
+
+    expect(findFleetContent('PolicyServer', bundles)).toBeNull();
+  });
+
+  it('should skip bundles with a chart matching skipChart', () => {
+    const bundles = [
+      {
+        spec: {
+          helm:      { chart: 'skip-this' },
+          resources: [{
+            name:    'file.yaml',
+            content: 'kind: PolicyServer'
+          }]
+        }
+      },
+      {
+        spec: {
+          helm:      { chart: 'valid-chart' },
+          resources: [{
+            name:    'file.yaml',
+            content: 'kind: PolicyServer'
+          }]
+        }
+      }
+    ];
+    const result = findFleetContent('PolicyServer', bundles, 'skip-this');
+
+    // It should skip the first bundle and return the second.
+    expect(result).toEqual(bundles[1]);
+  });
+
+  it('should return the first matching bundle that contains a resource with the context', () => {
+    const bundle1 = {
+      spec: {
+        helm:      { chart: 'chart1' },
+        resources: [{
+          name:    'file.yaml',
+          content: 'kind: SomethingElse'
+        }]
+      }
+    };
+    const bundle2 = {
+      spec: {
+        helm:      { chart: 'chart2' },
+        resources: [{
+          name:    'file.yaml',
+          content: 'kind: PolicyServer'
+        }]
+      }
+    };
+    const bundles = [bundle1, bundle2];
+
+    expect(findFleetContent('PolicyServer', bundles)).toEqual(bundle2);
+  });
+});
+
+describe('getPolicyServerModule', () => {
+  it('should return null if findFleetContent returns null', () => {
+    // Pass an empty array so findFleetContent returns null.
+    expect(getPolicyServerModule([])).toBeNull();
+  });
+
+  it('should return null if no values.yaml resource is found in the matching bundle', () => {
+    const bundle = {
+      spec: {
+        helm:      { chart: 'valid-chart' },
+        resources: [
+          {
+            name:    'mock.yaml',
+            content: 'kind: PolicyServer'
+          }
+        ]
+      }
+    };
+
+    expect(getPolicyServerModule([bundle])).toBeNull();
+  });
+
+  it('should return null if YAML parsing fails', () => {
+    const bundle = {
+      spec: {
+        helm:      { chart: 'valid-chart' },
+        resources: [
+          {
+            name:    'values.yaml',
+            content: 'invalid: : yaml: :'
+          }
+        ]
+      }
+    };
+
+    // getPolicyServerModule should catch the YAML parse error and return null.
+    expect(getPolicyServerModule([bundle])).toBeNull();
+  });
+
+  it('should return the module string if valid YAML content is provided', () => {
+    const validYaml = `
+global:
+  cattle:
+    systemDefaultRegistry: "docker.io"
+policyServer:
+  image:
+    repository: "policy-server"
+    tag: "1.0.0"
+`;
+    // Create a bundle that will be matched by findFleetContent.
+    const bundle = {
+      spec: {
+        helm:      { chart: 'valid-chart' },
+        resources: [
+          {
+            name:    'mock.yaml',
+            content: 'kind: PolicyServer'
+          },
+          {
+            name:    'values.yaml',
+            content: validYaml
+          }
+        ]
+      }
+    };
+    const result = getPolicyServerModule([bundle]);
+
+    expect(result).toBe('docker.io/policy-server:1.0.0');
+  });
+});

--- a/pkg/kubewarden/modules/__tests__/grafana.spec.ts
+++ b/pkg/kubewarden/modules/__tests__/grafana.spec.ts
@@ -1,0 +1,205 @@
+import {
+  grafanaProxy,
+  grafanaService,
+  findKubewardenDashboards,
+  addKubewardenDashboards
+} from '@kubewarden/modules/grafana'; // Adjust the path accordingly
+import { CONFIG_MAP } from '@shell/config/types';
+import { CatalogApp, KubewardenDashboards } from '@kubewarden/types';
+
+const createMockStore = () => ({ dispatch: jest.fn() });
+
+const monitoringApp: CatalogApp = {
+  metadata: {
+    name:      'monitor-app',
+    namespace: 'monitor-ns'
+  }
+} as CatalogApp;
+const controllerApp: CatalogApp = {
+  metadata: {
+    name:      'controller-app',
+    namespace: 'controller-ns'
+  }
+} as CatalogApp;
+
+describe('grafanaProxy', () => {
+  let mockStore: any;
+
+  beforeEach(() => {
+    mockStore = createMockStore();
+  });
+
+  it('should return a valid proxy URL when grafanaService returns a valid service', async() => {
+    const fakeService = {
+      metadata: {
+        namespace: 'foo-ns',
+        name:      'grafana-svc'
+      }
+    };
+
+    mockStore.dispatch.mockResolvedValueOnce(fakeService);
+    const result = await grafanaProxy({
+      store: mockStore,
+      type:  'dashboard'
+    });
+
+    // Expected URL:
+    // base = `/api/v1/namespaces/foo-ns/services`
+    // proxy = `/http:grafana-svc:80/proxy`
+    // path = `/d/dashboard?orgId=1&kiosk`
+    expect(result).toBe('/api/v1/namespaces/foo-ns/services/http:grafana-svc:80/proxy/d/dashboard?orgId=1&kiosk');
+  });
+
+  it('should call handleGrowl and return null when an error occurs', async() => {
+    const error = new Error('Test error');
+
+    mockStore.dispatch.mockRejectedValueOnce(error);
+    const handleGrowlSpy = jest.spyOn(require('../../utils/handle-growl'), 'handleGrowl');
+    const result = await grafanaProxy({
+      store: mockStore,
+      type:  'dashboard'
+    });
+
+    expect(handleGrowlSpy).toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+});
+
+describe('grafanaService', () => {
+  let mockStore: any;
+
+  beforeEach(() => {
+    mockStore = createMockStore();
+  });
+
+  it('should return the service when store.dispatch resolves', async() => {
+    const fakeService = {
+      metadata: {
+        namespace: 'foo-ns',
+        name:      'grafana-svc'
+      }
+    };
+
+    mockStore.dispatch.mockResolvedValueOnce(fakeService);
+    const result = await grafanaService(mockStore);
+
+    expect(result).toEqual(fakeService);
+  });
+
+  it('should call handleGrowl and return undefined when store.dispatch rejects', async() => {
+    const error = new Error('Service error');
+
+    mockStore.dispatch.mockRejectedValueOnce(error);
+    const handleGrowlSpy = jest.spyOn(require('../../utils/handle-growl'), 'handleGrowl');
+    const result = await grafanaService(mockStore);
+
+    expect(handleGrowlSpy).toHaveBeenCalled();
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('findKubewardenDashboards', () => {
+  let mockStore: any;
+
+  beforeEach(() => {
+    mockStore = createMockStore();
+  });
+
+  it('should return the dashboards when store.dispatch resolves', async() => {
+    const fakeResult = { metadata: { name: 'dashboard-config' } };
+
+    mockStore.dispatch.mockResolvedValueOnce(fakeResult);
+    const result = await findKubewardenDashboards(mockStore);
+
+    expect(result).toEqual(fakeResult);
+  });
+
+  it('should call handleGrowl and return undefined on error', async() => {
+    const error = new Error('Dashboard error');
+
+    mockStore.dispatch.mockRejectedValueOnce(error);
+    const handleGrowlSpy = jest.spyOn(require('../../utils/handle-growl'), 'handleGrowl');
+    const result = await findKubewardenDashboards(mockStore);
+
+    expect(handleGrowlSpy).toHaveBeenCalled();
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('addKubewardenDashboards', () => {
+  let mockStore: any;
+
+  beforeEach(() => {
+    mockStore = createMockStore();
+  });
+
+  let originalValues: any;
+
+  beforeAll(() => {
+    originalValues = Object.values;
+    Object.values = () => [KubewardenDashboards.POLICY_SERVER];
+  });
+  afterAll(() => {
+    Object.values = originalValues;
+  });
+
+  const stubFindDashboards = jest.spyOn(
+    require('../grafana.ts'),
+    'findKubewardenDashboards'
+  );
+
+  it('should create a new dashboard if no existing config map is found', async() => {
+    stubFindDashboards.mockResolvedValue(null);
+
+    await addKubewardenDashboards({
+      store: mockStore,
+      monitoringApp,
+      controllerApp
+    });
+
+    expect(mockStore.dispatch).toHaveBeenCalledWith(
+      'cluster/create',
+      expect.objectContaining({
+        type:     CONFIG_MAP,
+        metadata: expect.objectContaining({
+          name:      KubewardenDashboards.POLICY_SERVER,
+          namespace: 'cattle-dashboards'
+        }),
+        data: expect.any(Object)
+      })
+    );
+  });
+
+  it('should call handleGrowl if saving the config map fails', async() => {
+    stubFindDashboards.mockResolvedValueOnce(null);
+    jest.mock('../../assets/PolicyServer.json', () => ({ mock: 'data' }), { virtual: true });
+    const fakeConfigMapTemplate = { save: jest.fn().mockRejectedValue(new Error('Save failed')) };
+
+    mockStore.dispatch.mockResolvedValueOnce(fakeConfigMapTemplate);
+    const handleGrowlSpy = jest.spyOn(require('../../utils/handle-growl'), 'handleGrowl');
+
+    await addKubewardenDashboards({
+      store: mockStore,
+      monitoringApp,
+      controllerApp
+    });
+
+    expect(handleGrowlSpy).toHaveBeenCalled();
+  });
+
+  it('should do nothing if monitoringApp or controllerApp is not provided', async() => {
+    await addKubewardenDashboards({
+      store:         mockStore,
+      monitoringApp: null,
+      controllerApp
+    });
+    expect(mockStore.dispatch).not.toHaveBeenCalled();
+
+    await addKubewardenDashboards({
+      store:         mockStore,
+      monitoringApp,
+      controllerApp: null
+    });
+    expect(mockStore.dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/pkg/kubewarden/modules/__tests__/jaegerTracing.spec.ts
+++ b/pkg/kubewarden/modules/__tests__/jaegerTracing.spec.ts
@@ -1,0 +1,321 @@
+import { jaegerTraces, jaegerPolicyName, convertTagsToObject } from '@kubewarden/modules/jaegerTracing';
+import { KUBEWARDEN } from '@kubewarden/types';
+
+jest.mock('@kubewarden/utils/service', () => ({ proxyUrl: jest.fn().mockReturnValue('http://mocked-proxy:16686/') }));
+
+function createMockStore() {
+  return {
+    getters:   { currentCluster: { id: 'mock-cluster' } },
+    dispatch:  jest.fn()
+  };
+}
+
+describe('jaegerPolicyName', () => {
+  it('returns clusterwide-<name> for a ClusterAdmissionPolicy', () => {
+    const policy = {
+      kind:     'ClusterAdmissionPolicy',
+      metadata: { name: 'cap1' }
+    };
+    const result = jaegerPolicyName(policy);
+
+    expect(result).toBe('clusterwide-cap1');
+  });
+
+  it('returns namespaced-<ns>-<name> for an AdmissionPolicy', () => {
+    const policy = {
+      kind:     'AdmissionPolicy',
+      metadata: {
+        name:      'ap1',
+        namespace: 'ns1'
+      }
+    };
+    const result = jaegerPolicyName(policy);
+
+    expect(result).toBe('namespaced-ns1-ap1');
+  });
+
+  it('returns null if policy kind is unknown', () => {
+    const policy = {
+      kind:     'SomethingElse',
+      metadata: { name: 'test' }
+    };
+    const result = jaegerPolicyName(policy);
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('convertTagsToObject', () => {
+  it('converts string, int64, float64, bool tags to correct JS types', () => {
+    const input = [
+      {
+        key:   'myString',
+        type:  'string',
+        value: 'hello'
+      },
+      {
+        key:   'myInt',
+        type:  'int64',
+        value: '42'
+      },
+      {
+        key:   'myFloat',
+        type:  'float64',
+        value: '3.14'
+      },
+      {
+        key:   'myBool',
+        type:  'bool',
+        value: 'true'
+      },
+      {
+        key:   'unknown',
+        type:  'xyz',
+        value: 'whatever'
+      }
+    ];
+    const result = convertTagsToObject(input);
+
+    expect(result).toEqual({
+      myString: 'hello',
+      myInt:    42,
+      myFloat:  3.14,
+      myBool:   true,
+      unknown:  'whatever'
+    });
+  });
+});
+
+describe('jaegerTraces', () => {
+  let store: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store = createMockStore();
+  });
+
+  it('fetches traces for each related policy in PolicyServer context', async() => {
+    const config = {
+      store,
+      queryService:    {
+        metadata: {
+          name:      'jaeger-query',
+          namespace: 'jaeger-ns'
+        }
+      },
+      resource:        KUBEWARDEN.POLICY_SERVER,
+      relatedPolicies: [
+        {
+          kind:     'ClusterAdmissionPolicy',
+          metadata: { name: 'cap1' },
+          spec:     { mode: 'monitor' }
+        },
+        {
+          kind:     'AdmissionPolicy',
+          metadata: {
+            name:      'ap1',
+            namespace: 'ns1'
+          },
+          spec: { mode: 'protect' }
+        }
+      ],
+    };
+
+    store.dispatch.mockResolvedValue({
+      data: [
+        {
+          traceID: 'trace-111',
+          spans:   [
+            {
+              operationName: 'validation',
+              startTime:     123456789,
+              duration:      50000,
+              tags:          [
+                {
+                  key:   'policy_id',
+                  value: 'clusterwide-cap1'
+                },  // matches 1st policy
+                {
+                  key:   'allowed',
+                  value: 'true',
+                  type:  'bool'
+                }
+              ]
+            }
+          ]
+        },
+        {
+          traceID: 'trace-222',
+          spans:   [
+            {
+              operationName: 'validation',
+              startTime:     123450000,
+              duration:      40000,
+              tags:          [
+                {
+                  key:   'policy_id',
+                  value: 'namespaced-ns1-ap1'
+                }, // matches 2nd policy
+                {
+                  key:   'allowed',
+                  value: 'false',
+                  type:  'bool'
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    });
+
+    const result = await jaegerTraces(config);
+
+    expect(store.dispatch).toHaveBeenCalledTimes(6);
+
+    // Verify that it returns the scaffold with data for each policy
+    // The final structure from `scaffoldPolicyTrace` is an array of { policyName, cluster, traces: [] }
+    expect(result).toHaveLength(2);
+    expect(result[0].policyName).toBe('cap1');
+    expect(result[0].cluster).toBe('mock-cluster');
+    expect(result[0].traces).toHaveLength(2);
+    expect(result[0].traces[0]).toMatchObject({
+      id:      'trace-111',
+      allowed: true
+    });
+
+    expect(result[1].policyName).toBe('ap1');
+    expect(result[1].traces).toHaveLength(2);
+
+    // Also check that 'kubewarden/updatePolicyTraces' was dispatched for each trace
+    // The code calls store.dispatch('kubewarden/updatePolicyTraces', { policyName, cluster, updatedTrace: ...})
+    // inside scaffoldPolicyTrace
+    // So we expect 2 additional dispatch calls for updating policyTraces:
+    // - 1 for 'cap1'
+    // - 1 for 'ap1'
+    //
+    // The total number of dispatch calls might be 4:
+    //   2 for cluster/request + 2 for 'kubewarden/updatePolicyTraces'
+    //
+    const updateCalls = store.dispatch.mock.calls.filter(
+      (c) => c[0] === 'kubewarden/updatePolicyTraces'
+    );
+
+    expect(updateCalls).toHaveLength(4);
+
+    // Example: check one of them
+    expect(updateCalls[0][1]).toMatchObject({
+      policyName:   'cap1',
+      updatedTrace: {
+        allowed: true
+        // ...
+      }
+    });
+  });
+
+  it('fetches traces for a single policy when "policy" is provided and returns the scaffold', async() => {
+    const config = {
+      store,
+      queryService: {
+        metadata: {
+          name:      'jaeger-query',
+          namespace: 'jaeger-ns'
+        }
+      },
+      resource:     'kubewarden.admissionpolicy',
+      policy:       {
+        kind:     'AdmissionPolicy',
+        metadata: {
+          name:      'ap2',
+          namespace: 'ns2'
+        },
+        spec: { mode: 'protect' }
+      }
+    };
+
+    // Return a single trace
+    store.dispatch.mockResolvedValue({
+      data: [
+        {
+          traceID: 'trace-555',
+          spans:   [
+            {
+              operationName: 'validation',
+              startTime:     987654321,
+              duration:      60000,
+              tags:          [
+                {
+                  key:   'policy_id',
+                  value: 'namespaced-ns2-ap2'
+                },
+                {
+                  key:   'allowed',
+                  value: 'true',
+                  type:  'bool'
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    });
+
+    const result = await jaegerTraces(config);
+
+    expect(store.dispatch).toHaveBeenCalledTimes(2);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].policyName).toBe('ap2');
+    expect(result[0].traces).toHaveLength(1);
+    expect(result[0].traces[0].id).toBe('trace-555');
+  });
+
+  it('throws an error if policy is undefined (and no relatedPolicies), returning null', async() => {
+    // We'll check console.warn for the error message
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const config = {
+      store,
+      queryService: { metadata: { name: 'jaeger-query' } },
+      resource:     'kubewarden.admissionpolicy'
+      // no policy or relatedPolicies
+    };
+
+    const result = await jaegerTraces(config);
+
+    expect(result).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Error fetching Jaeger traces:')
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('handles errors in the request gracefully and returns null', async() => {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const error = new Error('Request failed');
+
+    store.dispatch.mockRejectedValueOnce(error);
+
+    const config = {
+      store,
+      queryService: { metadata: { name: 'jaeger-query' } },
+      resource:     'kubewarden.admissionpolicy',
+      policy:       {
+        kind:     'AdmissionPolicy',
+        metadata: {
+          name:      'ap2',
+          namespace: 'ns2'
+        },
+        spec: { mode: 'protect' }
+      }
+    };
+
+    const result = await jaegerTraces(config);
+
+    expect(result).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Error fetching Jaeger traces: Error: Request failed'
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/pkg/kubewarden/modules/__tests__/metricsConfig.spec.ts
+++ b/pkg/kubewarden/modules/__tests__/metricsConfig.spec.ts
@@ -1,0 +1,211 @@
+import { Store } from 'vuex';
+import { MONITORING } from '@shell/config/types';
+
+import {
+  CatalogApp,
+  Service,
+  ServiceMonitorSpec
+} from '@kubewarden/types';
+import {
+  monitoringIsConfigured,
+  serviceMonitorsConfigured,
+  findServiceMonitor,
+  addKubewardenServiceMonitor
+} from '@kubewarden/modules/metricsConfig';
+
+jest.mock('@kubewarden/utils/handle-growl', () => ({ handleGrowl: jest.fn() }));
+
+const mockControllerApp: CatalogApp = {
+  metadata: {
+    name:      'controller-app',
+    namespace: 'controller-ns'
+  }
+} as CatalogApp;
+
+const mockServiceMonitorSpec: ServiceMonitorSpec = {
+  namespaceSelector: { matchNames: ['controller-ns'] },
+  selector:          { matchLabels: { 'app-label': 'match-me' } }
+};
+
+const mockServiceMonitorConfiguredExpected = {
+  namespace: true,
+  selectors: [{ 'app-label': true }]
+};
+
+function createMockStore(getSchemaFor = true) {
+  return {
+    getters: {
+      'cluster/schemaFor': jest.fn().mockReturnValue(getSchemaFor),
+      currentCluster:      { id: 'mock-cluster' }
+    },
+    dispatch: jest.fn()
+  } as unknown as Store<any>;
+}
+
+describe('monitoringIsConfigured', () => {
+  it('should return true if at least one service monitor spec is configured correctly', () => {
+    const config = {
+      serviceMonitorSpec: [mockServiceMonitorSpec],
+      controllerApp:      mockControllerApp,
+      policyServerSvcs:   [{ metadata: { labels: { 'app-label': 'match-me' } } } as Service]
+    };
+
+    const configuredArray = serviceMonitorsConfigured(config);
+
+    // It should be an array; and monitoringIsConfigured should return true.
+    expect(Array.isArray(configuredArray)).toBe(true);
+    expect(configuredArray).toHaveLength(1);
+    expect(configuredArray[0]).toEqual(mockServiceMonitorConfiguredExpected);
+    expect(monitoringIsConfigured(config)).toBe(true);
+  });
+
+  it('should return false if no spec is configured correctly', () => {
+    // Use a spec that does not have a matching namespace
+    const badSpec = {
+      namespaceSelector: { matchNames: ['wrong-ns'] },
+      selector:          { matchLabels: { 'app-label': 'nomatch' } }
+    };
+    const config = {
+      serviceMonitorSpec: [badSpec],
+      controllerApp:      mockControllerApp,
+      policyServerSvcs:   [{ metadata: { labels: { 'app-label': 'match-me' } } } as Service]
+    };
+
+    expect(monitoringIsConfigured(config)).toBe(false);
+  });
+});
+
+describe('serviceMonitorsConfigured', () => {
+  it('should return an array of configured objects based on serviceMonitorSpec', () => {
+    const config = {
+      serviceMonitorSpec: [mockServiceMonitorSpec],
+      controllerApp:      mockControllerApp,
+      policyServerSvcs:   [
+        { metadata: { labels: { 'app-label': 'match-me' } } } as Service,
+        { metadata: { labels: { 'app-label': 'no-match' } } } as Service
+      ]
+    };
+
+    const result = serviceMonitorsConfigured(config);
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(1);
+    expect(result[0].namespace).toBe(true);
+    expect(result[0].selectors).toEqual([{ 'app-label': true }, { 'app-label': false }]);
+  });
+
+  it('should return false if serviceMonitorSpec is not provided', () => {
+    const config = {
+      serviceMonitorSpec: undefined,
+      controllerApp:      mockControllerApp,
+      policyServerSvcs:   []
+    };
+
+    expect(serviceMonitorsConfigured(config)).toBe(false);
+  });
+});
+
+describe('findServiceMonitor', () => {
+  it('should return a matching ServiceMonitor based on selector.matchLabels', () => {
+    const policyObj = { spec: { policyServer: 'mock' } };
+    const allServiceMonitors = [
+      { spec: { selector: { matchLabels: { app: 'kubewarden-policy-server-mock' } } } },
+      { spec: { selector: { matchLabels: { app: 'other' } } } }
+    ];
+    const config = {
+      policyObj,
+      allServiceMonitors,
+      store: {}
+    };
+    const result = findServiceMonitor(config);
+
+    expect(result).toEqual(allServiceMonitors[0]);
+  });
+
+  it('should return undefined if no matching ServiceMonitor is found', () => {
+    const policyServerObj = { id: 'nonexistent' };
+    const allServiceMonitors = [
+      { spec: { selector: { matchLabels: { app: 'kubewarden-policy-server-mock' } } } }
+    ];
+    const config = {
+      policyServerObj,
+      allServiceMonitors,
+      store: {}
+    };
+    const result = findServiceMonitor(config);
+
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('addKubewardenServiceMonitor', () => {
+  let mockStore: any;
+
+  beforeEach(() => {
+    mockStore = createMockStore(true);
+    jest.clearAllMocks();
+  });
+
+  it('should create a new ServiceMonitor when schema exists and none is provided', async() => {
+    const fakeServiceMonitorTemplate = { save: jest.fn().mockResolvedValue(undefined) };
+
+    mockStore.dispatch.mockResolvedValueOnce(fakeServiceMonitorTemplate);
+
+    const config = {
+      store:           mockStore,
+      policyServerObj: { id: 'mock' },
+      controllerNs:    'controller-ns'
+    };
+
+    await addKubewardenServiceMonitor(config);
+
+    expect(mockStore.getters['cluster/schemaFor']).toHaveBeenCalledWith(MONITORING.SERVICEMONITOR);
+    expect(mockStore.dispatch).toHaveBeenCalledWith('cluster/create', expect.objectContaining({
+      type:     MONITORING.SERVICEMONITOR,
+      metadata: expect.objectContaining({
+        name:      'mock',
+        namespace: 'controller-ns'
+      })
+    }));
+    expect(fakeServiceMonitorTemplate.save).toHaveBeenCalled();
+  });
+
+  it('should call handleGrowl if saving the created ServiceMonitor fails', async() => {
+    const fakeServiceMonitorTemplate = { save: jest.fn().mockRejectedValue(new Error('Save failed')) };
+
+    mockStore.dispatch.mockResolvedValueOnce(fakeServiceMonitorTemplate);
+    const handleGrowlSpy = jest.spyOn(require('@kubewarden/utils/handle-growl'), 'handleGrowl');
+    const config = {
+      store:           mockStore,
+      policyServerObj: { id: 'mock' },
+      controllerNs:    'controller-ns'
+    };
+
+    await addKubewardenServiceMonitor(config);
+    expect(handleGrowlSpy).toHaveBeenCalled();
+  });
+
+  it('should do nothing if a ServiceMonitor is already provided', async() => {
+    const config = {
+      store:           mockStore,
+      policyServerObj: { id: 'mock' },
+      controllerNs:    'controller-ns',
+      serviceMonitor:  {}
+    };
+
+    await addKubewardenServiceMonitor(config);
+    expect(mockStore.dispatch).not.toHaveBeenCalledWith('cluster/create', expect.anything());
+  });
+
+  it('should do nothing if the schema for ServiceMonitor is falsy', async() => {
+    const badStore = createMockStore(false);
+    const config = {
+      store:           badStore,
+      policyServerObj: { id: 'mock' },
+      controllerNs:    'controller-ns'
+    };
+
+    await addKubewardenServiceMonitor(config);
+    expect(badStore.dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/pkg/kubewarden/modules/__tests__/metricsConfig.spec.ts
+++ b/pkg/kubewarden/modules/__tests__/metricsConfig.spec.ts
@@ -15,7 +15,7 @@ import {
 
 jest.mock('@kubewarden/utils/handle-growl', () => ({ handleGrowl: jest.fn() }));
 
-const mockControllerApp: CatalogApp = {
+const mockControllerAppLegacy: CatalogApp = {
   metadata: {
     name:      'controller-app',
     namespace: 'controller-ns'
@@ -46,7 +46,7 @@ describe('monitoringIsConfigured', () => {
   it('should return true if at least one service monitor spec is configured correctly', () => {
     const config = {
       serviceMonitorSpec: [mockServiceMonitorSpec],
-      controllerApp:      mockControllerApp,
+      controllerApp:      mockControllerAppLegacy,
       policyServerSvcs:   [{ metadata: { labels: { 'app-label': 'match-me' } } } as Service]
     };
 
@@ -67,7 +67,7 @@ describe('monitoringIsConfigured', () => {
     };
     const config = {
       serviceMonitorSpec: [badSpec],
-      controllerApp:      mockControllerApp,
+      controllerApp:      mockControllerAppLegacy,
       policyServerSvcs:   [{ metadata: { labels: { 'app-label': 'match-me' } } } as Service]
     };
 
@@ -79,7 +79,7 @@ describe('serviceMonitorsConfigured', () => {
   it('should return an array of configured objects based on serviceMonitorSpec', () => {
     const config = {
       serviceMonitorSpec: [mockServiceMonitorSpec],
-      controllerApp:      mockControllerApp,
+      controllerApp:      mockControllerAppLegacy,
       policyServerSvcs:   [
         { metadata: { labels: { 'app-label': 'match-me' } } } as Service,
         { metadata: { labels: { 'app-label': 'no-match' } } } as Service
@@ -97,7 +97,7 @@ describe('serviceMonitorsConfigured', () => {
   it('should return false if serviceMonitorSpec is not provided', () => {
     const config = {
       serviceMonitorSpec: undefined,
-      controllerApp:      mockControllerApp,
+      controllerApp:      mockControllerAppLegacy,
       policyServerSvcs:   []
     };
 

--- a/pkg/kubewarden/modules/__tests__/policies.spec.ts
+++ b/pkg/kubewarden/modules/__tests__/policies.spec.ts
@@ -1,0 +1,21 @@
+import { kwDefaultsHelmChartSettings } from '@kubewarden/modules/policies';
+
+describe('kwDefaultsHelmChartSettings', () => {
+  it('should return true if uiPluginVersion is less than or equal to 1.4.1 regardless of kwDefaultsVersion', () => {
+    expect(kwDefaultsHelmChartSettings('0.0.0', '1.4.1')).toBe(true);
+    expect(kwDefaultsHelmChartSettings('1.9.9', '1.4.1')).toBe(true);
+    expect(kwDefaultsHelmChartSettings('2.0.0', '1.0.0')).toBe(true);
+  });
+
+  it('should return true if uiPluginVersion is greater than 1.4.1 and kwDefaultsVersion is greater than 1.9.9', () => {
+    // Example: uiPluginVersion "1.4.2" > "1.4.1" and "2.0.0" > "1.9.9"
+    expect(kwDefaultsHelmChartSettings('2.0.0', '1.4.2')).toBe(true);
+    expect(kwDefaultsHelmChartSettings('2.1.0', '2.0.0')).toBe(true);
+  });
+
+  it('should return false if uiPluginVersion is greater than 1.4.1 and kwDefaultsVersion is not greater than 1.9.9', () => {
+    // "1.9.9" is not strictly greater than "1.9.9", and "1.8.0" is less than "1.9.9"
+    expect(kwDefaultsHelmChartSettings('1.9.9', '1.4.2')).toBe(false);
+    expect(kwDefaultsHelmChartSettings('1.8.0', '1.4.2')).toBe(false);
+  });
+});

--- a/pkg/kubewarden/modules/__tests__/policyReporter.spec.ts
+++ b/pkg/kubewarden/modules/__tests__/policyReporter.spec.ts
@@ -1,7 +1,7 @@
 import { Store } from 'vuex';
 
 import * as policyReporterModule from '@kubewarden/modules/policyReporter';
-import { KUBEWARDEN } from '@kubewarden/types';
+import { KUBEWARDEN, Severity, Result } from '@kubewarden/types';
 import { mockPolicyReport, mockClusterPolicyReport } from '@tests/unit/mocks/policyReports';
 import { mockControllerApp } from '@tests/unit/mocks/controllerApp';
 
@@ -18,7 +18,6 @@ jest.mock('lodash/isEmpty', () => ({
 
 jest.mock('@shell/utils/string', () => ({ randomStr: jest.fn().mockReturnValue('randomString') }));
 
-// Create a mock store that now includes additional getters used by the module
 const mockStore = {
   getters: {
     'cluster/schemaFor':               jest.fn(),
@@ -29,7 +28,7 @@ const mockStore = {
     'kubewarden/controllerApp':        mockControllerApp
   },
   dispatch: jest.fn()
-}  as unknown as Store<any>;
+} as unknown as Store<any>;
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -37,16 +36,16 @@ beforeEach(() => {
   // Clear the report cache so each test runs fresh.
   policyReporterModule.__clearReportCache();
 
-  // Return a dummy schema for any type
+  // Return a mock schema for any type.
   mockStore.getters['cluster/schemaFor'].mockReturnValue(true);
 
-  // Assume no reports are cached by default so that findAll is triggered
+  // Assume no reports are cached by default so that findAll is triggered.
   mockStore.getters['cluster/all'].mockReturnValue([]);
 
-  // Default: no report is found by resource ID
+  // Default: no report is found by resource ID.
   mockStore.getters['kubewarden/reportByResourceId'].mockReturnValue(null);
 
-  // Polyfill requestIdleCallback for test environment if missing
+  // Polyfill requestIdleCallback for test environment if missing.
   global.requestIdleCallback = (cb) => setTimeout(cb, 0);
 });
 
@@ -89,23 +88,49 @@ describe('getReports', () => {
     );
     expect(mockStore.dispatch).toHaveBeenCalledWith('kubewarden/regenerateSummaryMap');
   });
+
+  it('should use cache for subsequent calls within TTL', async() => {
+    (mockStore.dispatch as jest.Mock).mockResolvedValueOnce([mockPolicyReport]);
+    const firstCall = await policyReporterModule.getReports(mockStore, false);
+    const secondCall = await policyReporterModule.getReports(mockStore, false);
+
+    // For the first call, dispatch is invoked for:
+    //   - 'cluster/findAll' (if needed) / update action inside processReportsInBatches,
+    //   - and 'kubewarden/regenerateSummaryMap'
+    // For the second call, the cached promise is used for the report fetch, but regenerateSummaryMap is still dispatched.
+    // Therefore, we expect a total of 4 dispatch calls.
+    expect((mockStore.dispatch as jest.Mock).mock.calls.length).toBe(4);
+    expect(firstCall).toEqual(secondCall);
+  });
+});
+
+describe('__clearReportCache', () => {
+  it('should clear the report cache so that new fetches occur', async() => {
+    (mockStore.dispatch as jest.Mock).mockResolvedValueOnce([mockPolicyReport]);
+    // First call caches the result.
+    await policyReporterModule.getReports(mockStore, false);
+    // Clear cache.
+    policyReporterModule.__clearReportCache();
+    // Second call should trigger dispatch again.
+    await policyReporterModule.getReports(mockStore, false);
+    // Expect dispatch to have been called again (i.e. more than previous count).
+    expect((mockStore.dispatch as jest.Mock).mock.calls.length).toBeGreaterThan(2);
+  });
 });
 
 describe('generateSummaryMap', () => {
   it('should correctly summarize policy report results', () => {
     // Create a mock report that meets the criteria:
-    // - It is managed by kubewarden.
-    // - It has a scope with namespace and name.
-    // - It includes one result marked as FAIL.
+    // - Managed by kubewarden.
+    // - Has a scope with namespace and name.
+    // - Includes one result marked as FAIL.
     const mockReport = {
       metadata: { labels: { 'app.kubernetes.io/managed-by': 'kubewarden' } },
       scope:    {
         name:      'resource1',
         namespace: 'default'
       },
-      results: [
-        { result: 'FAIL' }
-      ]
+      results: [{ result: 'FAIL' }]
     };
 
     const storeState = {
@@ -127,13 +152,63 @@ describe('generateSummaryMap', () => {
   });
 });
 
-describe('getLinkForPolicy', () => {
-  it('should return a route for a given policy report result', () => {
-    // Ensure the schema getter returns true for both types.
-    mockStore.getters['cluster/schemaFor'].mockImplementation((type: string) => type === KUBEWARDEN.CLUSTER_ADMISSION_POLICY || type === KUBEWARDEN.ADMISSION_POLICY
-    );
+describe('getFilteredReport', () => {
+  it('should return null if schema is falsy', async() => {
+    mockStore.getters['cluster/schemaFor'].mockReturnValueOnce(false);
+    const report = await policyReporterModule.getFilteredReport(mockStore, {
+      id:   'abc',
+      type: 'mock'
+    });
 
-    // For a cluster-level policy report (no namespace provided in properties)
+    expect(report).toBeNull();
+  });
+
+  it('should return null if no reports are fetched', async() => {
+    mockStore.getters['cluster/schemaFor'].mockReturnValue(true);
+    // Simulate getReports returning an empty array.
+    (mockStore.dispatch as jest.Mock).mockResolvedValueOnce([]);
+    const report = await policyReporterModule.getFilteredReport(mockStore, {
+      id:       'abc',
+      type:     'mock',
+      metadata: { namespace: 'default' }
+    });
+
+    expect(report).toBeNull();
+  });
+
+  it('should return a filtered report if found in store getters', async() => {
+    mockStore.getters['cluster/schemaFor'].mockReturnValue(true);
+    (mockStore.dispatch as jest.Mock).mockResolvedValueOnce([mockPolicyReport]);
+    // Simulate that reportByResourceId returns a report.
+    mockStore.getters['kubewarden/reportByResourceId'].mockReturnValueOnce(mockPolicyReport);
+    const report = await policyReporterModule.getFilteredReport(mockStore, {
+      id:       'abc',
+      type:     'mock',
+      metadata: { namespace: 'default' }
+    });
+
+    expect(report).toEqual(mockPolicyReport);
+  });
+
+  it('should return null if an error occurs during fetching', async() => {
+    mockStore.getters['cluster/schemaFor'].mockReturnValue(true);
+    // (mockStore.dispatch as jest.Mock).mockRejectedValueOnce(new Error('Test error'));
+    const report = await policyReporterModule.getFilteredReport(mockStore, {
+      id:       'abc',
+      type:     'mock',
+      metadata: { namespace: 'default' }
+    });
+
+    expect(report).toBeNull();
+  });
+});
+
+describe('getLinkForPolicy', () => {
+  it('should return a route for a given cluster-level policy report result', () => {
+    // Ensure the schema getter returns true for the cluster admission policy.
+    mockStore.getters['cluster/schemaFor'].mockImplementation((type: string) => type === KUBEWARDEN.CLUSTER_ADMISSION_POLICY);
+
+    // For a cluster-level policy report (no namespace provided)
     const report1 = {
       policy:     'clusterwide-example-policy',
       properties: { 'policy-name': 'example-policy' }
@@ -148,6 +223,11 @@ describe('getLinkForPolicy', () => {
         resource: KUBEWARDEN.CLUSTER_ADMISSION_POLICY
       })
     });
+  });
+
+  it('should return a route for a namespaced policy report result', () => {
+    // Ensure the schema getter returns true for the namespaced admission policy.
+    mockStore.getters['cluster/schemaFor'].mockImplementation((type: string) => type === KUBEWARDEN.ADMISSION_POLICY);
 
     // For a namespaced policy report
     const report2 = {
@@ -171,8 +251,98 @@ describe('getLinkForPolicy', () => {
   });
 });
 
+describe('getLinkForResource', () => {
+  it('should return undefined if report.scope is empty', () => {
+    const report = { scope: {} };
+    const route = policyReporterModule.getLinkForResource(report);
+
+    expect(route).toBeUndefined();
+  });
+
+  it('should return a namespaced route for a core resource', () => {
+    // Simulate a core resource by setting kind to a value that our module will detect.
+    const report = {
+      scope: {
+        kind:      'Pod',
+        name:      'mypod',
+        namespace: 'myns'
+      }
+    };
+    const route = policyReporterModule.getLinkForResource(report);
+
+    expect(route).toEqual({
+      name:   'c-cluster-product-resource-namespace-id',
+      params: {
+        resource:  'pod', // kind.toLowerCase()
+        id:        'mypod',
+        namespace: 'myns'
+      }
+    });
+  });
+
+  it('should return a non-namespaced route for a core resource without a namespace', () => {
+    const report = {
+      scope: {
+        kind: 'Pod',
+        name: 'mypod'
+      }
+    };
+    const route = policyReporterModule.getLinkForResource(report);
+
+    expect(route).toEqual({
+      name:   'c-cluster-product-resource-id',
+      params: {
+        resource: 'pod',
+        id:       'mypod'
+      }
+    });
+  });
+});
+
+describe('colorForResult', () => {
+  it('should return "text-error" for FAIL', () => {
+    expect(policyReporterModule.colorForResult(Result.FAIL)).toBe('text-error');
+  });
+  it('should return "sizzle-warning" for ERROR', () => {
+    expect(policyReporterModule.colorForResult(Result.ERROR)).toBe('sizzle-warning');
+  });
+  it('should return "text-success" for PASS', () => {
+    expect(policyReporterModule.colorForResult(Result.PASS)).toBe('text-success');
+  });
+  it('should return "text-warning" for WARN', () => {
+    expect(policyReporterModule.colorForResult(Result.WARN)).toBe('text-warning');
+  });
+  it('should return "text-darker" for SKIP', () => {
+    expect(policyReporterModule.colorForResult(Result.SKIP)).toBe('text-darker');
+  });
+  it('should return "text-muted" for an unknown result', () => {
+    expect(policyReporterModule.colorForResult('unknown' as Result)).toBe('text-muted');
+  });
+});
+
+describe('colorForSeverity', () => {
+  it('should return "bg-info" for INFO', () => {
+    expect(policyReporterModule.colorForSeverity(Severity.INFO)).toBe('bg-info');
+  });
+  it('should return "bg-warning" for LOW', () => {
+    expect(policyReporterModule.colorForSeverity(Severity.LOW)).toBe('bg-warning');
+  });
+  it('should return "bg-warning" for MEDIUM', () => {
+    expect(policyReporterModule.colorForSeverity(Severity.MEDIUM)).toBe('bg-warning');
+  });
+  it('should return "bg-warning" for HIGH', () => {
+    expect(policyReporterModule.colorForSeverity(Severity.HIGH)).toBe('bg-warning');
+  });
+  it('should return "bg-critical" for CRITICAL', () => {
+    expect(policyReporterModule.colorForSeverity(Severity.CRITICAL)).toBe('bg-critical');
+  });
+  it('should return "bg-muted" for an unknown severity', () => {
+    expect(policyReporterModule.colorForSeverity('unknown' as Severity)).toBe('bg-muted');
+  });
+});
+
 describe('newPolicyReportCompatible', () => {
-  it('should be incompatible with OLD data structure for a controller app version >= 1.10.0 && UI plugin version >= 1.4.0', () => {
+  it('should be compatible with OLD data structure for controllerAppVersion >= 1.10.0 and UI plugin version >= 1.4.0', () => {
     const result = policyReporterModule.newPolicyReportCompatible('1.10.0', '1.4.0');
 
     expect(result).toStrictEqual({
@@ -181,7 +351,7 @@ describe('newPolicyReportCompatible', () => {
     });
   });
 
-  it('should be incompatible with NEW data structure for a controller app version >= 1.11.0 && UI plugin version >= 1.3.6', () => {
+  it('should be incompatible with NEW data structure for controllerAppVersion >= 1.11.0 and UI plugin version >= 1.3.6', () => {
     const result = policyReporterModule.newPolicyReportCompatible('1.11.0', '1.3.6');
 
     expect(result).toStrictEqual({

--- a/pkg/kubewarden/modules/__tests__/policyReporter.spec.ts
+++ b/pkg/kubewarden/modules/__tests__/policyReporter.spec.ts
@@ -3,7 +3,7 @@ import { Store } from 'vuex';
 import * as policyReporterModule from '@kubewarden/modules/policyReporter';
 import { KUBEWARDEN, Severity, Result } from '@kubewarden/types';
 import { mockPolicyReport, mockClusterPolicyReport } from '@tests/unit/mocks/policyReports';
-import { mockControllerApp } from '@tests/unit/mocks/controllerApp';
+import { mockControllerAppLegacy } from '@tests/unit/mocks/controllerApp';
 
 jest.mock('lodash/isEmpty', () => ({
   __esModule: true,
@@ -25,7 +25,7 @@ const mockStore = {
     'kubewarden/reportByResourceId':   jest.fn(),
     'kubewarden/policyReports':        [mockPolicyReport],
     'kubewarden/clusterPolicyReports': [mockClusterPolicyReport],
-    'kubewarden/controllerApp':        mockControllerApp
+    'kubewarden/controllerApp':        mockControllerAppLegacy
   },
   dispatch: jest.fn()
 } as unknown as Store<any>;

--- a/pkg/kubewarden/plugins/__tests__/kubewarden-class.spec.ts
+++ b/pkg/kubewarden/plugins/__tests__/kubewarden-class.spec.ts
@@ -1,0 +1,196 @@
+import KubewardenModel, {
+  colorForStatus,
+  colorForPolicyServerState,
+  stateSort,
+  colorForTraceStatus,
+  getLatestVersion
+} from '@kubewarden/plugins/kubewarden-class';
+
+jest.mock('@kubewarden/formatters/PolicyStatus.vue', () => ({ default: 'mockComponent' }));
+
+describe('KubewardenModel', () => {
+  let instance: KubewardenModel;
+  let rootGetters: Record<string, jest.Mock>;
+  let dispatch: jest.Mock;
+
+  beforeEach(() => {
+    rootGetters = {
+      'cluster/all':    jest.fn(),
+      'management/all': jest.fn()
+    };
+
+    dispatch = jest.fn();
+
+    instance = new KubewardenModel({});
+
+    // Override read-only properties on the instance:
+    Object.defineProperty(instance, '$rootGetters', { value: rootGetters });
+    Object.defineProperty(instance, '$dispatch', { value: dispatch });
+
+    instance.status = {};
+    instance.metadata = {};
+    instance.spec = {};
+  });
+
+  describe('allServices', () => {
+    it('returns services from rootGetters if available', async() => {
+      const services = [{ id: 1 }];
+
+      rootGetters['cluster/all'].mockReturnValue(services);
+
+      const result = await instance.allServices();
+
+      expect(result).toBe(services);
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it('dispatches cluster/findAll if no services are found', async() => {
+      rootGetters['cluster/all'].mockReturnValue([]);
+      dispatch.mockResolvedValue(['fetched service']);
+
+      const result = await instance.allServices();
+
+      expect(dispatch).toHaveBeenCalledWith(
+        'cluster/findAll',
+        { type: expect.any(String) },
+        { root: true }
+      );
+      expect(result).toEqual(['fetched service']);
+    });
+  });
+
+  describe('detailPageHeaderBadgeOverride', () => {
+    it('returns status.policyStatus', () => {
+      instance.status = { policyStatus: 'active' };
+      expect(instance.detailPageHeaderBadgeOverride).toBe('active');
+    });
+  });
+
+  describe('componentForBadge', () => {
+    it('returns the component when detailPageHeaderBadgeOverride exists', () => {
+      instance.status = { policyStatus: 'active' };
+      expect(instance.componentForBadge).toBe('mockComponent');
+    });
+
+    it('returns null when detailPageHeaderBadgeOverride is falsy', () => {
+      instance.status = {};
+      expect(instance.componentForBadge).toBeNull();
+    });
+  });
+
+  describe('namespaceSelector', () => {
+    it('returns true if metadata.namespace is in RANCHER_NAMESPACES', () => {
+      // Assuming "cattle-system" is in the Rancher namespaces list.
+      instance.metadata = { namespace: 'cattle-system' };
+      instance.spec = { namespaceSelector: { matchExpressions: [] } };
+      expect(instance.namespaceSelector).toBe(true);
+    });
+
+    it('returns false when no matching selector is found', () => {
+      instance.metadata = { namespace: 'other' };
+      instance.spec = { namespaceSelector: { matchExpressions: [] } };
+      expect(instance.namespaceSelector).toBe(false);
+    });
+  });
+
+  describe('haveComponent', () => {
+    it('returns true if the component exists', () => {
+      expect(instance.haveComponent('kubewarden/admission')).toBe(true);
+    });
+
+    it('returns false if the component does not exist', () => {
+      expect(instance.haveComponent('nonexistent')).toBe(false);
+    });
+  });
+
+  describe('importComponent', () => {
+    it('throws an error if no name is provided', () => {
+      expect(() => instance.importComponent('')).toThrow('Name required');
+    });
+
+    it('returns a function when a valid name is provided', () => {
+      const importer = instance.importComponent('testComponent');
+
+      expect(typeof importer).toBe('function');
+    });
+  });
+
+  describe('toggleUpdateMode', () => {
+    it('dispatches cluster/promptModal with proper parameters', () => {
+      instance.toggleUpdateMode();
+      expect(dispatch).toHaveBeenCalledWith(
+        'cluster/promptModal',
+        expect.objectContaining({ component: 'UpdateModeDialog' }),
+        { root: true }
+      );
+    });
+  });
+
+  describe('Exported functions', () => {
+    describe('colorForStatus', () => {
+      it('returns correct colors for known statuses', () => {
+        expect(colorForStatus('unschedulable')).toBe('text-error');
+        expect(colorForStatus('pending')).toBe('text-info');
+        expect(colorForStatus('active')).toBe('text-success');
+      });
+      it('returns default color for unknown status', () => {
+        expect(colorForStatus('unknown')).toBe('text-warning');
+      });
+    });
+
+    describe('colorForPolicyServerState', () => {
+      it('returns "info" if state does not match any known state', () => {
+        expect(colorForPolicyServerState('non-existent')).toBe('info');
+      });
+    });
+
+    describe('stateSort', () => {
+      it('returns the correct sort string based on the color', () => {
+        expect(stateSort('text-error', 'Item')).toMatch(/^1 Item/);
+        expect(stateSort('bg-warning', 'Item')).toMatch(/^2 Item/);
+        expect(stateSort('text-success', 'Item')).toMatch(/^4 Item/);
+        // For an unknown color the default should be used:
+        expect(stateSort('text-unknown', 'Item')).toMatch(/^8 Item/);
+      });
+    });
+
+    describe('colorForTraceStatus', () => {
+      it('returns correct color for allowed', () => {
+        expect(colorForTraceStatus('allowed')).toBe('success');
+      });
+      it('returns correct color for denied', () => {
+        expect(colorForTraceStatus('denied')).toBe('error');
+      });
+      it('returns correct color for mutated', () => {
+        expect(colorForTraceStatus('mutated')).toBe('warning');
+      });
+      it('returns default color for an unknown status', () => {
+        expect(colorForTraceStatus('unknown')).toBe('success');
+      });
+    });
+
+    describe('getLatestVersion', () => {
+      it('returns the latest version excluding prereleases when showPreRelease is false', () => {
+        const versions = [
+          { version: '1.0.0' },
+          { version: '1.0.1-beta' },
+          { version: '1.0.2' }
+        ];
+        const storeWithoutPreRelease = { getters: { 'prefs/get': () => false } };
+
+        expect(getLatestVersion(storeWithoutPreRelease as any, versions)).toBe('1.0.2');
+      });
+
+      it('returns the latest version including prereleases when showPreRelease is true', () => {
+        const versions = [
+          { version: '1.0.0' },
+          { version: '1.0.1-beta' },
+          { version: '1.0.2' }
+        ];
+        const storeWithPreRelease = { getters: { 'prefs/get': () => true } };
+
+        expect(getLatestVersion(storeWithPreRelease as any, versions)).toBe('1.0.2');
+      });
+    });
+  });
+});

--- a/pkg/kubewarden/plugins/__tests__/kubewarden-class.spec.ts
+++ b/pkg/kubewarden/plugins/__tests__/kubewarden-class.spec.ts
@@ -30,6 +30,8 @@ describe('KubewardenModel', () => {
     instance.status = {};
     instance.metadata = {};
     instance.spec = {};
+
+    jest.spyOn(console, 'warn').mockImplementation(jest.fn());
   });
 
   describe('allServices', () => {

--- a/pkg/kubewarden/plugins/__tests__/policy-class.spec.ts
+++ b/pkg/kubewarden/plugins/__tests__/policy-class.spec.ts
@@ -1,0 +1,267 @@
+import { REPO_TYPE, REPO, CHART, VERSION } from '@shell/config/query-params';
+import { KUBERNETES, WORKSPACE_ANNOTATION } from '@shell/config/labels-annotations';
+
+import { KUBEWARDEN_CHARTS, KUBEWARDEN_PRODUCT_NAME } from '@kubewarden/types';
+
+import PolicyModel from '@kubewarden/plugins/policy-class';
+import KubewardenModel from '@kubewarden/plugins/kubewarden-class';
+
+describe('PolicyModel', () => {
+  let instance: PolicyModel;
+  let rootGetters: Record<string, any>;
+  let dispatch: jest.Mock;
+
+  beforeEach(() => {
+    // Pass a mock data object to avoid errors in parent constructor.
+    instance = new PolicyModel({});
+
+    // Override read-only Vuex properties using Object.defineProperty.
+    rootGetters = { currentCluster: { id: 'cluster-id' } };
+    dispatch = jest.fn();
+
+    Object.defineProperty(instance, '$rootGetters', { value: rootGetters });
+    Object.defineProperty(instance, '$dispatch', { value: dispatch });
+
+    // Reset metadata, spec, and status
+    instance.metadata = {};
+    instance.spec = {};
+    instance.status = {};
+  });
+
+  describe('_availableActions', () => {
+    let parentActionsSpy: jest.SpyInstance<any, []>;
+    const mockAction = {
+      action:  'mock',
+      label:   'Mock',
+      icon:    'mock-icon',
+      enabled: true
+    };
+
+    afterEach(() => {
+      if (parentActionsSpy) {
+        parentActionsSpy.mockRestore();
+      }
+    });
+
+    it('should prepend policy mode action when spec.mode is "monitor" and not deployed with fleet', () => {
+      // Simulate parent's _availableActions getter returning an array.
+      parentActionsSpy = jest.spyOn(KubewardenModel.prototype, '_availableActions', 'get').mockReturnValue([mockAction]);
+
+      instance.spec.mode = 'monitor';
+      // Ensure not deployed with fleet.
+      instance.metadata.annotations = {};
+
+      const actions = instance._availableActions;
+
+      expect(actions[0]).toMatchObject({
+        action:  'toggleUpdateMode',
+        enabled: true,
+        label:   'Update Mode',
+        icon:    'icon icon-fw icon-notifier'
+      });
+      // Ensure the parent's action is still included.
+      expect(actions).toEqual(expect.arrayContaining([mockAction]));
+    });
+
+    it('should filter out fleet actions when deployed with fleet', () => {
+      parentActionsSpy = jest.spyOn(KubewardenModel.prototype, '_availableActions', 'get').mockReturnValue([
+        {
+          action: 'goToEdit',
+          label:  'Edit'
+        },
+        {
+          action: 'toggleUpdateMode',
+          label:  'Update Mode'
+        },
+        {
+          action: 'other',
+          label:  'Other'
+        }
+      ]);
+
+      // Simulate deployment with fleet by setting the workspace annotation.
+      instance.metadata.annotations = { [WORKSPACE_ANNOTATION]: 'some-workspace' };
+      instance.spec.mode = 'monitor';
+
+      const actions = instance._availableActions;
+      const actionKeys = actions.map((a) => a.action);
+
+      // These actions should be filtered out.
+      expect(actionKeys).not.toContain('goToEdit');
+      expect(actionKeys).not.toContain('toggleUpdateMode');
+      // Other actions should remain.
+      expect(actionKeys).toContain('other');
+    });
+  });
+
+  describe('kubewardenDefaultsRoute', () => {
+    it('returns route object when helmChart is present with valid semver', () => {
+      instance.metadata.labels = { 'helm.sh/chart': 'kubewarden-defaults-1.2.3' };
+
+      const route = instance.kubewardenDefaultsRoute;
+      const expectedQuery = {
+        [REPO_TYPE]: 'cluster',
+        [REPO]:      'kubewarden-charts',
+        [CHART]:     'kubewarden-defaults',
+        [VERSION]:   '1.2.3'
+      };
+
+      expect(route).toEqual({
+        name:   'c-cluster-apps-charts-install',
+        params: { cluster: 'cluster-id' },
+        query:  expectedQuery
+      });
+    });
+
+    it('returns null when helmChart is not present', () => {
+      instance.metadata.labels = {};
+      expect(instance.kubewardenDefaultsRoute).toBeNull();
+    });
+  });
+
+  describe('isKubewardenDefaultPolicy', () => {
+    it('returns true when labels match Helm management, defaults, and part-of', () => {
+      instance.metadata.labels = {
+        [KUBERNETES.MANAGED_BY]:     'Helm',
+        [KUBERNETES.MANAGED_NAME]:   KUBEWARDEN_CHARTS.DEFAULTS,
+        'app.kubernetes.io/part-of': KUBEWARDEN_PRODUCT_NAME
+      };
+      expect(instance.isKubewardenDefaultPolicy).toBe(true);
+    });
+
+    it('returns false when one label does not match', () => {
+      instance.metadata.labels = {
+        [KUBERNETES.MANAGED_BY]:     'Helm',
+        [KUBERNETES.MANAGED_NAME]:   'not-default',
+        'app.kubernetes.io/part-of': KUBEWARDEN_PRODUCT_NAME
+      };
+      expect(instance.isKubewardenDefaultPolicy).toBe(false);
+    });
+  });
+
+  describe('isDeployedWithFleet', () => {
+    it('returns truthy when WORKSPACE_ANNOTATION exists and applied annotation is missing', () => {
+      instance.metadata.annotations = { [WORKSPACE_ANNOTATION]: 'workspace-value' };
+      expect(instance.isDeployedWithFleet).toBeTruthy();
+    });
+
+    it('returns falsy when applied annotation exists', () => {
+      instance.metadata.annotations = {
+        [WORKSPACE_ANNOTATION]:            'workspace-value',
+        'objectset.rio.cattle.io/applied': 'something'
+      };
+      expect(instance.isDeployedWithFleet).toBeFalsy();
+    });
+  });
+
+  describe('isApplied', () => {
+    it('returns the applied annotation value', () => {
+      instance.metadata.annotations = { 'objectset.rio.cattle.io/applied': 'applied-value' };
+      expect(instance.isApplied).toBe('applied-value');
+    });
+  });
+
+  describe('source', () => {
+    it('returns "kubewarden-defaults" when policy is default, not deployed with fleet, and not applied', () => {
+      instance.metadata.labels = {
+        [KUBERNETES.MANAGED_BY]:     'Helm',
+        [KUBERNETES.MANAGED_NAME]:   KUBEWARDEN_CHARTS.DEFAULTS,
+        'app.kubernetes.io/part-of': KUBEWARDEN_PRODUCT_NAME
+      };
+      instance.metadata.annotations = {}; // not deployed with fleet, not applied
+      expect(instance.source).toBe('kubewarden-defaults');
+    });
+
+    it('returns "fleet" when deployed with fleet and not applied', () => {
+      instance.metadata.annotations = {
+        [WORKSPACE_ANNOTATION]:            'workspace-value',
+        'objectset.rio.cattle.io/applied': ''
+      };
+      // Even if default labels are present, deployment with fleet takes precedence.
+      instance.metadata.labels = {
+        [KUBERNETES.MANAGED_BY]:     'Helm',
+        [KUBERNETES.MANAGED_NAME]:   KUBEWARDEN_CHARTS.DEFAULTS,
+        'app.kubernetes.io/part-of': KUBEWARDEN_PRODUCT_NAME
+      };
+      expect(instance.source).toBe('fleet');
+    });
+
+    it('returns "template" when artifacthub/pkg annotation is present', () => {
+      instance.metadata.annotations = { 'artifacthub/pkg': 'some-pkg' };
+      expect(instance.source).toBe('template');
+    });
+
+    it('returns "custom" by default', () => {
+      instance.metadata.annotations = {};
+      instance.metadata.labels = {};
+      expect(instance.source).toBe('custom');
+    });
+  });
+
+  describe('stateDisplay', () => {
+    let stateDisplaySpy: jest.SpyInstance<any, any>;
+
+    afterEach(() => {
+      if (stateDisplaySpy) {
+        stateDisplaySpy.mockRestore();
+      }
+    });
+
+    it('calls stateDisplay with status.policyStatus when present', () => {
+      instance.status = { policyStatus: 'active' };
+      stateDisplaySpy = jest.spyOn(require('@shell/plugins/dashboard-store/resource-class'), 'stateDisplay').mockReturnValue('Active Display');
+
+      expect(instance.stateDisplay).toBe('Active Display');
+      expect(stateDisplaySpy).toHaveBeenCalledWith('active');
+    });
+
+    it('calls stateDisplay with no arguments when status.policyStatus is absent', () => {
+      instance.status = {};
+      stateDisplaySpy = jest.spyOn(require('@shell/plugins/dashboard-store/resource-class'), 'stateDisplay').mockReturnValue('Default Display');
+
+      expect(instance.stateDisplay).toBe('Default Display');
+      expect(stateDisplaySpy).toHaveBeenCalledWith();
+    });
+  });
+
+  describe('colorForState', () => {
+    let colorForStatusSpy: jest.SpyInstance<any, any>;
+    let colorForStateFnSpy: jest.SpyInstance<any, any>;
+
+    afterEach(() => {
+      if (colorForStatusSpy) {
+        colorForStatusSpy.mockRestore();
+      }
+      if (colorForStateFnSpy) {
+        colorForStateFnSpy.mockRestore();
+      }
+    });
+
+    it('returns colorForStatus(status) if status.policyStatus exists', () => {
+      instance.status = { policyStatus: 'active' };
+      colorForStatusSpy = jest.spyOn(require('@kubewarden/plugins/kubewarden-class'), 'colorForStatus').mockReturnValue('text-active');
+      const result = instance.colorForState;
+
+      expect(result).toBe('text-active');
+      expect(colorForStatusSpy).toHaveBeenCalledWith('active');
+    });
+
+    it('returns colorForState(this.state) if status.policyStatus is absent', () => {
+      instance.status = {};
+      Object.defineProperty(instance, 'state', { value: 'pending' });
+      colorForStateFnSpy = jest.spyOn(require('@shell/plugins/dashboard-store/resource-class'), 'colorForState').mockReturnValue('text-pending');
+      const result = instance.colorForState;
+
+      expect(result).toBe('text-pending');
+      expect(colorForStateFnSpy).toHaveBeenCalledWith('pending');
+    });
+  });
+
+  describe('stateBackground', () => {
+    it('converts colorForState from "text-" to "bg-"', () => {
+      // Override colorForState getter to return a known value.
+      jest.spyOn(instance, 'colorForState', 'get').mockReturnValue('text-success');
+      expect(instance.stateBackground).toBe('bg-success');
+    });
+  });
+});

--- a/pkg/kubewarden/plugins/__tests__/policy-server-class.spec.ts
+++ b/pkg/kubewarden/plugins/__tests__/policy-server-class.spec.ts
@@ -1,0 +1,301 @@
+import { POD, WORKLOAD_TYPES } from '@shell/config/types';
+import PolicyServerModel from '@kubewarden/plugins/policy-server-class';
+import KubewardenModel from '@kubewarden/plugins/kubewarden-class';
+
+describe('PolicyServerModel', () => {
+  let instance: PolicyServerModel;
+  let rootGetters: Record<string, any>;
+  let dispatch: jest.Mock;
+
+  beforeEach(() => {
+    instance = new PolicyServerModel({});
+
+    rootGetters = { 'cluster/canList': jest.fn().mockReturnValue(true) };
+    dispatch = jest.fn();
+
+    Object.defineProperty(instance, '$rootGetters', { value: rootGetters });
+    Object.defineProperty(instance, '$dispatch', { value: dispatch });
+
+    instance.metadata = { name: 'policy-server-1' };
+  });
+
+  describe('_availableActions', () => {
+    let parentActionsSpy: jest.SpyInstance<any, []>;
+
+    afterEach(() => {
+      parentActionsSpy?.mockRestore();
+    });
+
+    it('should prepend openLogs action to parent available actions', () => {
+      parentActionsSpy = jest
+        .spyOn(KubewardenModel.prototype, '_availableActions', 'get')
+        .mockReturnValue([{
+          action: 'mockAction',
+          label:  'Mock'
+        }]);
+
+      const actions = instance._availableActions;
+
+      expect(actions[0]).toEqual({
+        action:  'openLogs',
+        enabled: true,
+        icon:    'icon icon-fw icon-chevron-right',
+        label:   'View Logs'
+      });
+      expect(actions).toContainEqual({
+        action: 'mockAction',
+        label:  'Mock'
+      });
+    });
+  });
+
+  describe('allRelatedPolicies', () => {
+    it('returns related policies that match metadata name', async() => {
+      const policy1 = { spec: { policyServer: 'policy-server-1' } };
+      const policy2 = { spec: { policyServer: 'other' } };
+
+      dispatch.mockImplementation((action) => {
+        if (action === 'cluster/findAll') {
+          return Promise.resolve([policy1, policy2]);
+        }
+      });
+
+      const fn = instance.allRelatedPolicies;
+      const result = await fn();
+
+      // Expect two of the same policies to be returned because they are both considered different types (i.e. ClusterPolicy and Policy).
+      expect(result).toEqual([policy1, policy1]);
+    });
+
+    it('handles errors and logs a warning', async() => {
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      dispatch.mockRejectedValue(new Error('Test error'));
+      const fn = instance.allRelatedPolicies;
+
+      await fn();
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Error fetching related policies:'));
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('policyGauges', () => {
+    it('returns an empty object if no related policies are found', async() => {
+      // Stub allRelatedPolicies to return null.
+      jest.spyOn(instance, 'allRelatedPolicies', 'get').mockReturnValue(() => Promise.resolve(null));
+      const gauges = await instance.policyGauges();
+
+      expect(gauges).toEqual({});
+    });
+
+    it('returns gauges with counts incremented based on related policies stateDisplay', async() => {
+      // Create related policies with stateDisplay values.
+      const relatedPolicies = [
+        { stateDisplay: 'Active' },
+        { stateDisplay: 'Pending' },
+        { stateDisplay: 'Active' }
+      ];
+
+      // Stub allRelatedPolicies to return these policies.
+      jest.spyOn(instance, 'allRelatedPolicies', 'get').mockReturnValue(() => Promise.resolve(relatedPolicies));
+
+      // Stub colorForStatus to return a predictable value.
+      const colorForStatusSpy = jest.spyOn(
+        require('@kubewarden/plugins/kubewarden-class'),
+        'colorForStatus'
+      ).mockImplementation((...args: unknown[]) => {
+        const status = args[0] as string;
+
+        return `text-${ status.toLowerCase() }`;
+      });
+
+
+      const gauges = await instance.policyGauges();
+
+      expect(gauges).toEqual({
+        Active:  {
+          color: 'active',
+          count: 2
+        },
+        Pending: {
+          color: 'pending',
+          count: 1
+        }
+      });
+      colorForStatusSpy.mockRestore();
+    });
+  });
+
+  describe('tracesGauges', () => {
+    it('returns an empty object if policyTraces is empty', () => {
+      const fn = instance.tracesGauges;
+      const result = fn([]);
+
+      expect(result).toEqual({});
+    });
+
+    it('calculates gauges correctly for denied and mutated traces', () => {
+      // Create sample policy traces.
+      const policyTraces = [
+        {
+          traces: [
+            {
+              allowed: false,
+              mode:    'protect',
+              mutated: false
+            },
+            {
+              allowed: false,
+              mode:    'protect',
+              mutated: false
+            },
+            {
+              allowed: true,
+              mode:    'protect',
+              mutated: true
+            },
+            {
+              allowed: true,
+              mode:    'monitor',
+              mutated: false
+            } // Should be skipped.
+          ]
+        }
+      ];
+
+      // Stub colorForTraceStatus to return predictable colors.
+      const colorForTraceStatusSpy = jest.spyOn(
+        require('@kubewarden/plugins/kubewarden-class'),
+        'colorForTraceStatus'
+      ).mockImplementation((...args: unknown[]) => {
+        const status = args[0] as string;
+
+        return status === 'denied' ? 'red' : status === 'mutated' ? 'yellow' : '';
+      });
+
+      const fn = instance.tracesGauges;
+      const result = fn(policyTraces);
+
+      expect(result).toEqual({
+        Denied:  {
+          color: 'red',
+          count: 2
+        },
+        Mutated: {
+          color: 'yellow',
+          count: 1
+        }
+      });
+      colorForTraceStatusSpy.mockRestore();
+    });
+  });
+
+  describe('matchingDeployment', () => {
+    it('returns matching deployment using dispatch', async() => {
+      const deployment = { id: 'deployment1' };
+
+      dispatch.mockResolvedValue(deployment);
+      const fn = instance.matchingDeployment;
+      const result = await fn();
+
+      expect(dispatch).toHaveBeenCalledWith(
+        'cluster/findMatching',
+        {
+          type:     WORKLOAD_TYPES.DEPLOYMENT,
+          selector: `kubewarden/policy-server=${ instance.metadata?.name }`
+        },
+        { root: true }
+      );
+      expect(result).toBe(deployment);
+    });
+
+    it('handles errors and logs a warning', async() => {
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      dispatch.mockRejectedValue(new Error('Deployment error'));
+      const fn = instance.matchingDeployment;
+
+      await fn();
+      expect(consoleSpy).toHaveBeenCalledWith('Error matching policy-server to deployment', expect.any(Error));
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('matchingPods', () => {
+    it('returns matching pods using dispatch', async() => {
+      const pods = [{ id: 'pod1' }];
+
+      dispatch.mockResolvedValue(pods);
+      const fn = instance.matchingPods;
+      const result = await fn();
+
+      expect(dispatch).toHaveBeenCalledWith(
+        'cluster/findMatching',
+        {
+          type:     POD,
+          selector: `app=kubewarden-policy-server-${ instance.metadata?.name }`
+        },
+        { root: true }
+      );
+      expect(result).toBe(pods);
+    });
+
+    it('handles errors and logs a warning', async() => {
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      dispatch.mockRejectedValue(new Error('Pods error'));
+      const fn = instance.matchingPods;
+
+      await fn();
+      expect(consoleSpy).toHaveBeenCalledWith('Error matching policy-server to pod', expect.any(Error));
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('openLogs', () => {
+    it('dispatches wm/open if matching pods are found', async() => {
+      const podArray = [{ id: 'pod1' }];
+
+      // Stub matchingPods to return podArray.
+      jest.spyOn(instance, 'matchingPods', 'get').mockReturnValue(() => Promise.resolve(podArray));
+
+      // Set properties needed for openLogs.
+      instance.id = 'server1';
+      Object.defineProperty(instance, 'metadata', { value: { name: 'policy-server-1' } });
+
+      await instance.openLogs();
+      expect(dispatch).toHaveBeenCalledWith(
+        'wm/open',
+        {
+          id:        'server1-logs',
+          label:     'policy-server-1',
+          icon:      'file',
+          component: 'ContainerLogs',
+          attrs:     { pod: podArray[0] }
+        },
+        { root: true }
+      );
+    });
+
+    it('does not dispatch wm/open if matching pods are empty', async() => {
+      // Stub matchingPods to return an empty array.
+      jest.spyOn(instance, 'matchingPods', 'get').mockReturnValue(() => Promise.resolve([]));
+      await instance.openLogs();
+      expect(dispatch).not.toHaveBeenCalledWith(
+        'wm/open',
+        expect.any(Object),
+        { root: true }
+      );
+    });
+
+    it('handles errors and logs a warning in openLogs', async() => {
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      // Stub matchingPods to reject.
+      jest.spyOn(instance, 'matchingPods', 'get').mockReturnValue(() => Promise.reject(new Error('Pod error')));
+      await instance.openLogs();
+      expect(consoleSpy).toHaveBeenCalledWith('Error dispatching console for pod', expect.any(Error));
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/pkg/kubewarden/store/kubewarden/__tests__/kubewardenStore.spec.ts
+++ b/pkg/kubewarden/store/kubewarden/__tests__/kubewardenStore.spec.ts
@@ -1,0 +1,132 @@
+import storeModule, { StateConfig } from '@kubewarden/store/kubewarden/index';
+
+describe('Kubewarden Vuex Store Module', () => {
+  let state: StateConfig;
+
+  beforeEach(() => {
+    state = storeModule.specifics.state();
+  });
+
+  describe('Initial State', () => {
+    it('should initialize with default values', () => {
+      expect(state.airGapped).toBe(false);
+      expect(state.fleetRepos).toEqual([]);
+      expect(state.hideBannerDefaults).toBe(false);
+      expect(state.hideBannerArtifactHub).toBe(false);
+      expect(state.hideBannerAirgapPolicy).toBe(false);
+      expect(state.controllerApp).toBeNull();
+      expect(state.kubewardenCrds).toEqual([]);
+      expect(state.loadingReports).toBe(false);
+      expect(state.policyReports).toEqual([]);
+      expect(state.clusterPolicyReports).toEqual([]);
+      expect(state.reportMap).toEqual({});
+      expect(state.summaryMap).toEqual({});
+      expect(state.policyTraces).toEqual([]);
+      expect(state.refreshingCharts).toBe(false);
+    });
+  });
+
+  describe('Getters', () => {
+    const { getters } = storeModule.specifics;
+
+    it('should return the airGapped state', () => {
+      expect(getters.airGapped(state)).toBe(false);
+    });
+
+    it('should return hideBannerDefaults state', () => {
+      expect(getters.hideBannerDefaults(state)).toBe(false);
+    });
+
+    it('should return hideBannerArtifactHub state', () => {
+      expect(getters.hideBannerArtifactHub(state)).toBe(false);
+    });
+
+    it('should return hideBannerAirgapPolicy state', () => {
+      expect(getters.hideBannerAirgapPolicy(state)).toBe(false);
+    });
+
+    it('should return controllerApp state', () => {
+      expect(getters.controllerApp(state)).toBeNull();
+    });
+
+    it('should return kubewardenCrds state', () => {
+      expect(getters.kubewardenCrds(state)).toEqual([]);
+    });
+
+    it('should return loadingReports state', () => {
+      expect(getters.loadingReports(state)).toBe(false);
+    });
+
+    it('should return policyReports state', () => {
+      expect(getters.policyReports(state)).toEqual([]);
+    });
+
+    it('should return clusterPolicyReports state', () => {
+      expect(getters.clusterPolicyReports(state)).toEqual([]);
+    });
+
+    it('should return policyTraces state', () => {
+      expect(getters.policyTraces(state)).toEqual([]);
+    });
+
+    it('should return refreshingCharts state', () => {
+      expect(getters.refreshingCharts(state)).toBe(false);
+    });
+
+    describe('reportByResourceId', () => {
+      it('should return the report for a given resource id from reportMap', () => {
+        const resourceId = 'test-resource';
+
+        state.reportMap = { [resourceId]: { report: 'some-report-data' } };
+
+        const report = getters.reportByResourceId(state)(resourceId);
+
+        expect(report).toEqual({ report: 'some-report-data' });
+      });
+
+      it('should return undefined for a non-existent resource id', () => {
+        const report = getters.reportByResourceId(state)('non-existent');
+
+        expect(report).toBeUndefined();
+      });
+    });
+
+    describe('summaryByResourceId', () => {
+      it('should return the default summary when a resource id is not found', () => {
+        const summary = getters.summaryByResourceId(state)('unknown-resource');
+
+        expect(summary).toEqual({
+          pass:  0,
+          fail:  0,
+          warn:  0,
+          error: 0,
+          skip:  0
+        });
+      });
+
+      it('should return the summary from summaryMap if available', () => {
+        const resourceId = 'existing-resource';
+
+        state.summaryMap = {
+          [resourceId]: {
+            pass:  3,
+            fail:  1,
+            warn:  2,
+            error: 0,
+            skip:  1
+          }
+        };
+
+        const summary = getters.summaryByResourceId(state)(resourceId);
+
+        expect(summary).toEqual({
+          pass:  3,
+          fail:  1,
+          warn:  2,
+          error: 0,
+          skip:  1
+        });
+      });
+    });
+  });
+});

--- a/pkg/kubewarden/store/kubewarden/__tests__/mutations.spec.ts
+++ b/pkg/kubewarden/store/kubewarden/__tests__/mutations.spec.ts
@@ -1,0 +1,307 @@
+import mutations from '@kubewarden/store/kubewarden/mutations';
+import { StateConfig } from '@kubewarden/store/kubewarden/index';
+
+describe('Vuex Mutations', () => {
+  let state: StateConfig;
+
+  beforeEach(() => {
+    state = {
+      airGapped:              false,
+      fleetRepos:             [],
+      hideBannerDefaults:     false,
+      hideBannerArtifactHub:  false,
+      hideBannerAirgapPolicy: false,
+      controllerApp:          null,
+      kubewardenCrds:         [],
+      loadingReports:         false,
+      policyReports:          [],
+      clusterPolicyReports:   [],
+      reportMap:              {},
+      summaryMap:             {},
+      policyTraces:           [],
+      refreshingCharts:       false
+    };
+  });
+
+  it('updateAirGapped sets airGapped state', () => {
+    mutations.updateAirGapped(state, true);
+    expect(state.airGapped).toBe(true);
+  });
+
+  it('updateHideBannerDefaults sets hideBannerDefaults state', () => {
+    mutations.updateHideBannerDefaults(state, true);
+    expect(state.hideBannerDefaults).toBe(true);
+  });
+
+  it('updateHideBannerArtifactHub sets hideBannerArtifactHub state', () => {
+    mutations.updateHideBannerArtifactHub(state, true);
+    expect(state.hideBannerArtifactHub).toBe(true);
+  });
+
+  it('updateHideBannerAirgapPolicy sets hideBannerAirgapPolicy state', () => {
+    mutations.updateHideBannerAirgapPolicy(state, true);
+    expect(state.hideBannerAirgapPolicy).toBe(true);
+  });
+
+  it('updateControllerApp adds new controllerApp if none exists', () => {
+    const app = {
+      id:       'app1',
+      metadata: { version: '1.0' },
+      spec:     { config: 'a' },
+      status:   { running: true }
+    };
+
+    mutations.updateControllerApp(state, app);
+    expect(state.controllerApp).toEqual(app);
+  });
+
+  it('updateControllerApp updates controllerApp if id matches', () => {
+    const existingApp = {
+      id:       'app1',
+      metadata: { version: '1.0' },
+      spec:     { config: 'a' },
+      status:   { running: false }
+    };
+
+    state.controllerApp = existingApp;
+    const updatedApp = {
+      id:       'app1',
+      metadata: { version: '2.0' },
+      spec:     { config: 'b' },
+      status:   { running: true }
+    };
+
+    mutations.updateControllerApp(state, updatedApp);
+    expect(state.controllerApp).toEqual(updatedApp);
+  });
+
+  it('removeControllerApp nullifies controllerApp if id matches', () => {
+    const app = {
+      id:       'app1',
+      metadata: {},
+      spec:     {},
+      status:   {}
+    };
+
+    state.controllerApp = app;
+    mutations.removeControllerApp(state, app);
+    expect(state.controllerApp).toBeNull();
+  });
+
+  it('updateKubewardenCrds adds a new CRD if it does not exist', () => {
+    const crd = {
+      metadata: { name: 'crd1' },
+      spec:     { a: 1 },
+      status:   {}
+    };
+
+    mutations.updateKubewardenCrds(state, crd);
+    expect(state.kubewardenCrds).toContainEqual(crd);
+  });
+
+  it('updateKubewardenCrds updates an existing CRD if it exists', () => {
+    const crd = {
+      metadata: { name: 'crd1' },
+      spec:     { a: 1 },
+      status:   {}
+    };
+
+    state.kubewardenCrds.push(crd);
+    const updatedCrd = {
+      metadata: { name: 'crd1' },
+      spec:     { a: 2 },
+      status:   { updated: true }
+    };
+
+    mutations.updateKubewardenCrds(state, updatedCrd);
+    expect(state.kubewardenCrds).toContainEqual(updatedCrd);
+  });
+
+  it('removeKubewardenCrds removes a CRD if it exists', () => {
+    const crd = {
+      metadata: { name: 'crd1' },
+      spec:     {},
+      status:   {}
+    };
+
+    state.kubewardenCrds.push(crd);
+    mutations.removeKubewardenCrds(state, crd);
+    expect(state.kubewardenCrds).not.toContain(crd);
+  });
+
+  it('updateLoadingReports sets loadingReports state', () => {
+    mutations.updateLoadingReports(state, true);
+    expect(state.loadingReports).toBe(true);
+  });
+
+  it('updateReportsBatch updates reports and reportMap', () => {
+    // Setup initial policyReports and reportMap
+    const report1 = {
+      id:      'r1',
+      scope:   { name: 'ns1' },
+      results: [1],
+      summary: {}
+    };
+    const report2 = {
+      id:      'r2',
+      scope:   { name: 'ns2' },
+      results: [2],
+      summary: {}
+    };
+
+    state.policyReports = [report1];
+    state.reportMap = { ns1: report1 };
+
+    // Create updated versions: update report1 and add report2
+    const updatedReport1 = {
+      id:      'r1',
+      scope:   { name: 'ns1' },
+      results: [10],
+      summary: { total: 10 }
+    };
+
+    mutations.updateReportsBatch(state, {
+      reportArrayKey: 'policyReports',
+      updatedReports: [updatedReport1, report2]
+    });
+
+    expect(state.policyReports.find((r) => r.id === 'r1')).toEqual(updatedReport1);
+    expect(state.policyReports.find((r) => r.id === 'r2')).toEqual(report2);
+
+    const resourceId1 = updatedReport1.scope?.name || updatedReport1.id;
+    const resourceId2 = report2.scope?.name || report2.id;
+
+    expect(state.reportMap[resourceId1]).toEqual(updatedReport1);
+    expect(state.reportMap[resourceId2]).toEqual(report2);
+  });
+
+  it('setSummaryMap merges new summary data into state.summaryMap', () => {
+    state.summaryMap = {
+      key1: {
+        pass:  1,
+        fail:  1,
+        warn:  1,
+        error: 1,
+        skip:  1
+      }
+    };
+    const newSummary = {
+      key2: {
+        pass:  2,
+        fail:  2,
+        warn:  2,
+        error: 2,
+        skip:  2
+      }
+    };
+
+    mutations.setSummaryMap(state, newSummary);
+    expect(state.summaryMap).toEqual({
+      key1: {
+        pass:  1,
+        fail:  1,
+        warn:  1,
+        error: 1,
+        skip:  1
+      },
+      key2: {
+        pass:  2,
+        fail:  2,
+        warn:  2,
+        error: 2,
+        skip:  2
+      }
+    });
+  });
+
+  it('removePolicyReportById removes a policy report by id', () => {
+    const report = { id: 'r1' };
+
+    state.policyReports = [report];
+    mutations.removePolicyReportById(state, 'r1');
+    expect(state.policyReports).not.toContain(report);
+  });
+
+  describe('updatePolicyTraces', () => {
+    it('adds a new policy trace object if none exists for the policyName', () => {
+      const payload = {
+        policyName:   'policy1',
+        cluster:      'cluster1',
+        updatedTrace: { id: 't1' }
+      };
+
+      mutations.updatePolicyTraces(state, payload);
+      expect(state.policyTraces).toContainEqual({
+        policyName: 'policy1',
+        cluster:    'cluster1',
+        traces:     [payload.updatedTrace]
+      });
+    });
+
+    it('adds a new trace to an existing policy trace object if not found', () => {
+      state.policyTraces = [{
+        policyName: 'policy1',
+        cluster:    'cluster1',
+        traces:     [{ id: 't1' }]
+      }];
+      const payload = {
+        policyName:   'policy1',
+        cluster:      'cluster1',
+        updatedTrace: { id: 't2' }
+      };
+
+      mutations.updatePolicyTraces(state, payload);
+      const policyTrace = state.policyTraces.find((pt) => pt.policyName === 'policy1');
+
+      expect(policyTrace.traces).toContainEqual({ id: 't1' });
+      expect(policyTrace.traces).toContainEqual({ id: 't2' });
+    });
+
+    it('updates an existing trace if it exists', () => {
+      state.policyTraces = [{
+        policyName: 'policy1',
+        cluster:    'cluster1',
+        traces:     [{
+          id:    't1',
+          value: 'old'
+        }]
+      }];
+      const payload = {
+        policyName:   'policy1',
+        cluster:      'cluster1',
+        updatedTrace: {
+          id:    't1',
+          value: 'new'
+        }
+      };
+
+      mutations.updatePolicyTraces(state, payload);
+      const policyTrace = state.policyTraces.find((pt) => pt.policyName === 'policy1');
+
+      expect(policyTrace.traces).toContainEqual({
+        id:    't1',
+        value: 'new'
+      });
+    });
+  });
+
+  describe('removeTraceById', () => {
+    it('removes a trace by id from an existing policy trace object', () => {
+      state.policyTraces = [{
+        policyName: 'policy1',
+        cluster:    'cluster1',
+        traces:     [{ id: 't1' }, { id: 't2' }]
+      }];
+      mutations.removeTraceById(state, { policyName: 'policy1' }, { id: 't1' });
+      const policyTrace = state.policyTraces.find((pt) => pt.policyName === 'policy1');
+
+      expect(policyTrace.traces).not.toContainEqual({ id: 't1' });
+      expect(policyTrace.traces).toContainEqual({ id: 't2' });
+    });
+  });
+
+  it('updateRefreshingCharts sets refreshingCharts state', () => {
+    mutations.updateRefreshingCharts(state, true);
+    expect(state.refreshingCharts).toBe(true);
+  });
+});

--- a/pkg/kubewarden/store/kubewarden/mutations.ts
+++ b/pkg/kubewarden/store/kubewarden/mutations.ts
@@ -167,21 +167,27 @@ export default {
   updatePolicyTraces(state: StateConfig, val: { policyName: string, cluster: string, updatedTrace: PolicyTrace }) {
     const { policyName, cluster, updatedTrace } = val;
     const existingPolicyObj = state.policyTraces.find((traceObj: PolicyTraceConfig) => traceObj.policyName === policyName);
-    let existingTrace = existingPolicyObj?.traces.find((trace: PolicyTrace) => trace.id === updatedTrace.id);
 
-    if (existingTrace) {
-      existingTrace = updatedTrace;
-    } else if (!existingPolicyObj) {
+    if (existingPolicyObj) {
+      const idx = existingPolicyObj.traces.findIndex((trace: PolicyTrace) => trace.id === updatedTrace.id);
+
+      if (idx !== -1) {
+        // Replace the existing trace with the updated trace.
+        existingPolicyObj.traces.splice(idx, 1, updatedTrace);
+      } else {
+        // If the trace doesn't exist, add it.
+        existingPolicyObj.traces.push(updatedTrace);
+      }
+    } else {
+      // If no policy trace object exists for the policy, add a new one.
       state.policyTraces.push({
         policyName,
         cluster,
         traces: [updatedTrace]
       });
-    } else {
-      // If the trace doesn't exist, add it to the store
-      existingPolicyObj?.traces.push(updatedTrace);
     }
   },
+
   /**
    * Searches for the existing policy object and removes a trace by the traceID from the store
    * @param state
@@ -192,7 +198,7 @@ export default {
     const existingPolicyObj = state.policyTraces.find((traceObj: PolicyTraceConfig) => traceObj.policyName === policy.policyName);
     const idx = existingPolicyObj?.traces.findIndex((trace: PolicyTrace) => trace.id === updatedTrace.id);
 
-    if (idx && idx !== -1) {
+    if (idx !== undefined && idx !== -1) {
       existingPolicyObj?.traces.splice(idx, 1);
     }
   },

--- a/pkg/kubewarden/utils/__tests__/custom-routing.spec.ts
+++ b/pkg/kubewarden/utils/__tests__/custom-routing.spec.ts
@@ -1,0 +1,79 @@
+import { KUBEWARDEN_PRODUCT_NAME } from '@kubewarden/types';
+
+import { rootKubewardenRoute, createKubewardenRoute } from '@kubewarden/utils/custom-routing';
+
+describe('Kubewarden Route Utilities', () => {
+  describe('rootKubewardenRoute', () => {
+    it('should return the default route config', () => {
+      const route = rootKubewardenRoute();
+
+      expect(route).toEqual({
+        name:   `c-cluster-${ KUBEWARDEN_PRODUCT_NAME }`,
+        params: { product: KUBEWARDEN_PRODUCT_NAME },
+        meta:   {
+          pkg:     KUBEWARDEN_PRODUCT_NAME,
+          product: KUBEWARDEN_PRODUCT_NAME
+        }
+      });
+    });
+  });
+
+  describe('createKubewardenRoute', () => {
+    it('should return default config when no config is provided', () => {
+      const route = createKubewardenRoute();
+
+      expect(route).toEqual({
+        name:   `c-cluster-${ KUBEWARDEN_PRODUCT_NAME }-resource`,
+        params: { product: KUBEWARDEN_PRODUCT_NAME },
+        meta:   {
+          pkg:     KUBEWARDEN_PRODUCT_NAME,
+          product: KUBEWARDEN_PRODUCT_NAME
+        }
+      });
+    });
+
+    it('should override the name if provided', () => {
+      const customName = 'custom-route';
+      const route = createKubewardenRoute({ name: customName });
+
+      expect(route.name).toBe(customName);
+    });
+
+    it('should merge provided params with root params', () => {
+      const extraParams = { extra: 'value' };
+      const route = createKubewardenRoute({ params: extraParams });
+
+      expect(route.params).toEqual({
+        product: KUBEWARDEN_PRODUCT_NAME,
+        extra:   'value'
+      });
+    });
+
+    it('should merge provided meta with root meta', () => {
+      const extraMeta = { extraMeta: 'value' };
+      const route = createKubewardenRoute({ meta: extraMeta });
+
+      expect(route.meta).toEqual({
+        pkg:       KUBEWARDEN_PRODUCT_NAME,
+        product:   KUBEWARDEN_PRODUCT_NAME,
+        extraMeta: 'value'
+      });
+    });
+
+    it('should override root meta values with provided meta', () => {
+      const overrideMeta = { pkg: 'override' };
+      const route = createKubewardenRoute({ meta: overrideMeta });
+
+      expect(route.meta).toEqual({
+        pkg:     'override',
+        product: KUBEWARDEN_PRODUCT_NAME
+      });
+    });
+
+    it('should override the default name when provided', () => {
+      const route = createKubewardenRoute({ name: 'custom-name' });
+
+      expect(route.name).toBe('custom-name');
+    });
+  });
+});

--- a/pkg/kubewarden/utils/__tests__/determine-airgap.spec.ts
+++ b/pkg/kubewarden/utils/__tests__/determine-airgap.spec.ts
@@ -1,0 +1,74 @@
+import { isAirgap } from '@kubewarden/utils/determine-airgap';
+
+describe('isAirgap', () => {
+  let store: any;
+  let context: { store: any };
+
+  beforeEach(() => {
+    store = {
+      dispatch: jest.fn(),
+      getters:  {}
+    };
+    context = { store };
+  });
+
+  it('returns false and updates airGapped as false when request returns status 200', async() => {
+    store.dispatch.mockResolvedValueOnce(null);
+    store.getters['management/byId'] = jest.fn().mockReturnValue({ value: 'example.com,other.com' });
+    store.dispatch.mockResolvedValueOnce({ _status: 200 });
+
+    const result = await isAirgap(context);
+
+    expect(store.dispatch).toHaveBeenCalledWith('kubewarden/updateAirGapped', false);
+    expect(result).toBe(false);
+  });
+
+  it('returns false and updates airGapped as false when request returns status 302', async() => {
+    store.dispatch.mockResolvedValueOnce(null);
+    store.getters['management/byId'] = jest.fn().mockReturnValue({ value: 'example.com,other.com' });
+    store.dispatch.mockResolvedValueOnce({ _status: 302 });
+
+    const result = await isAirgap(context);
+
+    expect(store.dispatch).toHaveBeenCalledWith('kubewarden/updateAirGapped', false);
+    expect(result).toBe(false);
+  });
+
+  it('returns true and updates airGapped as true when request returns non-success status', async() => {
+    store.dispatch.mockResolvedValueOnce(null);
+    store.getters['management/byId'] = jest.fn().mockReturnValue({ value: 'example.com,other.com' });
+    store.dispatch.mockResolvedValueOnce({ _status: 404 });
+
+    const result = await isAirgap(context);
+
+    expect(store.dispatch).toHaveBeenCalledWith('kubewarden/updateAirGapped', true);
+    expect(result).toBe(true);
+  });
+
+  it('returns false and updates airGapped as false when whitelist is empty', async() => {
+    store.dispatch.mockResolvedValueOnce(null);
+    store.getters['management/byId'] = jest.fn().mockReturnValue({});
+
+    const result = await isAirgap(context);
+
+    expect(store.dispatch).toHaveBeenCalledWith('kubewarden/updateAirGapped', false);
+    expect(result).toBe(false);
+  });
+
+  it('catches errors, logs them, dispatches updateAirGapped false and returns false', async() => {
+    const error = new Error('Test error');
+
+    store.dispatch.mockRejectedValueOnce(error);
+    store.getters['kubewarden/airGapped'] = false;
+
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const result = await isAirgap(context);
+
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(store.dispatch).toHaveBeenCalledWith('kubewarden/updateAirGapped', false);
+    expect(result).toBe(false);
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/pkg/kubewarden/utils/__tests__/duration-format.spec.ts
+++ b/pkg/kubewarden/utils/__tests__/duration-format.spec.ts
@@ -1,0 +1,53 @@
+import { formatDuration } from '@kubewarden/utils/duration-format';
+
+const ONE_MILLISECOND = 1000;                   // 1ms in microseconds
+const ONE_SECOND = 1000 * ONE_MILLISECOND;        // 1,000,000
+const ONE_MINUTE = 60 * ONE_SECOND;               // 60,000,000
+
+describe('formatDuration', () => {
+  it('should return a decimal representation for small durations (seconds)', () => {
+    // 1.5 seconds: 1,500,000 microseconds
+    expect(formatDuration(1500000)).toBe('1.5s');
+  });
+
+  it('should combine primary and secondary units when applicable (minutes and seconds)', () => {
+    // 5 minutes and 30 seconds:
+    // 5 minutes = 5 * ONE_MINUTE = 300,000,000 microseconds
+    // 30 seconds = 30 * ONE_SECOND = 30,000,000 microseconds
+    // Total = 330,000,000 microseconds
+    expect(formatDuration(330000000)).toBe('5m 30s');
+  });
+
+  it('should return only the primary unit when the secondary unit rounds to 0', () => {
+    // Exactly 5 minutes (300,000,000 microseconds) should return "5m"
+    expect(formatDuration(300000000)).toBe('5m');
+  });
+
+  it('should handle very small durations (microseconds)', () => {
+    // 123 microseconds should return "123μs"
+    expect(formatDuration(123)).toBe('123μs');
+  });
+
+  it('should correctly format durations in hours and minutes', () => {
+    // 1 hour and 30 minutes:
+    // 1 hour = ONE_HOUR = 3,600,000,000 microseconds
+    // 30 minutes = 30 * ONE_MINUTE = 1,800,000,000 microseconds
+    // Total = 5,400,000,000 microseconds
+    expect(formatDuration(5400000000)).toBe('1h 30m');
+  });
+
+  it('should return a decimal representation for milliseconds', () => {
+    // 500 milliseconds = 500 * ONE_MILLISECOND = 500,000 microseconds
+    expect(formatDuration(500000)).toBe('500ms');
+  });
+
+  it('should round decimals to two decimal places', () => {
+    // 1,234,567 microseconds is approximately 1.234567s, rounded to 1.23s
+    expect(formatDuration(1234567)).toBe('1.23s');
+  });
+
+  it('should correctly handle an exact unit boundary (exactly one minute)', () => {
+    // Exactly one minute (60,000,000 microseconds) should return "1m"
+    expect(formatDuration(ONE_MINUTE)).toBe('1m');
+  });
+});

--- a/pkg/kubewarden/utils/__tests__/handle-growl.spec.ts
+++ b/pkg/kubewarden/utils/__tests__/handle-growl.spec.ts
@@ -1,0 +1,108 @@
+import { handleGrowl, GrowlConfig } from '@kubewarden/utils/handle-growl';
+
+describe('handleGrowl', () => {
+  let store: { dispatch: jest.Mock };
+
+  beforeEach(() => {
+    store = { dispatch: jest.fn() };
+  });
+
+  it('should dispatch using error.data when available and default type ("Error")', () => {
+    const config: GrowlConfig = {
+      error: {
+        data: {
+          _statusText: 'Data Status',
+          message:     'Data error message'
+        },
+        _statusText: 'Fallback Status',
+        message:     'Fallback message'
+      },
+      store
+    };
+
+    handleGrowl(config);
+
+    expect(store.dispatch).toHaveBeenCalledWith(
+      'growl/error',
+      {
+        title:   'Data Status',
+        message: 'Data error message',
+        timeout: 5000,
+      },
+      { root: true }
+    );
+  });
+
+  it('should dispatch using error when error.data is not available and use provided type', () => {
+    const config: GrowlConfig = {
+      error: {
+        _statusText: 'Error Status',
+        message:     'Error message'
+      },
+      store,
+      type: 'Warning'
+    };
+
+    handleGrowl(config);
+
+    expect(store.dispatch).toHaveBeenCalledWith(
+      'growl/warning',
+      {
+        title:   'Error Status',
+        message: 'Error message',
+        timeout: 5000,
+      },
+      { root: true }
+    );
+  });
+
+  it('should fallback title to type when _statusText is empty in error.data', () => {
+    const config: GrowlConfig = {
+      error: {
+        data: {
+          _statusText: '', // empty _statusText
+          message:     'Data message'
+        },
+        _statusText: 'Fallback should not be used',
+        message:     'Fallback message'
+      },
+      store,
+      type: 'Info'
+    };
+
+    handleGrowl(config);
+
+    expect(store.dispatch).toHaveBeenCalledWith(
+      'growl/info',
+      {
+        title:   'Info', // fallback to provided type since _statusText is empty
+        message: 'Data message',
+        timeout: 5000,
+      },
+      { root: true }
+    );
+  });
+
+  it('should default type to "Error" when type is not provided and error._statusText is empty', () => {
+    const config: GrowlConfig = {
+      error: {
+        _statusText: '', // empty _statusText, so should fallback to default type
+        message:     'Error message'
+      },
+      store
+      // no type provided so default is "Error"
+    };
+
+    handleGrowl(config);
+
+    expect(store.dispatch).toHaveBeenCalledWith(
+      'growl/error',
+      {
+        title:   'Error', // fallback to default type because _statusText is empty
+        message: 'Error message',
+        timeout: 5000,
+      },
+      { root: true }
+    );
+  });
+});

--- a/pkg/kubewarden/utils/__tests__/permissions.spec.ts
+++ b/pkg/kubewarden/utils/__tests__/permissions.spec.ts
@@ -1,0 +1,86 @@
+import { CATALOG, MANAGEMENT } from '@shell/config/types';
+import { isAdminUser } from '@kubewarden/utils/permissions';
+
+describe('isAdminUser', () => {
+  let getters: any;
+
+  beforeEach(() => {
+    getters = { 'cluster/schemaFor': jest.fn(() => ({ resourceMethods: ['PUT'] })) };
+  });
+
+  it('should return true if all required schemas allow PUT', () => {
+    expect(isAdminUser(getters)).toBe(true);
+  });
+
+  it('should return false if MANAGEMENT.SETTING does not allow PUT', () => {
+    getters['cluster/schemaFor'].mockImplementation((resource: any) => {
+      if (resource === MANAGEMENT.SETTING) {
+        return { resourceMethods: [] };
+      }
+
+      return { resourceMethods: ['PUT'] };
+    });
+
+    expect(isAdminUser(getters)).toBe(false);
+  });
+
+  it('should return false if MANAGEMENT.FEATURE does not allow PUT', () => {
+    getters['cluster/schemaFor'].mockImplementation((resource: any) => {
+      if (resource === MANAGEMENT.FEATURE) {
+        return { resourceMethods: [] };
+      }
+
+      return { resourceMethods: ['PUT'] };
+    });
+
+    expect(isAdminUser(getters)).toBe(false);
+  });
+
+  it('should return false if CATALOG.APP does not allow PUT', () => {
+    getters['cluster/schemaFor'].mockImplementation((resource: any) => {
+      if (resource === CATALOG.APP) {
+        return { resourceMethods: [] };
+      }
+
+      return { resourceMethods: ['PUT'] };
+    });
+
+    expect(isAdminUser(getters)).toBe(false);
+  });
+
+  it('should return false if CATALOG.CLUSTER_REPO does not allow PUT', () => {
+    getters['cluster/schemaFor'].mockImplementation((resource: any) => {
+      if (resource === CATALOG.CLUSTER_REPO) {
+        return { resourceMethods: [] };
+      }
+
+      return { resourceMethods: ['PUT'] };
+    });
+
+    expect(isAdminUser(getters)).toBe(false);
+  });
+
+  it('should return false if CATALOG.OPERATION does not allow PUT', () => {
+    getters['cluster/schemaFor'].mockImplementation((resource: any) => {
+      if (resource === CATALOG.OPERATION) {
+        return { resourceMethods: [] };
+      }
+
+      return { resourceMethods: ['PUT'] };
+    });
+
+    expect(isAdminUser(getters)).toBe(false);
+  });
+
+  it('should return false if schemaFor returns undefined for a resource', () => {
+    getters['cluster/schemaFor'].mockImplementation((resource: any) => {
+      if (resource === MANAGEMENT.SETTING) {
+        return undefined;
+      }
+
+      return { resourceMethods: ['PUT'] };
+    });
+
+    expect(isAdminUser(getters)).toBe(false);
+  });
+});

--- a/pkg/kubewarden/utils/__tests__/service.spec.ts
+++ b/pkg/kubewarden/utils/__tests__/service.spec.ts
@@ -1,0 +1,84 @@
+import { proxyUrl, proxyUrlFromBase } from '@kubewarden/utils/service';
+
+describe('proxyUrlFromBase', () => {
+  it('should build the proxy URL correctly when a path is provided', () => {
+    const base = 'http://example.com/api';
+    const scheme = 'http';
+    const name = 'my-service';
+    const port = 8080;
+    const path = 'some/path';
+    // Expected: cleanBase remains "http://example.com/api"
+    // schemaNamePort becomes "http:my-service:8080"
+    // cleanPath becomes "/some/path"
+    // Final URL: "http://example.com/api/http:my-service:8080/proxy/some/path"
+    const expected = 'http://example.com/api/http:my-service:8080/proxy/some/path';
+
+    expect(proxyUrlFromBase(base, scheme, name, port, path)).toBe(expected);
+  });
+
+  it('should remove trailing slashes from the base URL', () => {
+    const base = 'http://example.com/api///';
+    const scheme = 'http';
+    const name = 'my-service';
+    const port = 8080;
+    const path = 'some/path';
+    // Trailing slashes in base should be removed.
+    const expected = 'http://example.com/api/http:my-service:8080/proxy/some/path';
+
+    expect(proxyUrlFromBase(base, scheme, name, port, path)).toBe(expected);
+  });
+
+  it('should default the path to "/" if no path is provided', () => {
+    const base = 'http://example.com/api';
+    const scheme = 'http';
+    const name = 'my-service';
+    const port = 3000;
+    // When path is undefined, cleanPath becomes "/" (an empty string replaced and then prefixed with "/").
+    const expected = 'http://example.com/api/http:my-service:3000/proxy/';
+
+    expect(proxyUrlFromBase(base, scheme, name, port)).toBe(expected);
+  });
+
+  it('should encode the scheme, name, and port correctly', () => {
+    const base = 'http://example.com/api';
+    const scheme = 'http';
+    const name = 'my service'; // space in name
+    const port = 8080;
+    const path = '/some/path';
+    // encodeURIComponent('my service') becomes "my%20service"
+    // Expected URL: "http://example.com/api/http:my%20service:8080/proxy/some/path"
+    const expected = 'http://example.com/api/http:my%20service:8080/proxy/some/path';
+
+    expect(proxyUrlFromBase(base, scheme, name, port, path)).toBe(expected);
+  });
+});
+
+describe('proxyUrl', () => {
+  it('should construct the proxy URL using the service.view and metadata.name', () => {
+    const service = {
+      links:    { view: 'http://example.com/api/my-service' },
+      metadata: { name: 'my-service' }
+    };
+    const port = 3000;
+    // For service.view = "http://example.com/api/my-service", lastIndexOf('/') returns the index before "my-service".
+    // view.slice(0, idx) gives "http://example.com/api"
+    // proxyUrlFromBase is then called with that base, "http", "my-service", and port 3000.
+    // Expected URL: "http://example.com/api/http:my-service:3000/proxy/"
+    const expected = 'http://example.com/api/http:my-service:3000/proxy/';
+
+    expect(proxyUrl(service, port)).toBe(expected);
+  });
+
+  it('should handle missing metadata.name by encoding "undefined"', () => {
+    const service = {
+      links:    { view: 'http://example.com/api/my-service' },
+      metadata: {}
+    };
+    const port = 3000;
+    // When name is undefined, encodeURIComponent(undefined) yields the string "undefined".
+    // Expected URL: "http://example.com/api/http:undefined:3000/proxy/"
+    const expected = 'http://example.com/api/http:undefined:3000/proxy/';
+
+    expect(proxyUrl(service, port)).toBe(expected);
+  });
+});

--- a/pkg/kubewarden/utils/__tests__/string.spec.ts
+++ b/pkg/kubewarden/utils/__tests__/string.spec.ts
@@ -1,0 +1,45 @@
+import { extractPortNumber } from '@kubewarden/utils/string';
+
+describe('extractPortNumber', () => {
+  it('should return the port number when a valid port is at the end of the string', () => {
+    const input = 'my-open-telemetry-collector.jaeger.svc.cluster.local:4317';
+    const result = extractPortNumber(input);
+
+    expect(result).toBe(4317);
+  });
+
+  it('should return null when no port is present in the string', () => {
+    const input = 'my-open-telemetry-collector.jaeger.svc.cluster.local';
+    const result = extractPortNumber(input);
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null when a colon is present but not followed by digits', () => {
+    const input = 'service:port';
+    const result = extractPortNumber(input);
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null for an empty string', () => {
+    const input = '';
+    const result = extractPortNumber(input);
+
+    expect(result).toBeNull();
+  });
+
+  it('should return the correct port when multiple colons exist but only the last segment is numeric', () => {
+    const input = 'prefix:middle:1234';
+    const result = extractPortNumber(input);
+
+    expect(result).toBe(1234);
+  });
+
+  it('should correctly extract a port number of 0', () => {
+    const input = 'my-service:0';
+    const result = extractPortNumber(input);
+
+    expect(result).toBe(0);
+  });
+});

--- a/tests/unit/mocks/controllerApp.ts
+++ b/tests/unit/mocks/controllerApp.ts
@@ -1,7 +1,22 @@
 import { FLEET } from '@shell/config/labels-annotations';
 import { CatalogApp } from '@kubewarden/types';
 
-export const mockControllerApp: CatalogApp = {
+export const controllerAppValuesLegacy: any = {
+  auditScanner: {
+    enable: true,
+    policyReporter: true
+  },
+  telemetry: {
+    metrics: {
+      enabled: false
+    },
+    tracing: {
+      enabled: false
+    }
+  }
+}
+
+export const mockControllerAppLegacy: CatalogApp = {
   id:         'cattle-kubewarden-system/rancher-kubewarden-controller',
   type:       'app',
   apiVersion: 'catalog.cattle.io/v1',
@@ -45,22 +60,113 @@ export const mockControllerApp: CatalogApp = {
     namespace: 'cattle-kubewarden-system',
     values:    {}
   },
-  status: { summary: { state: 'deployed' } }
+  status: { summary: { state: 'deployed' } },
+  values: { ...controllerAppValuesLegacy }
 };
 
 export const mockControllerAppWithFleet: CatalogApp = {
-  ...mockControllerApp,
+  ...mockControllerAppLegacy,
   spec: {
-    ...mockControllerApp.spec,
+    ...mockControllerAppLegacy.spec,
     chart: {
-      ...mockControllerApp.spec.chart,
+      ...mockControllerAppLegacy.spec.chart,
       metadata: {
-        ...mockControllerApp.spec.chart.metadata,
+        ...mockControllerAppLegacy.spec.chart.metadata,
         annotations: {
-          ...mockControllerApp.spec.chart.metadata.annotations,
+          ...mockControllerAppLegacy.spec.chart.metadata.annotations,
           [FLEET.BUNDLE_ID]: 'fleet-default/kw-kubewarden-defaults'
         }
       }
     }
   }
 };
+
+export const controllerAppValues: any = {
+  auditScanner: {
+    policyReporter: true
+  },
+  global: {
+    cattle: {
+      clusterId: "local",
+      clusterName: "local",
+      rkePathPrefix: "",
+      rkeWindowsPathPrefix: "",
+      systemDefaultRegistry: "ghcr.io",
+      systemProjectId: "p-w2nhb",
+      url: "https://example.com"
+    },
+    systemDefaultRegistry: "ghcr.io"
+  },
+  telemetry: {
+    metrics: true,
+    sidecar: {
+      tracing: {
+        jaeger: {
+          endpoint: "my-open-telemetry-collector.jaeger.svc.cluster.local:4317",
+          tls: {
+            insecure: true
+          }
+        }
+      }
+    },
+    tracing: true
+  }
+}
+
+export const mockControllerApp: CatalogApp = {
+  ...mockControllerAppLegacy,
+  spec: {
+    chart: {
+      metadata: {
+        annotations: {
+          'catalog.cattle.io/auto-install': "kubewarden-crds=1.13.0",
+          'catalog.cattle.io/certified': "rancher",
+          'catalog.cattle.io/display-name': "Kubewarden",
+          'catalog.cattle.io/namespace': "cattle-kubewarden-system",
+          'catalog.cattle.io/os': "linux",
+          'catalog.cattle.io/provides-gvr': "policyservers.policies.kubewarden.io/v1",
+          'catalog.cattle.io/rancher-version': ">= 2.6.0-0 <= 2.11.100-0",
+          'catalog.cattle.io/release-name': "rancher-kubewarden-controller",
+          'catalog.cattle.io/requests-cpu': "250m",
+          'catalog.cattle.io/requests-memory': "50Mi",
+          'catalog.cattle.io/type': "cluster-tool",
+          'catalog.cattle.io/ui-component': "kubewarden",
+          'catalog.cattle.io/ui-source-repo': "kubewarden-charts",
+          'catalog.cattle.io/ui-source-repo-type': "cluster",
+          'catalog.cattle.io/upstream-version': "4.1.0"
+        },
+        apiVersion: "v2",
+        appVersion: "v1.21.0",
+        description: "A Helm chart for deploying the Kubewarden stack",
+        home: "https://www.kubewarden.io/",
+        icon: "https://www.kubewarden.io/images/icon-kubewarden.svg",
+        keywords: [
+          "Kubewarden",
+          "Security",
+          "Infrastructure",
+          "Monitoring",
+          "policy agent",
+          "policies",
+          "validating webhook",
+          "admissions controller",
+          "policy report",
+          "audit scanner"
+        ],
+        kubeVersion: ">= 1.19.0-0",
+        maintainers: [
+          {
+            email: "cncf-kubewarden-maintainers@lists.cncf.io",
+            name: "Kubewarden Maintainers",
+            url: "https://github.com/orgs/kubewarden/teams/maintainers"
+          }
+        ],
+        name: "kubewarden-controller",
+        type: "application",
+        version: "4.1.0"
+      }
+    },
+    name: "rancher-kubewarden-controller",
+    namespace: "cattle-kubewarden-system",
+  },
+  values: { ...controllerAppValues }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8860,6 +8860,11 @@ floating-vue@5.2.2:
     "@floating-ui/dom" "~1.1.1"
     vue-resize "^2.0.0-alpha.1"
 
+flush-promises@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/flush-promises/-/flush-promises-1.0.2.tgz#4948fd58f15281fed79cbafc86293d5bb09b2ced"
+  integrity sha512-G0sYfLQERwKz4+4iOZYQEZVpOt9zQrlItIxQAAYAWpfby3gbHrx0osCHz5RLl/XoXevXk0xoN4hDFky/VV9TrA==
+
 focus-trap@7.6.2:
   version "7.6.2"
   resolved "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.2.tgz#a501988821ca23d0150a7229eb7a20a3695bdf0e"


### PR DESCRIPTION
Fix #1079 

This will add many missing unit tests that either were never implemented or were skipped due to the Vue 3 migration.

## Coverage Improvement

***Updated Coverage***

```
=============================== Coverage summary ===============================
Statements   : 89.32% ( 13674/15309 )
Branches     : 68.86% ( 1181/1715 )
Functions    : 65.83% ( 451/685 )
Lines        : 89.32% ( 13674/15309 )
================================================================================
Test Suites: 64 passed, 64 total
Tests:       449 passed, 449 total
```

***Previous Coverage***

```
=============================== Coverage summary ===============================
Statements   : 79.14% ( 10650/13457 )
Branches     : 59.74% ( 417/698 )
Functions    : 37.17% ( 200/538 )
Lines        : 79.14% ( 10650/13457 )
================================================================================
Test Suites: 29 passed, 29 total
Tests:       109 passed, 109 total
```