### PR TITLE
Add module to determine PolicyServer resources by labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@kubernetes/client-node": "^1.0.0",
     "@rancher/components": "^0.3.0-alpha.1",
-    "@rancher/shell": "^3.0.2-rc.5",
+    "@rancher/shell": "^3.0.2-rc.6",
     "vue": "^3.5.13",
     "vue-router": "^4.5.0",
     "vuex": "^4.1.0"

--- a/pkg/kubewarden/assets/kubewarden-dashboard-policy.json
+++ b/pkg/kubewarden/assets/kubewarden-dashboard-policy.json
@@ -561,7 +561,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Kubewarden Policy",
+  "title": "Kubewarden / Policy",
   "uid": "kubewarden-dashboard-policy",
   "version": 3
 }

--- a/pkg/kubewarden/assets/kubewarden-dashboard-policyserver.json
+++ b/pkg/kubewarden/assets/kubewarden-dashboard-policyserver.json
@@ -1215,7 +1215,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Kubewarden Policy Server",
+  "title": "Kubewarden / Policy Server",
   "uid": "kubewarden-dashboard-policyserver",
   "version": 3
 }

--- a/pkg/kubewarden/components/Dashboard/DashboardView.vue
+++ b/pkg/kubewarden/components/Dashboard/DashboardView.vue
@@ -10,9 +10,9 @@ import ConsumptionGauge from '@shell/components/ConsumptionGauge';
 import Loading from '@shell/components/Loading';
 
 import { DASHBOARD_HEADERS } from '@kubewarden/config/table-headers';
-import {
-  KUBEWARDEN, KUBEWARDEN_APPS, KUBEWARDEN_CHARTS, KUBEWARDEN_LABELS, WG_POLICY_K8S
-} from '@kubewarden/types';
+import { KUBEWARDEN, KUBEWARDEN_APPS, KUBEWARDEN_CHARTS, WG_POLICY_K8S } from '@kubewarden/types';
+
+import { isPolicyServerResource } from '@kubewarden/modules/policyServer';
 
 import Masthead from './Masthead';
 import Card from './Card';
