### PR TITLE
[Forward Port 2.11] Filter out Rego policies - refactor AH fetching

### DIFF
--- a/pkg/kubewarden/modules/artifacthub.ts
+++ b/pkg/kubewarden/modules/artifacthub.ts
@@ -1,11 +1,11 @@
-import { ArtifactHubPackage } from '@kubewarden/types';
+import { ArtifactHubPackageDetails } from '@kubewarden/types';
 
 /**
  * Extracts resource kinds from a list of ArtifactHub packages with the `kubewarden/resources` annotation.
  * @param artifactHubPackages
  * @returns `string[]` | Resource kinds
  */
-export function resourcesFromAnnotation(artifactHubPackages: ArtifactHubPackage[]): string[] | void {
+export function resourcesFromAnnotation(artifactHubPackages: ArtifactHubPackageDetails[]): string[] | void {
   const out: string[] = [];
 
   const resources = artifactHubPackages?.flatMap((artifactHubPackage) => {
@@ -43,7 +43,7 @@ export function resourcesFromAnnotation(artifactHubPackages: ArtifactHubPackage[
  * @param artifactHubPackage `schemas`
  * @returns boolean
  */
-export function isGlobalPolicy(artifactHubPackage: ArtifactHubPackage, schemas: any): boolean {
+export function isGlobalPolicy(artifactHubPackage: ArtifactHubPackageDetails, schemas: any): boolean {
   if (artifactHubPackage) {
     const resources: string[] | undefined = artifactHubPackage.data?.['kubewarden/resources']?.split(',');
     let targetsNonNamespaced: boolean = false;

--- a/pkg/kubewarden/store/kubewarden/actions.ts
+++ b/pkg/kubewarden/store/kubewarden/actions.ts
@@ -1,7 +1,17 @@
 import {
-  CatalogApp, CustomResourceDefinition, PolicyReport, ClusterPolicyReport, PolicyTraceConfig, PolicyTrace, PolicyReportSummary
+  CatalogApp,
+  CustomResourceDefinition,
+  PolicyReport,
+  ClusterPolicyReport,
+  PolicyTraceConfig,
+  PolicyTrace,
+  REGO_POLICIES_REPO,
+  ArtifactHubPackage,
+  ArtifactHubPackageDetails, PolicyReportSummary
 } from '@kubewarden/types';
 import { generateSummaryMap } from '@kubewarden/modules/policyReporter';
+
+const PACKAGES_TTL = 5 * 60 * 1000; // 5 minutes
 
 export default {
   updateAirGapped({ commit }: any, val: boolean) {
@@ -70,5 +80,79 @@ export default {
   },
   removeKubewardenCrds({ commit }: any, val: CustomResourceDefinition) {
     commit('removeKubewardenCrds', val);
-  }
+  },
+
+  /**
+   * Fetch all packages from the provided repository and store them in Vuex.
+   *
+   * @param {Object} param0 The Vuex context
+   * @param {Object} param1 The object containing:
+   *   - repository: The repository object returned by `value.artifactHubRepo()`
+   *   - value: The CR resource containing the method to fetch package details (artifactHubPackage)
+   *   - force: Boolean to force a fetch regardless of TTL (default: false)
+   */
+  async fetchPackages({ state, commit, dispatch }: any, { repository, value, force = false }: any) {
+    try {
+      // Check if we have a packageCacheTime, and if TTL is still valid
+      const now = Date.now();
+      const isCacheValid = state.packageCacheTime && (now - state.packageCacheTime < PACKAGES_TTL);
+
+      // If not forcing a refresh and the cache is still valid, return immediately
+      if (!force && isCacheValid) {
+        return;
+      }
+
+      if (!repository?.packages?.length) {
+        return;
+      }
+
+      commit('updateLoadingPackages', true);
+
+      // Filter out Rego-based packages
+      const packagesByRepo: ArtifactHubPackage[] = repository.packages.filter(
+        (pkg: ArtifactHubPackage) => !pkg?.repository?.url?.includes(REGO_POLICIES_REPO)
+      );
+
+      // Store all package details keyed by package_id
+      const packageDetailsMap: Record<string, ArtifactHubPackageDetails> = {};
+
+      const results = await Promise.all(
+        packagesByRepo.map(async(pkg) => {
+          const details = await dispatch('fetchPackageDetails', {
+            pkg,
+            value
+          });
+          const key: string = pkg.package_id;
+
+          packageDetailsMap[key] = details;
+
+          return details;
+        })
+      );
+
+      // Filter out any hidden UI packages
+      const filtered = results.filter((pkg) => pkg?.data?.['kubewarden/hidden-ui'] !== 'true');
+
+      commit('updatePackages', filtered);
+      commit('updatePackageDetails', packageDetailsMap);
+      commit('updatePackageCacheTime', Date.now());
+    } catch (err) {
+      console.warn('Error fetching packages', err);
+    } finally {
+      commit('updateLoadingPackages', false);
+    }
+  },
+
+  /**
+     * Fetch details for a single package.
+     */
+  async fetchPackageDetails(context: any, { pkg, value }: any) {
+    try {
+      return await value.artifactHubPackage(pkg);
+    } catch (err) {
+      console.warn('Error fetching package details:', err);
+
+      return null;
+    }
+  },
 };

--- a/pkg/kubewarden/store/kubewarden/getters.ts
+++ b/pkg/kubewarden/store/kubewarden/getters.ts
@@ -1,5 +1,11 @@
 import {
-  CatalogApp, CustomResourceDefinition, PolicyReport, ClusterPolicyReport, PolicyTraceConfig, PolicyReportSummary
+  CatalogApp,
+  CustomResourceDefinition,
+  PolicyReport,
+  ClusterPolicyReport,
+  PolicyTraceConfig,
+  PolicyReportSummary,
+  ArtifactHubPackageDetails
 } from '@kubewarden/types';
 import { StateConfig } from './index';
 
@@ -15,6 +21,10 @@ export default {
   clusterPolicyReports:   (state: StateConfig): ClusterPolicyReport[] => state.clusterPolicyReports,
   policyTraces:           (state: StateConfig): PolicyTraceConfig[] => state.policyTraces,
   refreshingCharts:       (state: StateConfig): boolean => state.refreshingCharts,
+  packages:               (state: StateConfig): any[] => state.packages,
+  loadingPackages:        (state: StateConfig): boolean => state.loadingPackages,
+  packageDetailsByKey:    (state: StateConfig) => (key: string): ArtifactHubPackageDetails => state.packageDetails[key],
+
 
   reportByResourceId:     (state: StateConfig) => (resourceId: string): PolicyReport | ClusterPolicyReport => {
     return state.reportMap[resourceId];

--- a/pkg/kubewarden/store/kubewarden/index.ts
+++ b/pkg/kubewarden/store/kubewarden/index.ts
@@ -9,6 +9,8 @@ import {
   PolicyTraceConfig,
   ClusterPolicyReport,
   PolicyReportSummary,
+  ArtifactHubPackage,
+  ArtifactHubPackageDetails,
 } from '@kubewarden/types';
 
 import getters from './getters';
@@ -30,6 +32,10 @@ export interface StateConfig {
   summaryMap: Record<string, PolicyReportSummary>;
   policyTraces: PolicyTraceConfig[];
   refreshingCharts: boolean;
+  packages: ArtifactHubPackage[];
+  packageDetails: Record<string, ArtifactHubPackageDetails>
+  loadingPackages: boolean;
+  packageCacheTime: number;
 }
 
 const kubewardenFactory = (config: StateConfig): CoreStoreSpecifics => {
@@ -49,7 +55,11 @@ const kubewardenFactory = (config: StateConfig): CoreStoreSpecifics => {
         reportMap:              config.reportMap,
         summaryMap:             config.summaryMap,
         policyTraces:           config.policyTraces,
-        refreshingCharts:       config.refreshingCharts
+        refreshingCharts:       config.refreshingCharts,
+        packages:               config.packages,
+        packageDetails:         config.packageDetails,
+        loadingPackages:        config.loadingPackages,
+        packageCacheTime:       config.packageCacheTime,
       };
     },
 
@@ -76,7 +86,11 @@ export default {
     reportMap:              {},
     summaryMap:             {},
     policyTraces:           [],
-    refreshingCharts:       false
+    refreshingCharts:       false,
+    packages:               [],
+    packageDetails:         {},
+    loadingPackages:        false,
+    packageCacheTime:       0,
   }),
   config
 };

--- a/pkg/kubewarden/store/kubewarden/mutations.ts
+++ b/pkg/kubewarden/store/kubewarden/mutations.ts
@@ -1,5 +1,13 @@
 import {
-  CatalogApp, ClusterPolicyReport, CustomResourceDefinition, PolicyReport, PolicyTrace, PolicyTraceConfig, PolicyReportSummary
+  ArtifactHubPackageDetails,
+  ArtifactHubPackage,
+  CatalogApp,
+  ClusterPolicyReport,
+  CustomResourceDefinition,
+  PolicyReport,
+  PolicyTrace,
+  PolicyTraceConfig,
+  PolicyReportSummary
 } from '@kubewarden/types';
 import { StateConfig } from './index';
 
@@ -191,5 +199,23 @@ export default {
 
   updateRefreshingCharts(state: StateConfig, val: boolean) {
     state.refreshingCharts = val;
-  }
+  },
+
+  updatePackages(state: StateConfig, packages: ArtifactHubPackage[]) {
+    state.packages = packages;
+  },
+
+  updatePackageDetails(state: StateConfig, payload: Record<string, ArtifactHubPackageDetails>) {
+    for (const key in payload) {
+      state.packageDetails[key] = payload[key];
+    }
+  },
+
+  updateLoadingPackages(state: StateConfig, value: boolean) {
+    state.loadingPackages = value;
+  },
+
+  updatePackageCacheTime(state: StateConfig, time: number) {
+    state.packageCacheTime = time;
+  },
 };

--- a/pkg/kubewarden/types/artifacthub.ts
+++ b/pkg/kubewarden/types/artifacthub.ts
@@ -9,86 +9,114 @@ export enum DATA_ANNOTATIONS {
 /* eslint-enable no-unused-vars */
 
 
+export interface Link {
+  url: string
+  name: string
+}
+
+export interface Data {
+  'kubewarden/rules': string
+  'kubewarden/mutation'?: string
+  'kubewarden/contextAwareResources'?: string
+  'kubewarden/resources': string
+  'kubewarden/questions-ui': string
+}
+
+export interface AvailableVersion {
+  version: string
+  contains_security_updates: boolean
+  prerelease: boolean
+  ts: number
+}
+
+export interface ContainersImage {
+  name: string
+  image: string
+  whitelisted: boolean
+}
+
+export interface Maintainer {
+  name: string
+  email: string
+}
+
+export interface Recommendation {
+  url: string
+}
+
+export interface Repository {
+  repository_id: string
+  name: string
+  display_name: string
+  url: string
+  branch?: string
+  private?: boolean
+  kind: number
+  verified_publisher: boolean
+  official: boolean
+  cncf: boolean
+  scanner_disabled: boolean
+  organization_name: string
+  organization_display_name: string
+}
+
+export interface Stats {
+  subscriptions: number
+  webhooks: number
+}
+
 export interface ArtifactHubPackage {
-  package_id: string;
-  name: string;
-  normalized_name: string;
-  category?: number;
-  is_operator?: boolean;
-  display_name: string;
-  description: string;
-  keywords?: string[];
-  home_url: string;
-  readme: string;
-  install: string;
-  links: [
-    {
-      url: string;
-      name: string;
-    }
-  ];
-  data?: {
-    [DATA_ANNOTATIONS.CONTEXT_AWARE]?: string
-    [DATA_ANNOTATIONS.RULES]?: string;
-    [DATA_ANNOTATIONS.MUTATION]?: string;
-    [DATA_ANNOTATIONS.RESOURCES]?: string;
-    [DATA_ANNOTATIONS.QUESTIONS]?: string;
-  };
-  version: string;
-  available_versions: [
-    {
-      version: string;
-      contains_security_updates?: boolean;
-      prerelease?: boolean;
-    }
-  ];
-  deprecated?: boolean;
-  contains_security_updates?: boolean;
-  prerelease?: boolean;
-  license: string;
-  signed?: boolean;
-  signatures?: string[];
-  containers_images?: [
-    {
-      name: string;
-      image: string;
-      whitelisted: boolean;
-    }
-  ];
-  all_containers_images_whitelisted?: boolean;
-  provider?: string;
-  has_values_schema?: boolean;
-  has_changelog?: boolean;
-  maintainers?: [
-    {
-      name: string;
-      email: string;
-    }
-  ];
-  recommendations?: [
-    {
-      url: string;
-    }
-  ];
-  repository: {
-    repository_id: string;
-    name: string;
-    display_name: string;
-    url: string;
-    branch: string;
-    private?: boolean;
-    kind: number;
-    verified_publisher?: boolean;
-    official?: boolean;
-    cncf?: boolean;
-    scanner_disabled?: boolean;
-    organization_name?: string;
-    organization_display_name?: string;
-  };
-  stats?: {
-    subscriptions: number;
-    webhooks: number;
-  };
-  production_organizations_count?: number;
+  package_id: string
+  name: string
+  normalized_name: string
+  category: number
+  stars: number
+  display_name: string
+  description: string
+  version: string
+  license: string
+  deprecated: boolean
+  has_values_schema: boolean
+  signed: boolean
+  signatures: string[]
+  all_containers_images_whitelisted: boolean
+  production_organizations_count: number
+  ts: number
+  repository: Repository
+}
+
+export interface ArtifactHubPackageDetails {
+  package_id: string
+  name: string
+  normalized_name: string
+  category: number
+  is_operator: boolean
+  display_name: string
+  description: string
+  keywords: string[]
+  home_url: string
+  readme: string
+  install: string
+  links: Link[]
+  data: Data
+  version: string
+  available_versions: AvailableVersion[]
+  deprecated: boolean
+  contains_security_updates: boolean
+  prerelease: boolean
+  license: string
+  signed: boolean
+  signatures: string[]
+  containers_images: ContainersImage[]
+  all_containers_images_whitelisted: boolean
+  provider: string
+  has_values_schema: boolean
+  has_changelog: boolean
+  ts: number
+  maintainers: Maintainer[]
+  recommendations: Recommendation[]
+  repository: Repository
+  stats: Stats
+  production_organizations_count: number
 }
 

--- a/pkg/kubewarden/types/kubewarden.ts
+++ b/pkg/kubewarden/types/kubewarden.ts
@@ -10,6 +10,7 @@ export const CHART_NAME = 'rancher-kubewarden';
 
 export const KUBEWARDEN_DASHBOARD = 'dashboard';
 export const KUBEWARDEN_REPO = 'https://charts.kubewarden.io';
+export const REGO_POLICIES_REPO = 'https://github.com/kubewarden/rego-policies-library';
 
 export const KUBEWARDEN_CHARTS = {
   CONTROLLER:       'kubewarden-controller',


### PR DESCRIPTION
Forward port of https://github.com/rancher/kubewarden-ui/pull/1048

We might not have helm-charts repository ready in time for rancher 2.11 release.

Currently we display mix of kubewarden & rego policies which is limited cut `search?kind=13&limit=50`.