### PR TITLE
[Backport] Add test path for release 3.1

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,5 +1,7 @@
 name: Playwright Tests
 
+run-name: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || '' }}
+
 on:
   workflow_dispatch:
     inputs:
@@ -74,10 +76,10 @@ on:
       - completed
 
   schedule:
-    - cron: "0 21 * * *"
+    - cron: "1 21 * * *"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.workflow_run.head_branch || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -64,8 +64,9 @@ on:
   pull_request:
     branches:
       - main
-      - release-1.6
-      - release-2.1
+      - release-1.6 # rancher 2.8
+      - release-2.1 # rancher 2.9
+      - release-3.1 # rancher 2.10
     paths:
       - pkg/kubewarden/**
       - package.json
@@ -103,7 +104,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rancher: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && fromJSON('["2.8", "2.9", "2.10"]') || fromJSON(format('["{0}"]', inputs.rancher || 'released')) }}
+        rancher: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && fromJSON('["2.8", "2.9", "2.10"]') || fromJSON(format('["{0}"]', inputs.rancher || github.event.pull_request.base.ref )) }}
         mode: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && fromJSON('["base", "upgrade", "fleet"]') || fromJSON(format('["{0}"]', inputs.mode || 'base')) }}
         exclude:
           # Run all modes on 2.10 since it's latest prime version
@@ -134,13 +135,14 @@ jobs:
     # Check out code
     # Use local kuberlr to avoid version skew
 
-    # Test from maintenance branch for Rancher < 2.10
+    # Test from maintenance branch for Rancher < 2.11
     - name: Find checkout branch ref
       id: set-ref
       run: |
         case "${{ matrix.rancher }}" in
           *2.8*) ref='release-1.6';;
           *2.9*) ref='release-2.1';;
+          *2.10*) ref='release-3.1';;
           *)     ref='';;
         esac
         echo "ref=$ref" | tee -a $GITHUB_OUTPUT
@@ -158,8 +160,10 @@ jobs:
         case ${{github.event_name}} in
           pull_request)
             # Override RANCHER for maintenance PRs
+            [[ "${{ github.event.pull_request.base.ref }}" == "main" ]] && RANCHER="2.11-0"
             [[ "${{ github.event.pull_request.base.ref }}" == "release-1.6" ]] && RANCHER="2.8"
             [[ "${{ github.event.pull_request.base.ref }}" == "release-2.1" ]] && RANCHER="2.9"
+            [[ "${{ github.event.pull_request.base.ref }}" == "release-3.1" ]] && RANCHER="2.10"
             KUBEWARDEN=source;;
           schedule)
             KUBEWARDEN=released;;
@@ -169,19 +173,18 @@ jobs:
 
         # Select repository
         helm repo add --force-update rancher-prime https://charts.rancher.com/server-charts/prime
-        helm repo add --force-update rancher-community https://releases.rancher.com/server-charts/latest
+        helm repo add --force-update rancher-community https://releases.rancher.com/server-charts/alpha # alpha | latest
         [[ "$RANCHER" == "rc" || "$RANCHER" == *"-0" ]] && REPO=rancher-community || REPO=rancher-prime
 
         # Translate to sematic version
         [ "$RANCHER" == "rc" ] && RANCHER='*-0'
         [ "$RANCHER" == "released" ] && RANCHER='*'
 
-        # Rancher 2.7 chart requires kubeVersion: < 1.28.0-0
+        # Limit k8s version - Rancher 2.7 chart supports < 1.28.0
         [[ "$RANCHER" == *2.7* ]] && K3S_VERSION="v1.27"
-        # Rancher 2.8 chart requires kubeVersion: < 1.29.0-0
         [[ "$RANCHER" == *2.8* ]] && K3S_VERSION="v1.28"
-        # Rancher 2.9 chart requires kubeVersion: < 1.31.0-0
         [[ "$RANCHER" == *2.9* ]] && K3S_VERSION="v1.30"
+        [[ "$RANCHER" == *2.10* ]] && K3S_VERSION="v1.31"
 
         # Complete partial K3S version from dockerhub v1.30 -> v1.30.5-k3s1
         if [[ ! $K3S_VERSION =~ ^v[0-9.]+-k3s[0-9]$ ]]; then
@@ -249,7 +252,7 @@ jobs:
     - uses: actions/setup-node@v4
       if: env.KUBEWARDEN == 'source'
       with:
-        node-version: ${{ github.event.pull_request.base.ref == 'main' && '20' || '16' }}
+        node-version: ${{ (github.event.pull_request.base.ref == 'release-1.6' || github.event.pull_request.base.ref == 'release-2.1') && '16' || '20' }}
 
     - name: Build Kubewarden extension
       if: env.KUBEWARDEN == 'source'

--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -7,6 +7,7 @@ import { apList, capList, ClusterAdmissionPoliciesPage } from './pages/policies.
 import { RancherAppsPage } from './rancher/rancher-apps.page'
 import { RancherFleetPage } from './rancher/rancher-fleet.page'
 import { RancherUI } from './components/rancher-ui'
+import { Common } from './components/common'
 
 // source (yarn dev) | rc (add github repo) | released (just install)
 const ORIGIN = process.env.ORIGIN || (process.env.API ? 'source' : 'rc')
@@ -15,25 +16,11 @@ expect(ORIGIN).toMatch(/^(source|rc|released)$/)
 const MODE = process.env.MODE || 'base'
 expect(MODE).toMatch(/^(base|fleet|upgrade)$/)
 
-// Known Kubewarden versions for upgrade test, start at [0]
-const upMap: AppVersion[] = [
-  { app: 'v1.11.0', controller: '2.0.10', crds: '1.4.6', defaults: '1.9.4' },
-  { app: 'v1.12.0', controller: '2.0.11', crds: '1.5.0', defaults: '2.0.0' },
-  { app: 'v1.13.0', controller: '2.1.0', crds: '1.5.1', defaults: '2.0.3' },
-  { app: 'v1.14.0', controller: '2.2.1', crds: '1.6.0', defaults: '2.1.0' },
-  { app: 'v1.15.0', controller: '2.3.1', crds: '1.7.0', defaults: '2.2.1' },
-  { app: 'v1.16.0', controller: '2.4.0', crds: '1.8.0', defaults: '2.3.1' },
-  { app: 'v1.17.0', controller: '3.0.1', crds: '1.9.0', defaults: '2.4.0' },
-  { app: 'v1.18.0', controller: '3.1.0', crds: '1.10.0', defaults: '2.5.0' },
-  { app: 'v1.19.0', controller: '3.2.0', crds: '1.11.0', defaults: '2.6.0' },
-  { app: 'v1.20.0', controller: '4.0.1', crds: '1.12.1', defaults: '2.7.1' },
-  { app: 'v1.21.0', controller: '4.1.0', crds: '1.13.0', defaults: '2.8.1' },
-  { app: 'v1.22.0', controller: '5.0.0', crds: '1.14.0', defaults: '3.0.0' },
-].splice(-3) // Limit upgrade path to last 3 versions
-
-// Support for Rancher 2.9 was added in KW 1.13.0
-if (RancherUI.isVersion('>=2.9')) upMap.splice(0, upMap.findIndex((v) => v.app === 'v1.13.0'))
-if (RancherUI.isVersion('>=2.10')) upMap.splice(0, upMap.findIndex((v) => v.app === 'v1.18.0'))
+// Fetch Kubewarden versions for upgrade test
+let upMap: AppVersion[]
+test.beforeAll(async() => {
+  if (MODE === 'upgrade') upMap = (await Common.fetchVersionMap()).splice(-3)
+})
 
 test('Initial rancher setup', async({ page, ui, nav }) => {
   const rancher = new RancherCommonPage(page)

--- a/tests/e2e/components/common.ts
+++ b/tests/e2e/components/common.ts
@@ -1,0 +1,42 @@
+import semver from 'semver'
+import yaml from 'js-yaml'
+import { AppVersion } from '../pages/kubewarden.page'
+import { RancherUI } from './rancher-ui'
+
+/**
+ * Common helper functions and constants
+ */
+export class Common {
+  // Build kubewarden version map for upgrade test
+  // { app: 'v1.22.0', controller: '5.0.0', crds: '1.14.0', defaults: '3.0.0' }
+  static async fetchVersionMap(): Promise<AppVersion[]> {
+    // Fetch and parse YAML index file
+    const response = await fetch('https://charts.kubewarden.io/index.yaml')
+    if (!response.ok) throw new Error(`Failed to fetch: ${response.statusText}`)
+
+    const indexData = yaml.load(await response.text()) as { entries: Record<string, any[]> }
+    const versionMap: Record<string, Partial<AppVersion>> = {}
+    const chartNames = ['kubewarden-controller', 'kubewarden-crds', 'kubewarden-defaults']
+
+    for (const chartName of chartNames) {
+      const key = chartName.replace('kubewarden-', '') as keyof AppVersion
+
+      for (const chart of indexData.entries[chartName]) {
+        // Remove prerelease and unsupported versions
+        if (semver.prerelease(chart.appVersion)) continue
+        if (!RancherUI.isVersion(chart.annotations?.['catalog.cattle.io/rancher-version'] || '*')) continue
+
+        // Process each relevant chart entry
+        versionMap[chart.appVersion] ??= { app: chart.appVersion }
+        if (semver.gt(chart.version, versionMap[chart.appVersion][key] ?? '0.0.0')) {
+          versionMap[chart.appVersion][key] = chart.version
+        }
+      }
+    }
+
+    // Filter only complete entries
+    return Object.values(versionMap)
+      .filter((entry): entry is AppVersion => !!entry.controller && !!entry.crds && !!entry.defaults)
+      .sort((a, b) => semver.compare(a.app.replace(/^v/, ''), b.app.replace(/^v/, '')))
+  }
+}


### PR DESCRIPTION
Workflow file from target branch is used, changes must be backported to fix scheduling of PR tests.

No tests are scheduled on PR's into release-3.1 branch:
https://github.com/rancher/kubewarden-ui/pull/1091