### PR TITLE
Paginate artifacthub packages to properly filter out rego policies

### DIFF
--- a/pkg/kubewarden/chart/kubewarden/admission/MatchConditions.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/MatchConditions.vue
@@ -49,13 +49,15 @@ export default {
     activeTab() {
       if (this.activeTab === 'matchConditions') {
         this.$nextTick(() => {
-          Object.keys(this.cmInstances)?.forEach((refKey) => {
-            const cmInstance = this.cmInstances[refKey][0];
+          if (this.cmInstances) {
+            Object.keys(this.cmInstances).forEach((refKey) => {
+              const cmInstance = this.cmInstances[refKey][0];
 
-            if (cmInstance && typeof cmInstance.refresh === 'function') {
-              cmInstance.refresh();
-            }
-          });
+              if (cmInstance && typeof cmInstance.refresh === 'function') {
+                cmInstance.refresh();
+              }
+            });
+          }
         });
       }
     }

--- a/pkg/kubewarden/chart/kubewarden/admission/MatchConditions.vue
+++ b/pkg/kubewarden/chart/kubewarden/admission/MatchConditions.vue
@@ -49,7 +49,7 @@ export default {
     activeTab() {
       if (this.activeTab === 'matchConditions') {
         this.$nextTick(() => {
-          Object.keys(this.cmInstances).forEach((refKey) => {
+          Object.keys(this.cmInstances)?.forEach((refKey) => {
             const cmInstance = this.cmInstances[refKey][0];
 
             if (cmInstance && typeof cmInstance.refresh === 'function') {

--- a/pkg/kubewarden/components/Policies/Create.vue
+++ b/pkg/kubewarden/components/Policies/Create.vue
@@ -61,14 +61,9 @@ export default ({
 
   mixins: [CreateEditView],
 
-  async fetch() {
+  async created() {
     if (this.hasArtifactHub) {
-      const repository = await this.value.artifactHubRepo();
-
-      await this.$store.dispatch('kubewarden/fetchPackages', {
-        repository,
-        value: this.value
-      });
+      await this.$store.dispatch('kubewarden/fetchPackages', { value: this.value });
     }
 
     this.value.apiVersion = `${ this.schema?.attributes?.group }.${ this.schema?.attributes?.version }`;

--- a/pkg/kubewarden/components/Policies/PolicyTable.vue
+++ b/pkg/kubewarden/components/Policies/PolicyTable.vue
@@ -237,7 +237,7 @@ export default {
     },
 
     isPrerelease(artifactHubPackage) {
-      const parsed = semver.prerelease(artifactHubPackage.version);
+      const parsed = semver.prerelease(artifactHubPackage?.version);
 
       /**
        * Custom condition for Deprecated API Versions policy as these versions

--- a/pkg/kubewarden/plugins/kubewarden-class.js
+++ b/pkg/kubewarden/plugins/kubewarden-class.js
@@ -54,12 +54,14 @@ export default class KubewardenModel extends SteveModel {
     Fetches all of the packages from the kubewarden org
   */
   get artifactHubRepo() {
-    return async() => {
+    return async({ offset = 0, limit = 60 } = {}) => {
       let url = '/meta/proxy/';
       const packages = 'packages/search';
+
       const params = {
-        kind:               13, // Kind for Kubewarden policies
-        limit:              50 // limit to 50, default is 20
+        kind: 13, // Kubewarden policies
+        limit, // Max limit is 60, default is 20.
+        offset // Used for pagination
       };
 
       url += `${ ARTIFACTHUB_ENDPOINT }/${ packages }`;

--- a/pkg/kubewarden/store/kubewarden/__tests__/actions.spec.ts
+++ b/pkg/kubewarden/store/kubewarden/__tests__/actions.spec.ts
@@ -1,0 +1,302 @@
+import { REGO_POLICIES_REPO } from '@kubewarden/types';
+
+import actions from '@kubewarden/store/kubewarden/actions';
+import { generateSummaryMap } from '@kubewarden/modules/policyReporter';
+
+jest.mock('@kubewarden/modules/policyReporter', () => ({ generateSummaryMap: jest.fn(() => ({ summary: 'testSummary' })) }));
+
+describe('Vuex Actions', () => {
+  let commit;
+  let dispatch;
+  let state;
+
+  beforeEach(() => {
+    commit = jest.fn();
+    dispatch = jest.fn();
+    state = {
+      packageCacheTime: null,
+      packages:         [],
+      packageDetails:   {},
+    };
+  });
+
+  it('updateAirGapped should commit "updateAirGapped" with the provided value', () => {
+    actions.updateAirGapped({ commit }, true);
+    expect(commit).toHaveBeenCalledWith('updateAirGapped', true);
+  });
+
+  it('updateHideBannerDefaults should commit "updateHideBannerDefaults" with the provided value', () => {
+    actions.updateHideBannerDefaults({ commit }, true);
+    expect(commit).toHaveBeenCalledWith('updateHideBannerDefaults', true);
+  });
+
+  it('updateHideBannerArtifactHub should commit "updateHideBannerArtifactHub" with the provided value', () => {
+    actions.updateHideBannerArtifactHub({ commit }, true);
+    expect(commit).toHaveBeenCalledWith('updateHideBannerArtifactHub', true);
+  });
+
+  it('updateHideBannerAirgapPolicy should commit "updateHideBannerAirgapPolicy" with the provided value', () => {
+    actions.updateHideBannerAirgapPolicy({ commit }, true);
+    expect(commit).toHaveBeenCalledWith('updateHideBannerAirgapPolicy', true);
+  });
+
+  it('updateLoadingReports should commit "updateLoadingReports" with the provided value', () => {
+    actions.updateLoadingReports({ commit }, true);
+    expect(commit).toHaveBeenCalledWith('updateLoadingReports', true);
+  });
+
+  it('updatePolicyReports should commit "updateReportsBatch" with reportArrayKey "policyReports"', () => {
+    const reports = [{
+      id:      '1',
+      results: []
+    }];
+
+    actions.updatePolicyReports({ commit }, reports);
+    expect(commit).toHaveBeenCalledWith('updateReportsBatch', {
+      reportArrayKey: 'policyReports',
+      updatedReports: reports
+    });
+  });
+
+  it('updateClusterPolicyReports should commit "updateReportsBatch" with reportArrayKey "clusterPolicyReports"', () => {
+    const reports = [{
+      id:      '2',
+      results: []
+    }];
+
+    actions.updateClusterPolicyReports({ commit }, reports);
+    expect(commit).toHaveBeenCalledWith('updateReportsBatch', {
+      reportArrayKey: 'clusterPolicyReports',
+      updatedReports: reports
+    });
+  });
+
+  describe('fetchPackages', () => {
+    const PACKAGES_TTL = 5 * 60 * 1000; // or whatever you use
+
+    it('should not fetch if cache is still valid and force is false', async() => {
+      // Make the cache still valid
+      state.packageCacheTime = Date.now();
+      // The difference between now and packageCacheTime is < PACKAGES_TTL, so it’s valid
+
+      await actions.fetchPackages({
+        state,
+        commit,
+        dispatch
+      }, {
+        value: {},
+        force: false
+      });
+
+      // Expect NO commits that indicate we fetched anything
+      expect(commit).not.toHaveBeenCalledWith('updatePackages', expect.anything());
+      expect(commit).not.toHaveBeenCalledWith('updatePackageDetails', expect.anything());
+    });
+
+    it('should fetch multiple pages if cache is invalid, then commit results', async() => {
+      // Make the cache too old (invalid)
+      state.packageCacheTime = Date.now() - (PACKAGES_TTL + 10000);
+
+      const mockValue = {
+        artifactHubRepo: jest.fn()
+          .mockResolvedValueOnce({
+            packages: Array.from({ length: 60 }, (_, i) => ({
+              package_id: `pkg-${ i }`,
+              name:       `packageName-${ i }`,
+              repository: { url: 'https://some-other-repo.com' },
+            }))
+          })
+          .mockResolvedValueOnce({
+            packages: Array.from({ length: 30 }, (_, i) => ({
+              package_id: `pkg-${ i + 60 }`,
+              name:       `packageName-${ i + 60 }`,
+              repository: { url: 'https://some-other-repo.com' },
+            }))
+          }),
+        artifactHubPackage: jest.fn((packageId) => {
+          return Promise.resolve({
+            data:       {},
+            package_id: packageId,
+          });
+        })
+      };
+
+      // Mock dispatch for fetching package details
+      dispatch.mockImplementation((actionName, payload) => {
+        if (actionName === 'fetchPackageDetails') {
+          return mockValue.artifactHubPackage(payload.pkg.package_id);
+        }
+      });
+
+      await actions.fetchPackages({
+        state,
+        commit,
+        dispatch
+      }, {
+        value: mockValue,
+        force: false
+      });
+
+      // Expect artifactHubRepo to have been called twice:
+      expect(mockValue.artifactHubRepo).toHaveBeenCalledTimes(2);
+      expect(mockValue.artifactHubRepo).toHaveBeenNthCalledWith(1, {
+        offset: 0,
+        limit:  60
+      });
+      expect(mockValue.artifactHubRepo).toHaveBeenNthCalledWith(2, {
+        offset: 60,
+        limit:  60
+      });
+
+      // Confirm that at least one call to fetchPackageDetails was made.
+      expect(dispatch).toHaveBeenCalledWith('fetchPackageDetails', expect.objectContaining({ pkg: expect.objectContaining({ package_id: 'pkg-0' }) }));
+
+      // Confirm that final commits were made
+      expect(commit).toHaveBeenCalledWith('updatePackages', expect.any(Array));
+      expect(commit).toHaveBeenCalledWith('updatePackageDetails', expect.any(Object));
+      expect(commit).toHaveBeenCalledWith('updatePackageCacheTime', expect.any(Number));
+    });
+
+    it('should filter out Rego-based packages and hidden UI packages', async() => {
+      const mockValue = {
+        artifactHubRepo: jest.fn().mockResolvedValueOnce({
+          packages: [
+            // Rego-based package (to be filtered out immediately)
+            {
+              package_id: 'rego-1',
+              repository: { url: REGO_POLICIES_REPO }
+            },
+            // Hidden UI package (will be filtered out after details fetch)
+            {
+              package_id: 'hidden-1',
+              repository: { url: 'https://some-other.example.com' }
+            },
+            // Normal package (should remain)
+            {
+              package_id: 'normal-1',
+              repository: { url: 'https://some-other.example.com' }
+            }
+          ]
+        }),
+        artifactHubPackage: jest.fn((packageId) => {
+          if (packageId === 'hidden-1') {
+            return Promise.resolve({
+              data:       { 'kubewarden/hidden-ui': 'true' },
+              package_id: packageId
+            });
+          }
+
+          return Promise.resolve({
+            data:       {},
+            package_id: packageId
+          });
+        })
+      };
+
+      dispatch.mockImplementation((actionName, payload) => {
+        if (actionName === 'fetchPackageDetails') {
+          return mockValue.artifactHubPackage(payload.pkg.package_id);
+        }
+      });
+
+      await actions.fetchPackages({
+        state,
+        commit,
+        dispatch
+      }, {
+        value: mockValue,
+        force: true
+      });
+
+      // The final commit should only include the normal package.
+      expect(commit).toHaveBeenCalledWith('updatePackages', [
+        expect.objectContaining({ package_id: 'normal-1' })
+      ]);
+
+      // We expect that fetchPackageDetails is called only for hidden-1 and normal-1,
+      // since Rego-based packages are filtered out before that.
+      expect(mockValue.artifactHubPackage).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('regenerateSummaryMap should call generateSummaryMap and commit "setSummaryMap"', async() => {
+    const context = {
+      state,
+      commit
+    };
+
+    await actions.regenerateSummaryMap(context);
+    expect(generateSummaryMap).toHaveBeenCalledWith(state);
+    expect(commit).toHaveBeenCalledWith('setSummaryMap', { summary: 'testSummary' });
+  });
+
+  it('updatePolicyTraces should commit "updatePolicyTraces" with the given payload', () => {
+    const payload = {
+      policyName:   'testPolicy',
+      cluster:      'testCluster',
+      updatedTrace: { id: 'trace1' }
+    };
+
+    actions.updatePolicyTraces({ commit }, payload);
+    expect(commit).toHaveBeenCalledWith('updatePolicyTraces', payload);
+  });
+
+  it('removePolicyTraceById should commit "removePolicyTraceById" with provided policy and trace', () => {
+    const policy = { policyName: 'testPolicy' };
+    const trace = { id: 'trace1' };
+
+    actions.removePolicyTraceById({ commit }, policy, trace);
+    expect(commit).toHaveBeenCalledWith('removePolicyTraceById', policy, trace);
+  });
+
+  it('updateRefreshingCharts should commit "updateRefreshingCharts" with the provided value', () => {
+    actions.updateRefreshingCharts({ commit }, true);
+    expect(commit).toHaveBeenCalledWith('updateRefreshingCharts', true);
+  });
+
+  it('updateControllerApp should commit "updateControllerApp" with the provided value', () => {
+    const app = {
+      id:       'app1',
+      metadata: {},
+      spec:     {},
+      status:   {}
+    };
+
+    actions.updateControllerApp({ commit }, app);
+    expect(commit).toHaveBeenCalledWith('updateControllerApp', app);
+  });
+
+  it('removeControllerApp should commit "removeControllerApp" with the provided value', () => {
+    const app = {
+      id:       'app1',
+      metadata: {},
+      spec:     {},
+      status:   {}
+    };
+
+    actions.removeControllerApp({ commit }, app);
+    expect(commit).toHaveBeenCalledWith('removeControllerApp', app);
+  });
+
+  it('updateKubewardenCrds should commit "updateKubewardenCrds" with the provided value', () => {
+    const crd = {
+      metadata: { name: 'crd1' },
+      spec:     {},
+      status:   {}
+    };
+
+    actions.updateKubewardenCrds({ commit }, crd);
+    expect(commit).toHaveBeenCalledWith('updateKubewardenCrds', crd);
+  });
+
+  it('removeKubewardenCrds should commit "removeKubewardenCrds" with the provided value', () => {
+    const crd = {
+      metadata: { name: 'crd1' },
+      spec:     {},
+      status:   {}
+    };
+
+    actions.removeKubewardenCrds({ commit }, crd);
+    expect(commit).toHaveBeenCalledWith('removeKubewardenCrds', crd);
+  });
+});


### PR DESCRIPTION
Fix #1094 

This will improve the fetching of packages from ArtifactHub by applying pagination batching to the requests. Since AH has a limit of `60` packages per request, we need to iterate over the packages by using an offset query param until the full amount of packages have been fetched. Afterwards, we can properly filter out Rego policies from our list.

Improvements to package fetching and management:

* [`pkg/kubewarden/components/Policies/Create.vue`](diffhunk://#diff-51620d557c8c41e598b1851cf6c28ba84bd74a4f80f7f761c8a9e0eccdc0ba64L64-R66): Changed the lifecycle hook from `async fetch` to `async created` to ensure proper fetching of packages.
* [`pkg/kubewarden/plugins/kubewarden-class.js`](diffhunk://#diff-a2fe30004d09f38ec9bc1fbe9526522963bdd41f3b99a0e1ecf1b02c2c2191c3L57-R64): Updated the `artifactHubRepo` method to support pagination by adding `offset` and `limit` parameters.
* [`pkg/kubewarden/store/kubewarden/actions.ts`](diffhunk://#diff-894d197043214ae063a3bba2613b9906fcff8aa0c5e03b85a85215c5b47bc987L86-R144): Refactored the `fetchPackages` method to handle pagination, filter out Rego-based packages, and fetch full package details before committing to the store. [[1]](diffhunk://#diff-894d197043214ae063a3bba2613b9906fcff8aa0c5e03b85a85215c5b47bc987L86-R144) [[2]](diffhunk://#diff-894d197043214ae063a3bba2613b9906fcff8aa0c5e03b85a85215c5b47bc987L125-R154) [[3]](diffhunk://#diff-894d197043214ae063a3bba2613b9906fcff8aa0c5e03b85a85215c5b47bc987R163)

Code quality improvements:

* [`pkg/kubewarden/chart/kubewarden/admission/MatchConditions.vue`](diffhunk://#diff-14348bb2d6b6280f882ce89e0a7ede1ead02c365a67e93f01f36f12e77ad6e29L52-R52): Added optional chaining to avoid potential errors when accessing `cmInstances`.
* [`pkg/kubewarden/components/Policies/PolicyTable.vue`](diffhunk://#diff-2ca046fd173016078098adb04c310ea0aedea464ccc6c9c9f3d44df3f1bb55ebL240-R240): Added optional chaining to safely access `artifactHubPackage.version`.

Testing improvements:

* [`pkg/kubewarden/store/kubewarden/__tests__/actions.spec.ts`](diffhunk://#diff-e1640d391437836aed31c4be2016e025161b6bcf7fdf795d7a428cd75f778583R1-R302): Added tests for Vuex actions to ensure correct behavior of package fetching, updating, and filtering.