### PR TITLE
Update job names and concurrency

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,5 +1,7 @@
 name: Playwright Tests
 
+run-name: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || '' }}
+
 on:
   workflow_dispatch:
     inputs:
@@ -75,10 +77,10 @@ on:
       - completed
 
   schedule:
-    - cron: "0 21 * * *"
+    - cron: "1 21 * * *"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.workflow_run.head_branch || github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
- workflow_run (release test jobs) will be named after tag (`Playwright Tests` -> `kubewarden-3.1.1-rc.1`) to differentiate between schedule jobs & release branches, other jobs will use default name from github
https://github.com/kravciak/kubewarden-ui/actions/runs/13650678104

- Schedule jobs and release jobs on different branches are canceling each other. I extended concurrency group to prevent that