@@ -105,10 +105,18 @@ export default {
 
     policyServerPods() {
       if (this.$store.getters['cluster/canList'](POD)) {
-        const pods = this.allPods?.filter((pod) => pod?.metadata?.labels?.[KUBEWARDEN_LABELS.POLICY_SERVER]);
+        const policyServerNames = this.allPolicyServers
+          ?.map((ps) => ps.metadata?.name)
+          .filter((name) => !!name);
+
+        const pods = this.allPods?.filter((pod) => {
+          const labels = pod?.metadata?.labels;
+
+          return policyServerNames?.some((name) => isPolicyServerResource(labels, name));
+        });
 
         if (!isEmpty(pods)) {
-          return Object.values(pods).flat();
+          return pods;
         }
 
         return null;

--- a/pkg/kubewarden/components/Dashboard/__tests__/DashboardView.spec.ts
+++ b/pkg/kubewarden/components/Dashboard/__tests__/DashboardView.spec.ts
@@ -23,7 +23,7 @@ const clusterAllMock = jest.fn((resourceType) => {
   case POD:
     return [{
       metadata: {
-        labels: { 'kubewarden/policy-server': 'default' },
+        labels: { app: 'kubewarden-policy-server-default' },
         state:  {
           name:          'running',
           error:         false,
@@ -33,15 +33,15 @@ const clusterAllMock = jest.fn((resourceType) => {
     },
     {
       metadata: {
-        labels: { 'kubewarden/policy-server': 'other' },
+        labels: { app: 'kubewarden-policy-server-other' },
         state:  {
           name:          'pending',
           error:         false,
           transitioning: true,
         },
       },
-    }
-    ];
+    }];
+
   case KUBEWARDEN.POLICY_SERVER:
     return mockPolicyServers;
   default:

--- a/pkg/kubewarden/components/MetricsChecklist.vue
+++ b/pkg/kubewarden/components/MetricsChecklist.vue
@@ -72,6 +72,10 @@ export default {
     unsupportedTelemetrySpec: {
       type:    Boolean,
       default: false
+    },
+    outdatedServiceMonitor: {
+      type:    Boolean,
+      default: false
     }
   },
 
@@ -159,6 +163,22 @@ export default {
       return null;
     },
 
+    updateServiceMonitorsTooltip() {
+      return this.t(
+        'kubewarden.monitoring.prerequisites.tooltips.updateServiceMonitor',
+        {},
+        true
+      );
+    },
+
+    updateServiceMonitorButtonDisabled() {
+      if (!this.kubewardenServiceMonitor || !this.monitoringApp) {
+        return true;
+      }
+
+      return false;
+    },
+
     showConflictingDashboardsBanner() {
       return !this.hasKubewardenDashboards && !isEmpty(this.conflictingGrafanaDashboards);
     }
@@ -196,6 +216,37 @@ export default {
       } catch (e) {
         handleGrowl({
           error: e,
+          store: this.$store
+        });
+        btnCb(false);
+      }
+    },
+
+    async updateServiceMonitor(btnCb) {
+      if (!this.kubewardenServiceMonitor) {
+        btnCb(false);
+
+        return;
+      }
+
+      try {
+        const sm = this.kubewardenServiceMonitor;
+
+        const psName = this.policyServerObj?.metadata?.name || this.policyObj?.spec?.policyServer;
+
+        sm.spec.selector.matchLabels = {
+          'app.kubernetes.io/instance':  `policy-server-${ psName }`,
+          'app.kubernetes.io/component': 'policy-server',
+          'app.kubernetes.io/part-of':   'kubewarden'
+        };
+
+        await sm.save();
+        this.$emit('updateServiceMonitorLabels');
+
+        btnCb(true);
+      } catch (err) {
+        handleGrowl({
+          error: err,
           store: this.$store
         });
         btnCb(false);
@@ -273,21 +324,23 @@ export default {
       <h2>{{ t('kubewarden.monitoring.prerequisites.label') }}</h2>
       <p>{{ t('kubewarden.monitoring.prerequisites.description') }}</p>
     </div>
+
     <Banner
       color="warning"
       :label="t('kubewarden.monitoring.prerequisites.warning')"
     />
+
+    <!-- Basic prerequisites items: OpenTelemetry, Monitoring app, etc. -->
     <div class="mt-20 mb-20">
+      <!-- openTel -->
       <div class="checklist__step mb-20" data-testid="kw-monitoring-checklist-step-open-tel">
         <i class="icon mr-10" :class="badgeIcon(openTelSvc)" />
         <p v-clean-html="t('kubewarden.tracing.openTelemetry', {}, true)" />
       </div>
 
+      <!-- Monitoring -->
       <div class="checklist__step mb-20" data-testid="kw-monitoring-checklist-step-monitoring-app">
-        <i
-          class="icon mr-10"
-          :class="badgeIcon(monitoringApp)"
-        />
+        <i class="icon mr-10" :class="badgeIcon(monitoringApp)" />
         <div class="checklist__config">
           <p v-clean-html="t('kubewarden.monitoring.prerequisites.monitoringApp.label', {}, true)" p />
           <button
@@ -303,22 +356,43 @@ export default {
         </div>
       </div>
 
+      <!-- ServiceMonitor: now split for "outdated" vs. "non-existent" -->
       <div class="checklist__step mb-20" data-testid="kw-monitoring-checklist-step-service-monitor-map">
-        <i class="icon mr-10" :class="badgeIcon(kubewardenServiceMonitor)" />
-        <div class="checklist__config">
-          <p v-clean-html="t('kubewarden.monitoring.prerequisites.serviceMonitor.label', {}, true)" p />
-          <AsyncButton
-            v-if="!kubewardenServiceMonitor"
-            v-clean-tooltip="serviceMonitorsTooltip"
-            data-testid="kw-monitoring-checklist-step-service-monitor-button"
-            mode="serviceMonitor"
-            class="ml-10"
-            :disabled="serviceMonitorButtonDisabled"
-            @click="addServiceMonitor"
-          />
-        </div>
+        <template v-if="outdatedServiceMonitor">
+          <!-- If it's outdated, we show an "Update" path -->
+          <i class="icon mr-10" :class="badgeIcon(!outdatedServiceMonitor)" />
+          <div class="checklist__config">
+            <p v-clean-html="t('kubewarden.monitoring.prerequisites.serviceMonitor.upgrade.label', {}, true)" p />
+            <AsyncButton
+              v-if="kubewardenServiceMonitor && outdatedServiceMonitor"
+              v-clean-tooltip="updateServiceMonitorsTooltip"
+              data-testid="kw-monitoring-checklist-step-service-monitor-upgrade-button"
+              mode="serviceMonitorUpgrade"
+              class="ml-10"
+              :disabled="updateServiceMonitorButtonDisabled"
+              @click="updateServiceMonitor"
+            />
+          </div>
+        </template>
+        <template v-else>
+          <!-- If it's not outdated, maybe it's simply missing? Show a "Create" path -->
+          <i class="icon mr-10" :class="badgeIcon(kubewardenServiceMonitor)" />
+          <div class="checklist__config">
+            <p v-clean-html="t('kubewarden.monitoring.prerequisites.serviceMonitor.label', {}, true)" p />
+            <AsyncButton
+              v-if="!kubewardenServiceMonitor"
+              v-clean-tooltip="serviceMonitorsTooltip"
+              data-testid="kw-monitoring-checklist-step-service-monitor-button"
+              mode="serviceMonitor"
+              class="ml-10"
+              :disabled="serviceMonitorButtonDisabled"
+              @click="addServiceMonitor"
+            />
+          </div>
+        </template>
       </div>
 
+      <!-- Dashboards -->
       <div class="checklist__step mb-20" data-testid="kw-monitoring-checklist-step-config-map">
         <i class="icon mr-10" :class="badgeIcon(hasKubewardenDashboards)" />
         <div class="checklist__config">
@@ -367,6 +441,7 @@ export default {
         />
       </div>
 
+      <!-- Controller metrics configuration -->
       <div class="checklist__step mb-20" data-testid="kw-monitoring-checklist-step-controller-config">
         <i class="icon mr-10" :class="badgeIcon(metricsConfiguration)" />
         <div class="checklist__config">
@@ -383,6 +458,7 @@ export default {
           </button>
         </div>
       </div>
+
     </div>
   </div>
 </template>

--- a/pkg/kubewarden/components/MetricsChecklist.vue
+++ b/pkg/kubewarden/components/MetricsChecklist.vue
@@ -334,13 +334,13 @@ export default {
     <div class="mt-20 mb-20">
       <!-- openTel -->
       <div class="checklist__step mb-20" data-testid="kw-monitoring-checklist-step-open-tel">
-        <i class="icon mr-10" :class="badgeIcon(openTelSvc)" />
+        <i data-testid="kw-otel-icon" class="icon mr-10" :class="badgeIcon(openTelSvc)" />
         <p v-clean-html="t('kubewarden.tracing.openTelemetry', {}, true)" />
       </div>
 
       <!-- Monitoring -->
       <div class="checklist__step mb-20" data-testid="kw-monitoring-checklist-step-monitoring-app">
-        <i class="icon mr-10" :class="badgeIcon(monitoringApp)" />
+        <i data-testid="kw-monitoring-icon" class="icon mr-10" :class="badgeIcon(monitoringApp)" />
         <div class="checklist__config">
           <p v-clean-html="t('kubewarden.monitoring.prerequisites.monitoringApp.label', {}, true)" p />
           <button
@@ -360,7 +360,7 @@ export default {
       <div class="checklist__step mb-20" data-testid="kw-monitoring-checklist-step-service-monitor-map">
         <template v-if="outdatedServiceMonitor">
           <!-- If it's outdated, we show an "Update" path -->
-          <i class="icon mr-10" :class="badgeIcon(!outdatedServiceMonitor)" />
+          <i data-testid="kw-sm-icon" class="icon mr-10" :class="badgeIcon(!outdatedServiceMonitor)" />
           <div class="checklist__config">
             <p v-clean-html="t('kubewarden.monitoring.prerequisites.serviceMonitor.upgrade.label', {}, true)" p />
             <AsyncButton
@@ -376,7 +376,7 @@ export default {
         </template>
         <template v-else>
           <!-- If it's not outdated, maybe it's simply missing? Show a "Create" path -->
-          <i class="icon mr-10" :class="badgeIcon(kubewardenServiceMonitor)" />
+          <i data-testid="kw-sm-icon" class="icon mr-10" :class="badgeIcon(kubewardenServiceMonitor)" />
           <div class="checklist__config">
             <p v-clean-html="t('kubewarden.monitoring.prerequisites.serviceMonitor.label', {}, true)" p />
             <AsyncButton
@@ -394,7 +394,7 @@ export default {
 
       <!-- Dashboards -->
       <div class="checklist__step mb-20" data-testid="kw-monitoring-checklist-step-config-map">
-        <i class="icon mr-10" :class="badgeIcon(hasKubewardenDashboards)" />
+        <i data-testid="kw-dashboard-icon" class="icon mr-10" :class="badgeIcon(hasKubewardenDashboards)" />
         <div class="checklist__config">
           <p v-clean-html="t('kubewarden.monitoring.prerequisites.configMap.label', {}, true)" p />
           <AsyncButton
@@ -412,7 +412,7 @@ export default {
         v-if="showConflictingDashboardsBanner"
         color="error"
       >
-        <div class="conflicting-banner">
+        <div data-testid="kw-monitoring-checklist-conflicting-banner" class="conflicting-banner">
           <p>
             {{ t('kubewarden.monitoring.prerequisites.configMap.conflictingDashboardsBanner', { count: conflictingGrafanaDashboards.length }, true) }}
           </p>
@@ -431,11 +431,13 @@ export default {
       <div>
         <Banner
           v-if="outdatedTelemetrySpec"
+          data-testid="kw-monitoring-checklist-outdated-telemetry"
           color="error"
           :label="t('kubewarden.monitoring.prerequisites.outdated')"
         />
         <Banner
           v-if="unsupportedTelemetrySpec"
+          data-testid="kw-monitoring-checklist-unsupported-telemetry"
           color="error"
           :label="t('kubewarden.monitoring.prerequisites.unsupported')"
         />
@@ -443,7 +445,7 @@ export default {
 
       <!-- Controller metrics configuration -->
       <div class="checklist__step mb-20" data-testid="kw-monitoring-checklist-step-controller-config">
-        <i class="icon mr-10" :class="badgeIcon(metricsConfiguration)" />
+        <i data-testid="kw-metrics-config-icon" class="icon mr-10" :class="badgeIcon(metricsConfiguration)" />
         <div class="checklist__config">
           <p v-clean-html="t('kubewarden.monitoring.prerequisites.controllerConfig.label', {}, true)" p />
           <button

--- a/pkg/kubewarden/components/MetricsTab.vue
+++ b/pkg/kubewarden/components/MetricsTab.vue
@@ -23,6 +23,7 @@ import { refreshCharts } from '@kubewarden/utils/chart';
 import { grafanaProxy } from '@kubewarden/modules/grafana';
 import { findServiceMonitor } from '@kubewarden/modules/metricsConfig';
 import { jaegerPolicyName } from '@kubewarden/modules/jaegerTracing';
+import { findPolicyServerResource } from '@kubewarden/modules/policyServer';
 
 import MetricsChecklist from './MetricsChecklist';
 
@@ -324,12 +325,11 @@ export default {
 
     policyServerSvcs() {
       if (!isEmpty(this.allPolicyServers)) {
-        const policyServerNames = this.allPolicyServers.map((ps) => ps?.metadata?.name);
-        const out = [];
+        const policyServerNames = this.allPolicyServers
+          .map((ps) => ps?.metadata?.name)
+          .filter(Boolean);
 
-        for (const ps of policyServerNames) {
-          out.push(this.allServices?.find((svc) => svc?.metadata?.labels?.app === `kubewarden-policy-server-${ ps }`));
-        }
+        const out = policyServerNames.map((name) => findPolicyServerResource(this.allServices, name));
 
         return out;
       }

--- a/pkg/kubewarden/components/MetricsTab.vue
+++ b/pkg/kubewarden/components/MetricsTab.vue
@@ -18,6 +18,7 @@ import Loading from '@shell/components/Loading';
 import { Banner } from '@components/Banner';
 
 import { KUBEWARDEN, KUBEWARDEN_CHARTS, KubewardenDashboardLabels, KubewardenDashboards } from '@kubewarden/types';
+import { isAdminUser } from '@kubewarden/utils/permissions';
 import { handleGrowl } from '@kubewarden/utils/handle-growl';
 import { refreshCharts } from '@kubewarden/utils/chart';
 import { grafanaProxy } from '@kubewarden/modules/grafana';
@@ -57,86 +58,7 @@ export default {
   mixins: [ResourceFetch],
 
   async fetch() {
-    this.debouncedRefreshCharts = debounce((init = false) => {
-      refreshCharts({
-        store:     this.$store,
-        chartName: 'rancher-monitoring',
-        init
-      });
-    }, 500);
-
-    const resourceMap = [
-      {
-        name:     CATALOG.APP,
-        property: this.allApps
-      },
-      {
-        name:     CATALOG.CLUSTER_REPO,
-        property: this.allRepos
-      },
-      {
-        name:     CONFIG_MAP,
-        property: this.allConfigMaps
-      },
-      {
-        name:     KUBEWARDEN.POLICY_SERVER,
-        property: this.allPolicyServers
-      },
-      {
-        name:     MONITORING.SERVICEMONITOR,
-        property: this.allServiceMonitors
-      },
-      {
-        name:     NAMESPACE,
-        property: this.allNamespaces
-      },
-      {
-        name:     SERVICE,
-        property: this.allServices
-      },
-    ];
-    const hash = [];
-
-    // Check if the resources are already stored with their respective getters before fetching
-    for (const resource of resourceMap) {
-      if (isEmpty(resource.property) && this.$store.getters['cluster/canList'](resource.name)) {
-        hash.push(this.$fetchType(resource.name));
-      }
-    }
-
-    await allHash(hash);
-
-    if (this.showChecklist && !this.monitoringChart) {
-      this.debouncedRefreshCharts(true);
-    }
-
-    // If monitoring is installed look for the dashboard based on the METRICS_TYPE
-    if (this.monitoringStatus.installed) {
-      try {
-        this.metricsProxy = await grafanaProxy({
-          store: this.$store,
-          type:  this.METRICS_TYPE
-        });
-
-        if (this.metricsProxy) {
-          this.metricsService = await dashboardExists('v2', this.$store, this.currentCluster?.id, this.metricsProxy);
-        }
-      } catch (e) {
-        const error = {
-          _statusText: 'Error',
-          message:     `Error fetching Grafana Service: ${ e }`
-        };
-
-        handleGrowl({
-          error,
-          store: this.$store
-        });
-      }
-    }
-
-    if (this.controllerApp) {
-      await this.controllerApp.fetchValues(true);
-    }
+    await this.fetchData();
   },
 
   data() {
@@ -144,6 +66,17 @@ export default {
 
     return {
       METRICS_TYPE,
+
+      isAdminUser: false,
+      permissions: {
+        policyServer:   false,
+        app:            false,
+        clusterRepo:    false,
+        configMap:      false,
+        serviceMonitor: false,
+        namespace:      false,
+        service:        false
+      },
 
       [CATALOG.APP]:               null,
       [CATALOG.CLUSTER_REPO]:      null,
@@ -236,6 +169,10 @@ export default {
       const monitoringServices = this.allServices?.filter((svc) => svc?.metadata?.labels?.['app.kubernetes.io/instance'] === 'rancher-monitoring');
 
       return monitoringServices?.find((svc) => svc?.metadata?.labels?.['app.kubernetes.io/name'] === 'grafana');
+    },
+
+    hasAvailability() {
+      return this.isAdminUser || Object.values(this.permissions).every((value) => value);
     },
 
     kubewardenGrafanaDashboards() {
@@ -363,6 +300,138 @@ export default {
   },
 
   methods: {
+    async fetchData() {
+      this.setAdminUser();
+      this.setPermissions();
+      this.initDebouncedRefreshCharts();
+      await this.fetchResourcesData();
+      this.refreshChartsIfNeeded();
+      await this.handleGrafanaDashboard();
+      await this.fetchControllerAppValues();
+    },
+
+    setAdminUser() {
+      // Determine if the current user is an admin.
+      this.isAdminUser = isAdminUser(this.$store.getters);
+    },
+
+    setPermissions() {
+      // Map resource types to their respective keys.
+      const types = {
+        policyServer:   { type: KUBEWARDEN.POLICY_SERVER },
+        app:            { type: CATALOG.APP },
+        clusterRepo:    { type: CATALOG.CLUSTER_REPO },
+        configMap:      { type: CONFIG_MAP },
+        serviceMonitor: { type: MONITORING.SERVICEMONITOR },
+        namespace:      { type: NAMESPACE },
+        service:        { type: SERVICE }
+      };
+
+      // Set permissions based on store getters.
+      Object.entries(types).forEach(([key, value]) => {
+        if (this.$store.getters['cluster/canList'](value)) {
+          this.permissions[key] = true;
+        }
+      });
+    },
+
+    initDebouncedRefreshCharts() {
+      // Create a debounced function for refreshing charts.
+      this.debouncedRefreshCharts = debounce((init = false) => {
+        refreshCharts({
+          store:     this.$store,
+          chartName: 'rancher-monitoring',
+          init
+        });
+      }, 500);
+    },
+
+    async fetchResourcesData() {
+      // Define the mapping of resource names to their stored properties.
+      const resourceMap = [
+        {
+          name:     CATALOG.APP,
+          property: this.allApps
+        },
+        {
+          name:     CATALOG.CLUSTER_REPO,
+          property: this.allRepos
+        },
+        {
+          name:     CONFIG_MAP,
+          property: this.allConfigMaps
+        },
+        {
+          name:     KUBEWARDEN.POLICY_SERVER,
+          property: this.allPolicyServers
+        },
+        {
+          name:     MONITORING.SERVICEMONITOR,
+          property: this.allServiceMonitors
+        },
+        {
+          name:     NAMESPACE,
+          property: this.allNamespaces
+        },
+        {
+          name:     SERVICE,
+          property: this.allServices
+        }
+      ];
+
+      // Collect resource fetch promises if the property is empty and listing is allowed.
+      const promises = resourceMap.reduce((acc, resource) => {
+        if (isEmpty(resource.property) && this.$store.getters['cluster/canList'](resource.name)) {
+          acc.push(this.$fetchType(resource.name));
+        }
+
+        return acc;
+      }, []);
+
+      await allHash(promises);
+    },
+
+    refreshChartsIfNeeded() {
+      // Refresh charts if the checklist is shown and no monitoring chart exists.
+      if (this.showChecklist && !this.monitoringChart) {
+        this.debouncedRefreshCharts(true);
+      }
+    },
+
+    async handleGrafanaDashboard() {
+      if (this.monitoringStatus.installed) {
+        try {
+          this.metricsProxy = await grafanaProxy({
+            store: this.$store,
+            type:  this.METRICS_TYPE
+          });
+
+          if (this.metricsProxy) {
+            this.metricsService = await dashboardExists(
+              'v2',
+              this.$store,
+              this.currentCluster?.id,
+              this.metricsProxy
+            );
+          }
+        } catch (error) {
+          handleGrowl({
+            error: {
+              _statusText: 'Error',
+              message:     `Error fetching Grafana Service: ${ error }`
+            },
+            store: this.$store
+          });
+        }
+      }
+    },
+
+    async fetchControllerAppValues() {
+      if (this.controllerApp) {
+        await this.controllerApp.fetchValues(true);
+      }
+    },
+
     async updateServiceMonitors() {
       await this.$fetchType(MONITORING.SERVICEMONITOR);
     },
@@ -382,28 +451,36 @@ export default {
 <template>
   <Loading v-if="$fetchState.pending" mode="relative" />
   <div v-else>
-    <MetricsChecklist
-      v-if="showChecklist"
-      :cattle-dashboard-ns="cattleDashboardNs"
-      :conflicting-grafana-dashboards="conflictingGrafanaDashboards"
-      :controller-app="controllerApp"
-      :controller-chart="controllerChart"
-      :kubewarden-service-monitor="kubewardenServiceMonitor"
-      :kubewarden-dashboards="kubewardenGrafanaDashboards"
-      :metrics-configuration="metricsConfiguration"
-      :monitoring-app="monitoringApp"
-      :monitoring-chart="monitoringChart"
-      :open-tel-svc="openTelSvc"
-      :policy-obj="policyObj"
-      :policy-server-obj="policyServerObj"
-      :outdated-telemetry-spec="outdatedTelemetrySpec"
-      :unsupported-telemetry-spec="unsupportedTelemetrySpec"
-      :outdated-service-monitor="outdatedServiceMonitor"
-      @updateServiceMonitors="updateServiceMonitors"
-      @updateServiceMonitorLabels="updateServiceMonitorLabels"
-    />
+    <Banner
+        v-if="!hasAvailability"
+        color="error"
+        class="mt-20 mb-20"
+        data-testid="kw-unavailability-banner"
+        :label="t('kubewarden.unavailability.banner', { type: t('kubewarden.unavailability.type.metricsDashboard') })"
+      />
 
-    <template v-if="!showChecklist">
+      <MetricsChecklist
+        v-else-if="showChecklist"
+        :cattle-dashboard-ns="cattleDashboardNs"
+        :conflicting-grafana-dashboards="conflictingGrafanaDashboards"
+        :controller-app="controllerApp"
+        :controller-chart="controllerChart"
+        :kubewarden-service-monitor="kubewardenServiceMonitor"
+        :kubewarden-dashboards="kubewardenGrafanaDashboards"
+        :metrics-configuration="metricsConfiguration"
+        :monitoring-app="monitoringApp"
+        :monitoring-chart="monitoringChart"
+        :open-tel-svc="openTelSvc"
+        :policy-obj="policyObj"
+        :policy-server-obj="policyServerObj"
+        :outdated-telemetry-spec="outdatedTelemetrySpec"
+        :unsupported-telemetry-spec="unsupportedTelemetrySpec"
+        :outdated-service-monitor="outdatedServiceMonitor"
+        @updateServiceMonitors="updateServiceMonitors"
+        @updateServiceMonitorLabels="updateServiceMonitorLabels"
+      />
+
+    <template v-else>
       <Banner
         v-if="monitoringApp && !metricsProxy"
         color="error"

--- a/pkg/kubewarden/components/MetricsTab.vue
+++ b/pkg/kubewarden/components/MetricsTab.vue
@@ -189,7 +189,7 @@ export default {
     },
 
     metricsConfiguration() {
-      if (!this.controllerApp) {
+      if (!this.controllerApp?.values) {
         return null;
       }
 

--- a/pkg/kubewarden/components/TraceTable.vue
+++ b/pkg/kubewarden/components/TraceTable.vue
@@ -132,7 +132,7 @@ export default {
     },
 
     tracingConfiguration() {
-      if (!this.controllerApp) {
+      if (!this.controllerApp?.values) {
         return null;
       }
 

--- a/pkg/kubewarden/components/__tests__/MetricsTab.spec.ts
+++ b/pkg/kubewarden/components/__tests__/MetricsTab.spec.ts
@@ -117,15 +117,18 @@ describe('KubewardenDashboard Component', () => {
     expect(wrapper.findComponent({ name: 'Loading' }).exists()).toBe(true);
   });
 
-  it('renders MetricsChecklist when showChecklist is true', () => {
+  it('renders MetricsChecklist when showChecklist is true', async() => {
     // With the above data, computed showChecklist should be true if any required condition is missing.
     // In this test, we let the checklist appear.
     const wrapper = createWrapper({
       props: {
         policyObj:       {},
         policyServerObj: {} // purposely not setting a valid policy server so that showChecklist is true
-      }
+      },
     });
+
+    wrapper.setData({ isAdminUser: true });
+    await wrapper.vm.$nextTick();
 
     expect(wrapper.findComponent({ name: 'MetricsChecklist' }).exists()).toBe(true);
   });
@@ -161,7 +164,10 @@ describe('KubewardenDashboard Component', () => {
     });
 
     // Simulate that we found a valid metricsProxy from Grafana
-    wrapper.setData({ metricsProxy });
+    wrapper.setData({
+      metricsProxy,
+      isAdminUser: true
+    });
 
     await wrapper.vm.$nextTick();
 

--- a/pkg/kubewarden/components/__tests__/MetricsTab.spec.ts
+++ b/pkg/kubewarden/components/__tests__/MetricsTab.spec.ts
@@ -130,17 +130,21 @@ describe('KubewardenDashboard Component', () => {
     expect(wrapper.findComponent({ name: 'MetricsChecklist' }).exists()).toBe(true);
   });
 
-  it('renders Banner when showChecklist is false, monitoringApp exists, and metricsProxy is null', () => {
-    // To get showChecklist to be false, supply valid data for every computed property.
-    const wrapper = createWrapper({ props: { policyServerObj: { id: 'policy-server-1' } } });
+  it('renders Banner when showChecklist is false (all dependencies present) but metricsProxy is null', () => {
+    // Pass a valid policyServerObj so the SM is found
+    // and we have the telemetry set, dashboards found, etc.
+    // That means showChecklist = false. Because the store mocks have everything needed.
+    const wrapper = createWrapper({
+      props: {
+        policyServerObj: {
+          id:       'policy-server-1',
+          metadata: { labels: { app: 'kubewarden-policy-server-policy-server-1' } }
+        }
+      }
+    });
 
-    // With the above store data:
-    // - openTelSvc exists (from SERVICE)
-    // - monitoringApp exists (from CATALOG.APP with rancher-monitoring)
-    // - kubewardenServiceMonitor is truthy (because the service monitor selector matches the policy server id)
-    // - metricsConfiguration returns true (from the controller app telemetry setup)
-    // - kubewardenGrafanaDashboards is truthy (from CONFIG_MAP)
-    // So, showChecklist should be false and the template should render the Banner.
+    // By default, metricsProxy is null => so we expect the Banner to appear
+    expect(wrapper.findComponent({ name: 'MetricsChecklist' }).exists()).toBe(true);
     expect(wrapper.findComponent({ name: 'Banner' }).exists()).toBe(true);
     expect(wrapper.findComponent({ name: 'DashboardMetrics' }).exists()).toBe(false);
   });
@@ -153,10 +157,14 @@ describe('KubewardenDashboard Component', () => {
       }
     });
 
+    // Simulate that we found a valid metricsProxy from Grafana
     wrapper.setData({ metricsProxy });
 
     await wrapper.vm.$nextTick();
 
+    // Now showChecklist should be false, metricsProxy is set, active is true => show the DashboardMetrics
+    expect(wrapper.findComponent({ name: 'MetricsChecklist' }).exists()).toBe(false);
+    expect(wrapper.findComponent({ name: 'Banner' }).exists()).toBe(false);
     expect(wrapper.findComponent({ name: 'DashboardMetrics' }).exists()).toBe(true);
   });
 

--- a/pkg/kubewarden/components/__tests__/MetricsTab.spec.ts
+++ b/pkg/kubewarden/components/__tests__/MetricsTab.spec.ts
@@ -138,13 +138,16 @@ describe('KubewardenDashboard Component', () => {
       props: {
         policyServerObj: {
           id:       'policy-server-1',
-          metadata: { labels: { app: 'kubewarden-policy-server-policy-server-1' } }
+          metadata: {
+            labels: { app: 'kubewarden-policy-server-policy-server-1' },
+            uid:    'asdf'
+          }
         }
       }
     });
 
     // By default, metricsProxy is null => so we expect the Banner to appear
-    expect(wrapper.findComponent({ name: 'MetricsChecklist' }).exists()).toBe(true);
+    expect(wrapper.findComponent({ name: 'MetricsChecklist' }).exists()).toBe(false);
     expect(wrapper.findComponent({ name: 'Banner' }).exists()).toBe(true);
     expect(wrapper.findComponent({ name: 'DashboardMetrics' }).exists()).toBe(false);
   });

--- a/pkg/kubewarden/components/__tests__/TraceTable.spec.ts
+++ b/pkg/kubewarden/components/__tests__/TraceTable.spec.ts
@@ -118,7 +118,7 @@ describe('TraceTable.vue', () => {
     expect(wrapper.findComponent({ name: 'Loading' }).exists()).toBe(true);
   });
 
-  it('renders TraceChecklist when showChecklist is true', () => {
+  it('renders TraceChecklist when showChecklist is true', async() => {
     // To force showChecklist to be true we simulate missing required services by making SERVICE getter return an empty array.
     const wrapper = createWrapper({
       props: { resource: 'non-policy-resource' },
@@ -131,6 +131,9 @@ describe('TraceTable.vue', () => {
         }
       }
     });
+
+    wrapper.setData({ isAdminUser: true });
+    await wrapper.vm.$nextTick();
 
     // With no SERVICE data, computed "jaegerQuerySvc" and "openTelSvc" will be null,
     // so "showChecklist" (which is computed as: (!openTelSvc || !jaegerQuerySvc || !tracingConfiguration)) is true.
@@ -179,7 +182,10 @@ describe('TraceTable.vue', () => {
     // Here, we *do not* call fetch if we plan to manually set specificValidations,
     // because fetch might overwrite them with the real Jaeger data (which we’ve mocked as empty).
     // Instead, we just do:
-    wrapper.setData({ specificValidations: mockTraces });
+    wrapper.setData({
+      specificValidations: mockTraces,
+      isAdminUser:         true
+    });
 
     await wrapper.vm.$nextTick();
 

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -23,7 +23,7 @@ kubewarden:
       appUpgrade: App Upgrade
       controllerChart: Controller
       defaultsChart: Defaults
-      appVersionUnsatisfied: "The app version of the Kubewarden Defaults ({defaultsAppVersion}) chart does not match the app version of the Kubewarden Controller chart ({controllerAppVersion}). This chart will need to be updated to match the app version of the Kubewarden Controller chart."
+      appVersionUnsatisfied: 'The app version of the Kubewarden Defaults ({defaultsAppVersion}) chart does not match the app version of the Kubewarden Controller chart ({controllerAppVersion}). This chart will need to be updated to match the app version of the Kubewarden Controller chart.'
     policyReports:
       oldPolicyReportsIncompatible: 'Policy Reports are not compatible with the current version of the Kubewarden App. Please update to version v1.11.0 or newer.'
       newPolicyReportsIncompatible: 'Policy Reports are not compatible with the current version of the Kubewarden extension. Please update to version 1.4.0 or newer.'
@@ -214,6 +214,8 @@ kubewarden:
         edit: Edit Config
       serviceMonitor:
         label: A Service Monitor for this Policy Server does not exist. Follow the <a href="https://docs.kubewarden.io/next/howtos/ui-extension/metrics#install" target="_blank" rel="noopener noreferrer nofollow">documentation</a> to learn more about Service Monitors.
+        upgrade:
+          label: The Service Monitor for this Policy Server is outdated. Follow the <a href="https://docs.kubewarden.io/next/howtos/ui-extension/metrics#upgrade" target="_blank" rel="noopener noreferrer nofollow">documentation</a> to learn more about Service Monitors.
       configMap:
         label: Grafana Dashboards (ConfigMaps) for the Policy Servers and for Kubewarden Policies must be created.
         button: Add Dashboards
@@ -507,6 +509,10 @@ asyncButton:
     action: Add Service Monitor
     success: Added
     waiting: Adding&hellip;
+  serviceMonitorUpgrade:
+    action: Upgrade Service Monitor
+    success: Upgraded
+    waiting: Upgrading&hellip;
   policyReporterRepo:
     action: Add Policy Reporter Repository
     success: Added

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -5,6 +5,8 @@ kubewarden:
     type:
       dashboard: Kubewarden Dashboard
       policyReporter: Policy Reporter
+      metricsDashboard: Metrics Dashboard
+      tracingDashboard: Tracing Dashboard
   generic:
     name: Name
   dashboard:

--- a/pkg/kubewarden/modules/__tests__/metricsConfig.spec.ts
+++ b/pkg/kubewarden/modules/__tests__/metricsConfig.spec.ts
@@ -160,13 +160,30 @@ describe('addKubewardenServiceMonitor', () => {
     await addKubewardenServiceMonitor(config);
 
     expect(mockStore.getters['cluster/schemaFor']).toHaveBeenCalledWith(MONITORING.SERVICEMONITOR);
-    expect(mockStore.dispatch).toHaveBeenCalledWith('cluster/create', expect.objectContaining({
-      type:     MONITORING.SERVICEMONITOR,
-      metadata: expect.objectContaining({
-        name:      'mock',
-        namespace: 'controller-ns'
+
+    // Then it calls 'cluster/create' with an object containing name:'kubewarden' by default
+    expect(mockStore.dispatch).toHaveBeenCalledWith(
+      'cluster/create',
+      expect.objectContaining({
+        type:     MONITORING.SERVICEMONITOR,
+        metadata: expect.objectContaining({
+          name:      'kubewarden',
+          namespace: 'controller-ns'
+        }),
+        // Also check spec.selector.matchLabels
+        spec: expect.objectContaining({
+          selector: expect.objectContaining({
+            matchLabels: {
+              'app.kubernetes.io/component': 'policy-server',
+              'app.kubernetes.io/instance':  'policy-server-mock',
+              'app.kubernetes.io/part-of':   'kubewarden'
+            }
+          })
+        })
       })
-    }));
+    );
+
+    // Finally, that object’s save() is called
     expect(fakeServiceMonitorTemplate.save).toHaveBeenCalled();
   });
 

--- a/pkg/kubewarden/modules/__tests__/policyServer.spec.ts
+++ b/pkg/kubewarden/modules/__tests__/policyServer.spec.ts
@@ -20,8 +20,7 @@ describe('isPolicyServerResource', () => {
     const labels: Labels = {
       'app.kubernetes.io/instance':   'policy-server-default',
       'app.kubernetes.io/component':  'policy-server',
-      'app.kubernetes.io/part-of':    'kubewarden',
-      'app.kubernetes.io/managed-by': 'kubewarden-controller',
+      'app.kubernetes.io/part-of':    'kubewarden'
     };
 
     expect(isPolicyServerResource(labels, 'default')).toBe(true);
@@ -54,8 +53,7 @@ describe('findPolicyServerResource', () => {
         labels: {
           'app.kubernetes.io/instance':   'policy-server-other',
           'app.kubernetes.io/component':  'policy-server',
-          'app.kubernetes.io/part-of':    'kubewarden',
-          'app.kubernetes.io/managed-by': 'kubewarden-controller',
+          'app.kubernetes.io/part-of':    'kubewarden'
         },
       },
     },
@@ -101,8 +99,7 @@ describe('findServiceMonitor', () => {
         matchLabels: {
           'app.kubernetes.io/instance':   'policy-server-default',
           'app.kubernetes.io/component':  'policy-server',
-          'app.kubernetes.io/part-of':    'kubewarden',
-          'app.kubernetes.io/managed-by': 'kubewarden-controller',
+          'app.kubernetes.io/part-of':    'kubewarden'
         },
       },
     },

--- a/pkg/kubewarden/modules/__tests__/policyServer.spec.ts
+++ b/pkg/kubewarden/modules/__tests__/policyServer.spec.ts
@@ -1,0 +1,167 @@
+import {
+  isPolicyServerResource,
+  findPolicyServerResource,
+  findServiceMonitor,
+  Labels,
+} from '@kubewarden/modules/policyServer';
+
+describe('isPolicyServerResource', () => {
+  it('should return false if labels is undefined', () => {
+    expect(isPolicyServerResource(undefined, 'default')).toBe(false);
+  });
+
+  it('should return true for legacy label match', () => {
+    const labels: Labels = { app: 'kubewarden-policy-server-default' };
+
+    expect(isPolicyServerResource(labels, 'default')).toBe(true);
+  });
+
+  it('should return true for new strict labels match', () => {
+    const labels: Labels = {
+      'app.kubernetes.io/instance':   'policy-server-default',
+      'app.kubernetes.io/component':  'policy-server',
+      'app.kubernetes.io/part-of':    'kubewarden',
+      'app.kubernetes.io/managed-by': 'kubewarden-controller',
+    };
+
+    expect(isPolicyServerResource(labels, 'default')).toBe(true);
+  });
+
+  it('should return false when labels do not match any supported format', () => {
+    const labels: Labels = { app: 'some-other-app' };
+
+    expect(isPolicyServerResource(labels, 'default')).toBe(false);
+  });
+
+  it('should return false when only a partial new format is provided', () => {
+    const labels: Labels = {
+      'app.kubernetes.io/instance': 'policy-server-default',
+      // Missing the other required new-format keys.
+    };
+
+    expect(isPolicyServerResource(labels, 'default')).toBe(false);
+  });
+});
+
+describe('findPolicyServerResource', () => {
+  // Create a sample array of resources with metadata.labels
+  const resources = [
+    // Matches legacy format for "default"
+    { metadata: { labels: { app: 'kubewarden-policy-server-default' } } },
+    // Matches new strict format for "other"
+    {
+      metadata: {
+        labels: {
+          'app.kubernetes.io/instance':   'policy-server-other',
+          'app.kubernetes.io/component':  'policy-server',
+          'app.kubernetes.io/part-of':    'kubewarden',
+          'app.kubernetes.io/managed-by': 'kubewarden-controller',
+        },
+      },
+    },
+    // Non-matching resource
+    { metadata: { labels: { app: 'not-matching' } } },
+  ];
+
+  it('should return the resource matching the legacy label', () => {
+    const result = findPolicyServerResource(resources, 'default');
+
+    expect(result).toBe(resources[0]);
+  });
+
+  it('should return the resource matching the new strict labels', () => {
+    const result = findPolicyServerResource(resources, 'other');
+
+    expect(result).toBe(resources[1]);
+  });
+
+  it('should return undefined if no resource matches', () => {
+    const result = findPolicyServerResource(resources, 'nonexistent');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should allow a custom label accessor', () => {
+    const customResources = [
+      { labels: { app: 'kubewarden-policy-server-custom' } },
+    ];
+    const customAccessor = (resource: any) => resource.labels;
+    const result = findPolicyServerResource(customResources, 'custom', customAccessor);
+
+    expect(result).toBe(customResources[0]);
+  });
+});
+
+describe('findServiceMonitor', () => {
+  const mockLegacySM = { spec: { selector: { matchLabels: { app: 'kubewarden-policy-server-default' } } } };
+
+  const mockNewSM = {
+    spec: {
+      selector: {
+        matchLabels: {
+          'app.kubernetes.io/instance':   'policy-server-default',
+          'app.kubernetes.io/component':  'policy-server',
+          'app.kubernetes.io/part-of':    'kubewarden',
+          'app.kubernetes.io/managed-by': 'kubewarden-controller',
+        },
+      },
+    },
+  };
+
+  it('should return undefined when allServiceMonitors is empty', () => {
+    const config = {
+      policyObj:          { spec: { policyServer: 'default' } },
+      policyServerObj:    undefined,
+      allServiceMonitors: [],
+    };
+    const result = findServiceMonitor(config);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined if no policy server name is provided', () => {
+    const config = {
+      policyObj:          { spec: {} },
+      policyServerObj:    {},
+      allServiceMonitors: [mockLegacySM],
+    };
+    const result = findServiceMonitor(config);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return a matching ServiceMonitor using legacy labels', () => {
+    const config = {
+      policyObj:          { spec: { policyServer: 'default' } },
+      policyServerObj:    undefined,
+      allServiceMonitors: [mockLegacySM, mockNewSM],
+    };
+    const result = findServiceMonitor(config);
+
+    expect(result).toBe(mockLegacySM);
+  });
+
+  it('should return a matching ServiceMonitor using new strict labels', () => {
+    // Use policyServerObj when policyObj is not provided.
+    const config = {
+      policyObj:          undefined,
+      policyServerObj:    { id: 'default' },
+      allServiceMonitors: [mockNewSM, mockLegacySM],
+    };
+    const result = findServiceMonitor(config);
+
+    expect(result).toBe(mockNewSM);
+  });
+
+  it('should return the first matching ServiceMonitor if multiple matches exist', () => {
+    // In this scenario, both monitors match; the first in the array should be returned.
+    const config = {
+      policyObj:          { spec: { policyServer: 'default' } },
+      policyServerObj:    undefined,
+      allServiceMonitors: [mockNewSM, mockLegacySM],
+    };
+    const result = findServiceMonitor(config);
+
+    expect(result).toBe(mockNewSM);
+  });
+});

--- a/pkg/kubewarden/modules/metricsConfig.ts
+++ b/pkg/kubewarden/modules/metricsConfig.ts
@@ -119,8 +119,8 @@ export async function addKubewardenServiceMonitor(config: ServiceMonitorConfig):
   if (store.getters['cluster/schemaFor'](MONITORING.SERVICEMONITOR)) {
     const smName: string = policyObj ? policyObj.spec?.policyServer : policyServerObj?.id as string;
     const labels = {
-      'app.kubernetes.io/instance':   `kubewarden-policy-server-${ policyServerObj?.id }`,
-      'app.kubernetes.io/component':  `kubewarden-policy-server-${ policyServerObj?.id }`,
+      'app.kubernetes.io/instance':   `policy-server-${ policyServerObj?.id }`,
+      'app.kubernetes.io/component':  'policy-server',
       'app.kubernetes.io/part-of':    'kubewarden',
       'app.kubernetes.io/managed-by': 'kubewarden-controller'
     };

--- a/pkg/kubewarden/modules/metricsConfig.ts
+++ b/pkg/kubewarden/modules/metricsConfig.ts
@@ -193,6 +193,7 @@ export function isServiceMonitorOutOfDate(ps: PolicyServer, sm: ServiceMonitor):
 
   const psLabels = ps.metadata?.labels || {};
   const smLabels = sm.spec?.selector?.matchLabels || {};
+  const psName = ps.metadata?.name || ps.id;
 
   const newLabels = {
     'app.kubernetes.io/instance':  `policy-server-${ ps.metadata?.name }`,
@@ -200,12 +201,12 @@ export function isServiceMonitorOutOfDate(ps: PolicyServer, sm: ServiceMonitor):
     'app.kubernetes.io/part-of':   'kubewarden'
   };
 
-  const policyServerIsNewStyle =
+  const psIsNewStyle =
     psLabels['app.kubernetes.io/instance']  === newLabels['app.kubernetes.io/instance']  &&
     psLabels['app.kubernetes.io/component'] === newLabels['app.kubernetes.io/component'] &&
     psLabels['app.kubernetes.io/part-of']   === newLabels['app.kubernetes.io/part-of'];
 
-  if (policyServerIsNewStyle) {
+  if (psIsNewStyle) {
     const smHasNewLabels =
       smLabels['app.kubernetes.io/instance']  === newLabels['app.kubernetes.io/instance']  &&
       smLabels['app.kubernetes.io/component'] === newLabels['app.kubernetes.io/component'] &&
@@ -214,7 +215,7 @@ export function isServiceMonitorOutOfDate(ps: PolicyServer, sm: ServiceMonitor):
     return !smHasNewLabels;
   }
 
-  const smHasOldStyle = smLabels.app === `kubewarden-policy-server-${ ps.metadata?.name }`;
+  const smHasOldStyle = smLabels.app === `kubewarden-policy-server-${ psName }`;
 
   return !smHasOldStyle;
 }

--- a/pkg/kubewarden/modules/metricsConfig.ts
+++ b/pkg/kubewarden/modules/metricsConfig.ts
@@ -193,7 +193,6 @@ export function isServiceMonitorOutOfDate(ps: PolicyServer, sm: ServiceMonitor):
 
   const psLabels = ps.metadata?.labels || {};
   const smLabels = sm.spec?.selector?.matchLabels || {};
-  const psName = ps.metadata?.name || ps.id;
 
   const newLabels = {
     'app.kubernetes.io/instance':  `policy-server-${ ps.metadata?.name }`,
@@ -201,22 +200,23 @@ export function isServiceMonitorOutOfDate(ps: PolicyServer, sm: ServiceMonitor):
     'app.kubernetes.io/part-of':   'kubewarden'
   };
 
+  // Determine if the PolicyServer is using the new label style.
   const psIsNewStyle =
-    psLabels['app.kubernetes.io/instance']  === newLabels['app.kubernetes.io/instance']  &&
+    psLabels['app.kubernetes.io/instance'] === newLabels['app.kubernetes.io/instance'] &&
     psLabels['app.kubernetes.io/component'] === newLabels['app.kubernetes.io/component'] &&
-    psLabels['app.kubernetes.io/part-of']   === newLabels['app.kubernetes.io/part-of'];
+    psLabels['app.kubernetes.io/part-of'] === newLabels['app.kubernetes.io/part-of'];
 
+  // Only if the PolicyServer is new style do we need the ServiceMonitor to have the new labels.
   if (psIsNewStyle) {
     const smHasNewLabels =
-      smLabels['app.kubernetes.io/instance']  === newLabels['app.kubernetes.io/instance']  &&
+      smLabels['app.kubernetes.io/instance'] === newLabels['app.kubernetes.io/instance'] &&
       smLabels['app.kubernetes.io/component'] === newLabels['app.kubernetes.io/component'] &&
-      smLabels['app.kubernetes.io/part-of']   === newLabels['app.kubernetes.io/part-of'];
+      smLabels['app.kubernetes.io/part-of'] === newLabels['app.kubernetes.io/part-of'];
 
     return !smHasNewLabels;
   }
 
-  const smHasOldStyle = smLabels.app === `kubewarden-policy-server-${ psName }`;
-
-  return !smHasOldStyle;
+  // If the PolicyServer is still using old labels, we consider the ServiceMonitor up-to-date.
+  return false;
 }
 

--- a/pkg/kubewarden/modules/metricsConfig.ts
+++ b/pkg/kubewarden/modules/metricsConfig.ts
@@ -195,21 +195,20 @@ export function isServiceMonitorOutOfDate(ps: PolicyServer, sm: ServiceMonitor):
   const smLabels = sm.spec?.selector?.matchLabels || {};
 
   const newLabels = {
-    'app.kubernetes.io/instance':  `policy-server-${ ps.metadata?.name }`,
     'app.kubernetes.io/component': 'policy-server',
     'app.kubernetes.io/part-of':   'kubewarden'
   };
 
   // Determine if the PolicyServer is using the new label style.
   const psIsNewStyle =
-    psLabels['app.kubernetes.io/instance'] === newLabels['app.kubernetes.io/instance'] &&
-    psLabels['app.kubernetes.io/component'] === newLabels['app.kubernetes.io/component'] &&
-    psLabels['app.kubernetes.io/part-of'] === newLabels['app.kubernetes.io/part-of'];
+    psLabels['app.kubernetes.io/instance'] &&
+    psLabels['app.kubernetes.io/component'] &&
+    psLabels['app.kubernetes.io/part-of'];
 
   // Only if the PolicyServer is new style do we need the ServiceMonitor to have the new labels.
   if (psIsNewStyle) {
     const smHasNewLabels =
-      smLabels['app.kubernetes.io/instance'] === newLabels['app.kubernetes.io/instance'] &&
+      smLabels['app.kubernetes.io/instance'] &&
       smLabels['app.kubernetes.io/component'] === newLabels['app.kubernetes.io/component'] &&
       smLabels['app.kubernetes.io/part-of'] === newLabels['app.kubernetes.io/part-of'];
 

--- a/pkg/kubewarden/modules/policyServer.ts
+++ b/pkg/kubewarden/modules/policyServer.ts
@@ -11,7 +11,6 @@ export type Labels = Record<string, string> | undefined;
  *    - `app.kubernetes.io/instance`: `policy-server-<policyServerName>`
  *    - `app.kubernetes.io/component`: `policy-server`
  *    - `app.kubernetes.io/part-of`: `kubewarden`
- *    - `app.kubernetes.io/managed-by`: `kubewarden-controller`
  *
  * @param labels - The labels object to check.
  * @param policyServerName - The policy server name.
@@ -29,8 +28,7 @@ export function isPolicyServerResource(labels: Labels, policyServerName: string)
   const newMatch =
     labels['app.kubernetes.io/instance'] === `policy-server-${ policyServerName }` &&
     labels['app.kubernetes.io/component'] === 'policy-server' &&
-    labels['app.kubernetes.io/part-of'] === 'kubewarden' &&
-    labels['app.kubernetes.io/managed-by'] === 'kubewarden-controller';
+    labels['app.kubernetes.io/part-of'] === 'kubewarden';
 
   return legacyMatch || newMatch;
 }

--- a/pkg/kubewarden/modules/policyServer.ts
+++ b/pkg/kubewarden/modules/policyServer.ts
@@ -1,0 +1,84 @@
+import { ServiceMonitor, ServiceMonitorConfig } from '@kubewarden/types';
+
+export type Labels = Record<string, string> | undefined;
+
+/**
+ * Checks if the provided labels object matches a Policy Server resource.
+ *
+ * It supports both:
+ * - The legacy label: `app=kubewarden-policy-server-<policyServerName>`
+ * - The new strict labels:
+ *    - `app.kubernetes.io/instance`: `policy-server-<policyServerName>`
+ *    - `app.kubernetes.io/component`: `policy-server`
+ *    - `app.kubernetes.io/part-of`: `kubewarden`
+ *    - `app.kubernetes.io/managed-by`: `kubewarden-controller`
+ *
+ * @param labels - The labels object to check.
+ * @param policyServerName - The policy server name.
+ * @returns True if the labels match.
+ */
+export function isPolicyServerResource(labels: Labels, policyServerName: string): boolean {
+  if (!labels) {
+    return false;
+  }
+
+  // Check the legacy label format.
+  const legacyMatch = labels.app === `kubewarden-policy-server-${ policyServerName }`;
+
+  // Check the new strict label format.
+  const newMatch =
+    labels['app.kubernetes.io/instance'] === `policy-server-${ policyServerName }` &&
+    labels['app.kubernetes.io/component'] === 'policy-server' &&
+    labels['app.kubernetes.io/part-of'] === 'kubewarden' &&
+    labels['app.kubernetes.io/managed-by'] === 'kubewarden-controller';
+
+  return legacyMatch || newMatch;
+}
+
+/**
+ * Finds the first matching resource from an array based on Policy Server labels.
+ *
+ * @param resources - The list of resources to search.
+ * @param policyServerName - The policy server name to match.
+ * @param labelAccessor - Optional function to extract the labels from a resource.
+ *                        Defaults to extracting `res.metadata?.labels`.
+ * @returns The matching resource if found.
+ */
+export function findPolicyServerResource<T>(
+  resources: T[],
+  policyServerName: string,
+  labelAccessor: (resource: T) => Record<string, string> | undefined = (res: any) => res.metadata?.labels // eslint-disable-line no-unused-vars
+): T | undefined {
+  return resources.find((resource: T) => {
+    const labels = labelAccessor(resource);
+
+    return isPolicyServerResource(labels, policyServerName);
+  });
+}
+
+/**
+ * Searches provided ServiceMonitors for a matching resource based on selector.matchLabels.
+ * It checks for both the legacy and new strict Policy Server labels.
+ *
+ * @param config - Contains either a policy object or policy server object along with all fetched ServiceMonitors.
+ * @returns The matching ServiceMonitor if found.
+ */
+export function findServiceMonitor(config: ServiceMonitorConfig): ServiceMonitor | undefined {
+  const { policyObj, policyServerObj, allServiceMonitors } = config;
+
+  if (allServiceMonitors && allServiceMonitors.length > 0) {
+    const smName: string | undefined = policyObj ? policyObj.spec?.policyServer : policyServerObj?.id;
+
+    if (!smName) {
+      return undefined;
+    }
+
+    return allServiceMonitors.find((sm) => {
+      const labels = sm?.spec?.selector?.matchLabels;
+
+      return isPolicyServerResource(labels, smName);
+    });
+  }
+
+  return undefined;
+}

--- a/pkg/kubewarden/plugins/__tests__/policy-server-class.spec.ts
+++ b/pkg/kubewarden/plugins/__tests__/policy-server-class.spec.ts
@@ -223,7 +223,12 @@ describe('PolicyServerModel', () => {
 
   describe('matchingPods', () => {
     it('returns matching pods using dispatch', async() => {
-      const pods = [{ id: 'pod1' }];
+      const pods = [{
+        metadata: {
+          name: 'pod1',
+          uid:  'asdf'
+        }
+      }];
 
       dispatch.mockResolvedValue(pods);
       const fn = instance.matchingPods;
@@ -237,7 +242,7 @@ describe('PolicyServerModel', () => {
         },
         { root: true }
       );
-      expect(result).toBe(pods);
+      expect(result).toStrictEqual(pods);
     });
 
     it('handles errors and logs a warning', async() => {
@@ -254,7 +259,12 @@ describe('PolicyServerModel', () => {
 
   describe('openLogs', () => {
     it('dispatches wm/open if matching pods are found', async() => {
-      const podArray = [{ id: 'pod1' }];
+      const podArray = [{
+        metadata: {
+          name: 'pod1',
+          uid:  'asdf'
+        }
+      }];
 
       // Stub matchingPods to return podArray.
       jest.spyOn(instance, 'matchingPods', 'get').mockReturnValue(() => Promise.resolve(podArray));

--- a/pkg/kubewarden/plugins/policy-server-class.js
+++ b/pkg/kubewarden/plugins/policy-server-class.js
@@ -128,10 +128,28 @@ export default class PolicyServerModel extends KubewardenModel {
   get matchingPods() {
     return async() => {
       try {
-        return await this.$dispatch('cluster/findMatching', {
-          type:     POD,
-          selector: `app=kubewarden-policy-server-${ this.metadata?.name }` // kubewarden-policy-server is hardcoded from the kubewarden-controller
-        }, { root: true });
+        const name = this.metadata?.name;
+        const oldSelector = `app=kubewarden-policy-server-${ name }`;
+        const newSelector = `app.kubernetes.io/instance=policy-server-${ name }`;
+
+        const [podsOld, podsNew] = await Promise.all([
+          this.$dispatch('cluster/findMatching', {
+            type:     POD,
+            selector: oldSelector
+          }, { root: true }),
+          this.$dispatch('cluster/findMatching', {
+            type:     POD,
+            selector: newSelector
+          }, { root: true })
+        ]);
+
+        // Merge the two arrays and remove duplicates based on a unique identifier (e.g. metadata.uid)
+        const podsMap = new Map();
+
+        (podsOld || []).forEach((p) => podsMap.set(p.metadata.id, p));
+        (podsNew || []).forEach((p) => podsMap.set(p.metadata.id, p));
+
+        return Array.from(podsMap.values());
       } catch (e) {
         console.warn('Error matching policy-server to pod', e);
       }

--- a/pkg/kubewarden/plugins/policy-server-class.js
+++ b/pkg/kubewarden/plugins/policy-server-class.js
@@ -146,8 +146,8 @@ export default class PolicyServerModel extends KubewardenModel {
         // Merge the two arrays and remove duplicates based on a unique identifier (e.g. metadata.uid)
         const podsMap = new Map();
 
-        (podsOld || []).forEach((p) => podsMap.set(p.metadata.id, p));
-        (podsNew || []).forEach((p) => podsMap.set(p.metadata.id, p));
+        (podsOld || []).forEach((p) => podsMap.set(p?.metadata?.uid, p));
+        (podsNew || []).forEach((p) => podsMap.set(p?.metadata?.uid, p));
 
         return Array.from(podsMap.values());
       } catch (e) {

--- a/pkg/kubewarden/types.ts
+++ b/pkg/kubewarden/types.ts
@@ -8,6 +8,7 @@ export * from './types/grafana';
 export * from './types/kubewarden';
 export * from './types/jaeger';
 export * from './types/metrics';
+export * from './types/monitoring.coreos.com';
 export * from './types/policy';
 export * from './types/policy-reporter';
 export * from './types/rancher';

--- a/pkg/kubewarden/types/metrics.ts
+++ b/pkg/kubewarden/types/metrics.ts
@@ -1,26 +1,23 @@
-type Endpoint = {
-  interval: string,
-  port: string
+import {
+  ServiceMonitor, ServiceMonitorSpec, CatalogApp, Service, PolicyServer, Policy
+} from '@kubewarden/types';
+
+export type ServiceMonitorConfigured = {
+  namespace: boolean,
+  selectors?: {[key: string]: boolean}[];
 }
 
-export interface ServiceMonitorSpec {
-  endpoints?: Endpoint[],
-  name?: string,
-  namespaceSelector?: {
-    matchNames?: string[]
-  },
-  selector?: {
-    matchLabels?: {[key: string]: string}
-  }
+export interface MonitoringConfig {
+  serviceMonitorSpec: ServiceMonitorSpec[],
+  controllerApp: CatalogApp,
+  policyServerSvcs: Service[]
 }
 
-export interface ServiceMonitor {
-  apiVersion?: string,
-  kind?: string,
-  metadata: {
-    name: string
-    namespace: string
-  },
-  spec: ServiceMonitorSpec,
-  type?: string
+export interface ServiceMonitorConfig {
+  store: any,
+  policyObj?: Policy,
+  policyServerObj?: PolicyServer,
+  controllerNs: string,
+  allServiceMonitors?: ServiceMonitor[]
+  serviceMonitor?: ServiceMonitor
 }

--- a/pkg/kubewarden/types/monitoring.coreos.com.ts
+++ b/pkg/kubewarden/types/monitoring.coreos.com.ts
@@ -1,0 +1,100 @@
+import { V1ObjectMeta, V1LabelSelector } from '@kubernetes/client-node';
+
+/**
+ * ServiceMonitor is the custom resource definition (CRD) that defines how Prometheus
+ * and PrometheusAgent scrape metrics from a group of services.
+ */
+export interface ServiceMonitor {
+  apiVersion: 'monitoring.coreos.com/v1';
+  kind: 'ServiceMonitor';
+  metadata: V1ObjectMeta;
+  spec: ServiceMonitorSpec;
+  type?: string; // This is not part of the CRD, it's added by Rancher
+}
+
+/**
+ * ServiceMonitorSpec defines the desired Service selection for target discovery by Prometheus.
+ */
+export interface ServiceMonitorSpec {
+  jobLabel?: string;
+  targetLabels?: string[];
+  podTargetLabels?: string[];
+  endpoints: Endpoint[];
+  selector: V1LabelSelector;
+  selectorMechanism?: SelectorMechanism;
+  namespaceSelector?: NamespaceSelector;
+  sampleLimit?: number;
+  scrapeProtocols?: ScrapeProtocol[];
+  fallbackScrapeProtocol?: ScrapeProtocol;
+  targetLimit?: number;
+  labelLimit?: number;
+  labelNameLengthLimit?: number;
+  labelValueLengthLimit?: number;
+  scrapeClassicHistograms?: boolean;
+  nativeHistogramBucketLimit?: number;
+  nativeHistogramMinBucketFactor?: string;
+  keepDroppedTargets?: number;
+  attachMetadata?: AttachMetadata;
+  scrapeClass?: string;
+  bodySizeLimit?: ByteSize;
+}
+
+/**
+ * Endpoint defines how to scrape metrics from Kubernetes Endpoints objects.
+ */
+export interface Endpoint {
+  port?: string;
+  interval?: string;
+  path?: string;
+  scheme?: string;
+  tlsConfig?: TLSConfig;
+  bearerTokenFile?: string;
+  params?: { [key: string]: string[] };
+  honorLabels?: boolean;
+  metricRelabelings?: any[];
+  relabelings?: any[];
+}
+
+/**
+ * TLSConfig provides the TLS configuration for secure communication.
+ */
+export interface TLSConfig {
+  caFile?: string;
+  certFile?: string;
+  keyFile?: string;
+  serverName?: string;
+  insecureSkipVerify?: boolean;
+}
+
+/**
+ * SelectorMechanism defines the mechanism used to select endpoints.
+ */
+export type SelectorMechanism = 'label' | 'role';
+
+/**
+ * NamespaceSelector defines in which namespaces Prometheus should discover the services.
+ */
+export interface NamespaceSelector {
+  any?: boolean;
+  matchNames?: string[];
+}
+
+/**
+ * ScrapeProtocol defines the protocol used during scraping.
+ */
+export type ScrapeProtocol = 'http' | 'https';
+
+/**
+ * AttachMetadata defines additional metadata to add to discovered targets.
+ * You can expand this interface based on further documentation.
+ */
+export interface AttachMetadata {
+  labels?: string[];
+  annotations?: string[];
+}
+
+/**
+ * ByteSize is a type alias for representing size limits.
+ * Typically sizes are provided as strings (e.g., "10Mi").
+ */
+export type ByteSize = string;

--- a/tests/e2e/pages/telemetry.page.ts
+++ b/tests/e2e/pages/telemetry.page.ts
@@ -23,7 +23,7 @@ export class TelemetryPage extends BasePage {
       otel          : getLine(page, /^The OpenTelemetry Operator/),
       jaeger        : getLine(this.tracingTab, /^The Jaeger Operator/),
       monitoring    : getLine(this.metricsTab, /^The Rancher Monitoring app/),
-      servicemonitor: getLine(this.metricsTab, /^A Service Monitor/),
+      servicemonitor: page.locator('[data-testid="kw-sm-icon"]'),
       configmap     : getLine(this.metricsTab, /^Grafana Dashboards/),
       config        : getLine(page, /^(Tracing|The Kubewarden Controller) must be (enabled and )?configured/)
     }

--- a/tests/e2e/pages/telemetry.page.ts
+++ b/tests/e2e/pages/telemetry.page.ts
@@ -23,7 +23,7 @@ export class TelemetryPage extends BasePage {
       otel          : getLine(page, /^The OpenTelemetry Operator/),
       jaeger        : getLine(this.tracingTab, /^The Jaeger Operator/),
       monitoring    : getLine(this.metricsTab, /^The Rancher Monitoring app/),
-      servicemonitor: page.locator('[data-testid="kw-sm-icon"]'),
+      servicemonitor: getLine(this.metricsTab, /^(A|The) Service Monitor/),
       configmap     : getLine(this.metricsTab, /^Grafana Dashboards/),
       config        : getLine(page, /^(Tracing|The Kubewarden Controller) must be (enabled and )?configured/)
     }

--- a/tests/unit/mocks/policyServers.ts
+++ b/tests/unit/mocks/policyServers.ts
@@ -108,5 +108,113 @@ export default <PolicyServer[]>[
         }
       ]
     }
+  },
+  {
+    id:    'other',
+    type:  'policies.kubewarden.io.policyserver',
+    links: {
+      remove: 'https://localhost:8005/v1/policies.kubewarden.io.policyservers/other',
+      self:   'https://localhost:8005/v1/policies.kubewarden.io.policyservers/other',
+      update: 'https://localhost:8005/v1/policies.kubewarden.io.policyservers/other',
+      view:   'https://localhost:8005/apis/policies.kubewarden.io/v1/policyservers/other'
+    },
+    apiVersion: 'policies.kubewarden.io/v1',
+    kind:       'PolicyServer',
+    metadata:   {
+      annotations: {
+        'meta.helm.sh/release-name':      'rancher-kubewarden-defaults',
+        'meta.helm.sh/release-namespace': 'cattle-kubewarden-system'
+      },
+      creationTimestamp: '2025-02-21T11:42:01Z',
+      finalizers:        [
+        'kubewarden.io/finalizer'
+      ],
+      generation: 1,
+      labels:     {
+        'app.kubernetes.io/component':  'policy-server',
+        'app.kubernetes.io/instance':   'rancher-kubewarden-defaults',
+        'app.kubernetes.io/managed-by': 'Helm',
+        'app.kubernetes.io/name':       'kubewarden-defaults',
+        'app.kubernetes.io/part-of':    'kubewarden',
+        'app.kubernetes.io/version':    'v1.21.0',
+        'helm.sh/chart':                'kubewarden-defaults-2.8.1'
+      },
+      name:            'other',
+      resourceVersion: '157416',
+      state:           {
+        error:         false,
+        message:       'Resource is current',
+        name:          'active',
+        transitioning: false
+      },
+      uid: 'e2f90b41-60b6-412d-956c-617eff095840'
+    },
+    spec: {
+      affinity: {},
+      env:      [
+        {
+          name:  'KUBEWARDEN_LOG_LEVEL',
+          value: 'info'
+        }
+      ],
+      image:              'ghcr.io/kubewarden/policy-server:v1.21.1',
+      replicas:           1,
+      securityContexts:   {},
+      serviceAccountName: 'policy-server'
+    },
+    status: {
+      conditions: [
+        {
+          error:              false,
+          lastTransitionTime: '2025-02-21T11:42:01Z',
+          lastUpdateTime:     '2025-02-21T11:42:01Z',
+          message:            '',
+          reason:             'ReconciliationSucceeded',
+          status:             'True',
+          transitioning:      false,
+          type:               'CertSecretReconciled'
+        },
+        {
+          error:              false,
+          lastTransitionTime: '2025-02-21T11:42:02Z',
+          lastUpdateTime:     '2025-02-21T11:42:02Z',
+          message:            '',
+          reason:             'ReconciliationSucceeded',
+          status:             'True',
+          transitioning:      false,
+          type:               'ConfigMapReconciled'
+        },
+        {
+          error:              false,
+          lastTransitionTime: '2025-02-21T11:42:02Z',
+          lastUpdateTime:     '2025-02-21T11:42:02Z',
+          message:            '',
+          reason:             'ReconciliationSucceeded',
+          status:             'True',
+          transitioning:      false,
+          type:               'PodDisruptionBudgetReconciled'
+        },
+        {
+          error:              false,
+          lastTransitionTime: '2025-02-21T11:42:02Z',
+          lastUpdateTime:     '2025-02-21T11:42:02Z',
+          message:            '',
+          reason:             'ReconciliationSucceeded',
+          status:             'True',
+          transitioning:      false,
+          type:               'DeploymentReconciled'
+        },
+        {
+          error:              false,
+          lastTransitionTime: '2025-02-21T11:42:02Z',
+          lastUpdateTime:     '2025-02-21T11:42:02Z',
+          message:            '',
+          reason:             'ReconciliationSucceeded',
+          status:             'True',
+          transitioning:      false,
+          type:               'ServiceReconciled'
+        }
+      ]
+    }
   }
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -3333,10 +3333,10 @@
   resolved "https://registry.npmjs.org/@rancher/icons/-/icons-2.0.29.tgz#6546d69768c706bebd66bfa73b36aef3d105987a"
   integrity sha512-qBBqfazS9y5VjV7fJDPNXmxd9AP/2uiE05mKFWP41kpbO+tEb62RnUBXCm14XLeScDZQcOuiAKVHMmvCFzF0BA==
 
-"@rancher/shell@^3.0.2-rc.5":
-  version "3.0.2-rc.5"
-  resolved "https://registry.npmjs.org/@rancher/shell/-/shell-3.0.2-rc.5.tgz#721a5697c89c3339846f0be9acbbb545cd7ac20e"
-  integrity sha512-oOh/HlMS562OU+UWE35t1b5fLVW0cZD/bq67g7Uos/jMzEZEV7AWtbFzByyhJmo3hSipVMBoWyws4JQKhmqjcA==
+"@rancher/shell@^3.0.2-rc.6":
+  version "3.0.2-rc.6"
+  resolved "https://registry.npmjs.org/@rancher/shell/-/shell-3.0.2-rc.6.tgz#bde65a3da391c4aa0352e2adf8180900a2575000"
+  integrity sha512-UpNCv0iZH16nlo+x/4xVisIX20v1JrQC47GUUtXcGDw9pde6HnnBPxpN0cF32r+Kg7F0QRp4Yvjoljmpp1HS7g==
   dependencies:
     "@aws-sdk/client-ec2" "3.658.1"
     "@aws-sdk/client-eks" "3.1.0"
@@ -3391,7 +3391,7 @@
     entities "4.5.0"
     eslint "7.32.0"
     eslint-config-standard "16.0.3"
-    eslint-import-resolver-node "0.3.4"
+    eslint-import-resolver-node "0.3.9"
     eslint-module-utils "2.6.1"
     eslint-plugin-cypress "2.12.1"
     eslint-plugin-import "2.31.0"
@@ -3412,7 +3412,7 @@
     jest-serializer-vue "2.0.2"
     jexl "2.3.0"
     jquery "3.5.1"
-    js-cookie "2.2.1"
+    js-cookie "3.0.5"
     js-yaml "4.1.0"
     js-yaml-loader "1.2.2"
     jsdiff "1.1.1"
@@ -7406,7 +7406,7 @@ debounce@^1.2.1:
   resolved "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
   integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
 
-debug@2.6.9, debug@^2.6.9:
+debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -8042,15 +8042,7 @@ eslint-config-standard@16.0.3:
   resolved "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.3.tgz#6c8761e544e96c531ff92642eeb87842b8488516"
   integrity sha512-x4fmJL5hGqNJKGHSjnLdgA6U6h1YW/G2dW9fA+cyVur4SK6lyue8+UgNKWlZtUDTXvgKDD/Oa3GQjmB5kjtVvg==
 
-eslint-import-resolver-node@0.3.4:
-  version "0.3.4"
-  resolved "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz#85ffa81942c25012d8231096ddf679c03042c717"
-  integrity sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==
-  dependencies:
-    debug "^2.6.9"
-    resolve "^1.13.1"
-
-eslint-import-resolver-node@^0.3.9:
+eslint-import-resolver-node@0.3.9, eslint-import-resolver-node@^0.3.9:
   version "0.3.9"
   resolved "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz#d4eaac52b8a2e7c3cd1903eb00f7e053356118ac"
   integrity sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==
@@ -11091,12 +11083,7 @@ js-beautify@^1.14.9, js-beautify@^1.6.12:
     js-cookie "^3.0.5"
     nopt "^8.0.0"
 
-js-cookie@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
-  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
-
-js-cookie@^3.0.5:
+js-cookie@3.0.5, js-cookie@^3.0.5:
   version "3.0.5"
   resolved "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz#0b7e2fd0c01552c58ba86e0841f94dc2557dcdbc"
   integrity sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==


### PR DESCRIPTION
Fix #1096 

This will update how we were determining/identifying PolicyServer resources by using a new set of standardized labels and backwards compatibility for the legacy `app` label

* Added utility functions `isPolicyServerResource` and `findPolicyServerResource` to identify and locate policy server resources based on both legacy and new strict label formats. (`pkg/kubewarden/modules/policyServer.ts`, `pkg/kubewarden/modules/__tests__/policyServer.spec.ts`) [[1]](diffhunk://#diff-0a3a2c4320d47af273806d49acbade967ea2e204c1310c37ff22f47c422f58faR1-R84) [[2]](diffhunk://#diff-9c7eef6ec2b43a8859fba7266a5a7b5eb83e79bbb1492b7e1e5ed95a3ab5eaa6R1-R167)

* Updated the `policyServerPods` method in `DashboardView.vue` to filter pods using the new utility function to ensure compatibility with both legacy and new label formats. (`pkg/kubewarden/components/Dashboard/DashboardView.vue`)

* Modified the `MetricsTab.vue` component to use the `findPolicyServerResource` function for locating policy server services. (`pkg/kubewarden/components/MetricsTab.vue`)

* Added comprehensive tests for the new utility functions to ensure they correctly identify and locate policy server resources under various label configurations. (`pkg/kubewarden/modules/__tests__/policyServer.spec.ts`)

* Refactored the `addKubewardenServiceMonitor` function to use the new label format. (`pkg/kubewarden/modules/metricsConfig.ts`)
