### PR TITLE
Test improvements for rancher 2.11

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -290,6 +290,8 @@ jobs:
       env:
         MODE: ${{ matrix.mode }}
         RANCHER_URL: https://${{ env.RANCHER_FQDN }}
+        # Check that installed extension version matches release tag
+        UIVERSION: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || '' }}
         ORIGIN: ${{ env.KUBEWARDEN }}
         QASE_MODE: ${{ env.QASE == 'true' && 'testops' || 'off' }}
         QASE_TESTOPS_API_TOKEN: ${{ secrets.QASE_APITOKEN }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -173,7 +173,7 @@ jobs:
 
         # Select repository
         helm repo add --force-update rancher-prime https://charts.rancher.com/server-charts/prime
-        helm repo add --force-update rancher-community https://releases.rancher.com/server-charts/alpha # alpha | latest
+        helm repo add --force-update rancher-community https://releases.rancher.com/server-charts/latest # /alpha | /latest
         [[ "$RANCHER" == "rc" || "$RANCHER" == *"-0" ]] && REPO=rancher-community || REPO=rancher-prime
 
         # Translate to sematic version

--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -81,7 +81,7 @@ test('Install UI extension', async({ page, ui }) => {
     if (ORIGIN === 'source') {
       await extensions.developerLoad('http://127.0.0.1:4500/kubewarden-0.0.1/kubewarden-0.0.1.umd.min.js')
     } else {
-      await extensions.install('kubewarden')
+      await extensions.install('kubewarden', { version: process.env.UIVERSION?.replace(/^kubewarden-/, '') } )
     }
   })
 })

--- a/tests/e2e/60-telemetry.spec.ts
+++ b/tests/e2e/60-telemetry.spec.ts
@@ -8,8 +8,7 @@ const cmanRepo: ChartRepo = { name: 'jetstack', url: 'https://charts.jetstack.io
 const cmanChart: Chart = { title: 'cert-manager', name: 'cert-manager', namespace: 'cert-manager', check: 'cert-manager' }
 // OpenTelemetry
 const otelRepo: ChartRepo = { name: 'open-telemetry', url: 'https://open-telemetry.github.io/opentelemetry-helm-charts' }
-// Locked to v0.80.2: https://github.com/kubewarden/kubewarden-controller/issues/1026
-const otelChart: Chart = { title: 'opentelemetry-operator', name: 'opentelemetry-operator', namespace: 'open-telemetry', check: 'opentelemetry-operator', version: '0.80.2' }
+const otelChart: Chart = { title: 'opentelemetry-operator', name: 'opentelemetry-operator', namespace: 'open-telemetry', check: 'opentelemetry-operator' }
 // Jaeger Tracing
 const jaegerRepo: ChartRepo = { name: 'jaegertracing', url: 'https://jaegertracing.github.io/helm-charts' }
 const jaegerChart: Chart = { title: 'jaeger-operator', name: 'jaeger-operator', namespace: 'jaeger', check: 'jaeger-operator' }

--- a/tests/e2e/fleet/open-telemetry/fleet.yaml
+++ b/tests/e2e/fleet/open-telemetry/fleet.yaml
@@ -2,7 +2,7 @@ defaultNamespace: opentelemetry
 helm:
   releaseName: opentelemetry
   chart: opentelemetry-operator
-  version: "0.80.2" # 0.68.1
+  version: "*" # 0.68.1
   repo: https://open-telemetry.github.io/opentelemetry-helm-charts
   values:
     manager:


### PR DESCRIPTION
- switch to rancher -rc channel for rancher 2.11
- remove OTEL lock to version 0.82.2
- add check for correct UI version

We test release after tag is created. This release is named `kubewarden-3.1.1` for example.
Parse version from this tag name and check that tested kubewarden extension has proper version.