### PR TITLE
Add policyServerID to ServiceMonitor creation template name

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -19,7 +19,7 @@ const config: Config.InitialOptions = {
   transform: {
     '^.+\\.js$':   '<rootDir>/node_modules/babel-jest',
     '.*\\.vue$':   '<rootDir>/node_modules/@vue/vue3-jest',
-    '^.+\\.tsx?$': ['ts-jest', { isolatedModules: true }],
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.json' }],
     '^.+\\.svg$':  '<rootDir>/tests/unit/config/svgTransform.ts' // to mock `*.svg` files
   },
   transformIgnorePatterns:  ['/node_modules/(?!(@vue|@rancher|jsonpath-plus))'],

--- a/pkg/kubewarden/modules/__tests__/metricsConfig.spec.ts
+++ b/pkg/kubewarden/modules/__tests__/metricsConfig.spec.ts
@@ -167,7 +167,7 @@ describe('addKubewardenServiceMonitor', () => {
       expect.objectContaining({
         type:     MONITORING.SERVICEMONITOR,
         metadata: expect.objectContaining({
-          name:      'kubewarden',
+          name:      'kubewarden-mock',
           namespace: 'controller-ns'
         }),
         // Also check spec.selector.matchLabels

--- a/pkg/kubewarden/modules/metricsConfig.ts
+++ b/pkg/kubewarden/modules/metricsConfig.ts
@@ -152,7 +152,7 @@ export async function addKubewardenServiceMonitor(config: ServiceMonitorConfig):
       kind:       'ServiceMonitor',
       type:       MONITORING.SERVICEMONITOR,
       metadata:   {
-        name:        'kubewarden',
+        name:        `kubewarden-${ policyServerID }`,
         namespace:   controllerNs
       },
       spec: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "strict": true,
     "noEmit": true,
     "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
     "baseUrl": ".",
     "paths": {
       "~/*": ["./*"],


### PR DESCRIPTION
This will fix an issue when attempting to create ServiceMonitors for multiple PolicyServers. Currently the Metrics checklist attempts to create a SM with only the name `kubewarden`, this PR will add the policy server ID to the name, e.g. `kubewarden-my-policyserver` to ensure there are no duplication errors.

Also updated the jest.config.ts to remove the deprecated configuration option of setting `isolatedModules` within the config and thus moved that option to the root level `tsconfig.json`.