### PR TITLE
[2.8] Backport tests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -22,11 +22,13 @@ on:
         - '~ 2.8'
         - '~ 2.9'
         - '~ 2.10'
+        - '~ 2.11'
         - 'rc'       # rc versions
         - '~ 2.7-0'
         - '~ 2.8-0'
         - '~ 2.9-0'
         - '~ 2.10-0'
+        - '~ 2.11-0'
       k3s:
         description: Kubernetes version
         type: choice

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -270,6 +270,8 @@ jobs:
       env:
         MODE: ${{ matrix.mode }}
         RANCHER_URL: https://${{ env.RANCHER_FQDN }}
+        # Check that installed extension version matches release tag
+        UIVERSION: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || '' }}
         ORIGIN: ${{ env.KUBEWARDEN }}
         QASE_MODE: ${{ env.QASE == 'true' && 'testops' || 'off' }}
         QASE_TESTOPS_API_TOKEN: ${{ secrets.QASE_APITOKEN }}

--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -7,6 +7,7 @@ import { apList, capList, ClusterAdmissionPoliciesPage } from './pages/policies.
 import { RancherAppsPage } from './rancher/rancher-apps.page'
 import { RancherFleetPage } from './rancher/rancher-fleet.page'
 import { RancherUI } from './components/rancher-ui'
+import { Common } from './components/common'
 
 // source (yarn dev) | rc (add github repo) | released (just install)
 const ORIGIN = process.env.ORIGIN || (process.env.API ? 'source' : 'rc')
@@ -15,28 +16,11 @@ expect(ORIGIN).toMatch(/^(source|rc|released)$/)
 const MODE = process.env.MODE || 'base'
 expect(MODE).toMatch(/^(base|fleet|upgrade)$/)
 
-// Known Kubewarden versions for upgrade test, start at [0]
-const upMap: AppVersion[] = [
-  { app: 'v1.11.0', controller: '2.0.10', crds: '1.4.6', defaults: '1.9.4' },
-  { app: 'v1.12.0', controller: '2.0.11', crds: '1.5.0', defaults: '2.0.0' },
-  { app: 'v1.13.0', controller: '2.1.0', crds: '1.5.1', defaults: '2.0.3' },
-  { app: 'v1.14.0', controller: '2.2.1', crds: '1.6.0', defaults: '2.1.0' },
-  { app: 'v1.15.0', controller: '2.3.1', crds: '1.7.0', defaults: '2.2.1' },
-  { app: 'v1.16.0', controller: '2.4.0', crds: '1.8.0', defaults: '2.3.1' },
-  { app: 'v1.17.0', controller: '3.0.1', crds: '1.9.0', defaults: '2.4.0' },
-  { app: 'v1.18.0', controller: '3.1.0', crds: '1.10.0', defaults: '2.5.0' },
-  { app: 'v1.19.0', controller: '3.2.0', crds: '1.11.0', defaults: '2.6.0' },
-  { app: 'v1.20.0', controller: '4.0.1', crds: '1.12.1', defaults: '2.7.1' },
-  { app: 'v1.21.0', controller: '4.1.0', crds: '1.13.0', defaults: '2.8.1' },
-  { app: 'v1.22.0', controller: '4.2.0', crds: '1.14.0', defaults: '2.9.0' },
-].splice(-3) // Limit upgrade path to last 3 versions
-
-// Support for Rancher 2.9 was added in KW 1.13.0
-if (RancherUI.isVersion('>=2.9')) {
-  upMap.splice(0, upMap.findIndex(v => v.app === 'v1.13.0'))
-} else if (RancherUI.isVersion('>=2.10')) {
-  upMap.splice(0, upMap.findIndex(v => v.app === 'v1.18.0'))
-}
+// Fetch Kubewarden versions for upgrade test
+let upMap: AppVersion[]
+test.beforeAll(async() => {
+  if (MODE === 'upgrade') upMap = (await Common.fetchVersionMap()).splice(-3)
+})
 
 test('Initial rancher setup', async({ page, ui, nav }) => {
   const rancher = new RancherCommonPage(page)

--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -78,7 +78,7 @@ test('Install UI extension', async({ page, ui }) => {
     if (ORIGIN === 'source') {
       await extensions.developerLoad('http://127.0.0.1:4500/kubewarden-0.0.1/kubewarden-0.0.1.umd.min.js')
     } else {
-      await extensions.install('kubewarden')
+      await extensions.install('kubewarden', { version: process.env.UIVERSION?.replace(/^kubewarden-/, '') } )
     }
   })
 })

--- a/tests/e2e/60-telemetry.spec.ts
+++ b/tests/e2e/60-telemetry.spec.ts
@@ -219,10 +219,12 @@ test.describe('Metrics', () => {
     await shell.run('kubectl delete cm -n cattle-dashboards kubewarden-dashboard-policy kubewarden-dashboard-policyserver')
     // Check
     await nav.pserver('default', 'Metrics')
-    await telPage.toBeIncomplete('config')
-    await telPage.toBeIncomplete('monitoring')
-    await telPage.toBeIncomplete('servicemonitor')
-    await telPage.toBeIncomplete('configmap')
+    await ui.retry(async()=> {
+      await telPage.toBeIncomplete('config')
+      await telPage.toBeIncomplete('monitoring')
+      await telPage.toBeIncomplete('servicemonitor')
+      await telPage.toBeIncomplete('configmap')
+    }, 'Service monitor shows as installed')
     await expect(telPage.configBtn).toBeDisabled()
   })
 })

--- a/tests/e2e/components/common.ts
+++ b/tests/e2e/components/common.ts
@@ -1,0 +1,42 @@
+import semver from 'semver'
+import yaml from 'js-yaml'
+import { AppVersion } from '../pages/kubewarden.page'
+import { RancherUI } from './rancher-ui'
+
+/**
+ * Common helper functions and constants
+ */
+export class Common {
+  // Build kubewarden version map for upgrade test
+  // { app: 'v1.22.0', controller: '5.0.0', crds: '1.14.0', defaults: '3.0.0' }
+  static async fetchVersionMap(): Promise<AppVersion[]> {
+    // Fetch and parse YAML index file
+    const response = await fetch('https://charts.kubewarden.io/index.yaml')
+    if (!response.ok) throw new Error(`Failed to fetch: ${response.statusText}`)
+
+    const indexData = yaml.load(await response.text()) as { entries: Record<string, any[]> }
+    const versionMap: Record<string, Partial<AppVersion>> = {}
+    const chartNames = ['kubewarden-controller', 'kubewarden-crds', 'kubewarden-defaults']
+
+    for (const chartName of chartNames) {
+      const key = chartName.replace('kubewarden-', '') as keyof AppVersion
+
+      for (const chart of indexData.entries[chartName]) {
+        // Remove prerelease and unsupported versions
+        if (semver.prerelease(chart.appVersion)) continue
+        if (!RancherUI.isVersion(chart.annotations?.['catalog.cattle.io/rancher-version'] || '*')) continue
+
+        // Process each relevant chart entry
+        versionMap[chart.appVersion] ??= { app: chart.appVersion }
+        if (semver.gt(chart.version, versionMap[chart.appVersion][key] ?? '0.0.0')) {
+          versionMap[chart.appVersion][key] = chart.version
+        }
+      }
+    }
+
+    // Filter only complete entries
+    return Object.values(versionMap)
+      .filter((entry): entry is AppVersion => !!entry.controller && !!entry.crds && !!entry.defaults)
+      .sort((a, b) => semver.compare(a.app.replace(/^v/, ''), b.app.replace(/^v/, '')))
+  }
+}

--- a/tests/e2e/pages/kubewarden.page.ts
+++ b/tests/e2e/pages/kubewarden.page.ts
@@ -158,8 +158,8 @@ export class KubewardenPage extends BasePage {
       }
       await apps.updateApp('rancher-kubewarden-controller', { navigate: false, timeout: 4 * 60_000 })
       // 4.1.0 Error: error while loading policies from "/config/policies.yml": data did not match any variant of untagged enum PolicyOrPolicyGroup
-      // 4.2.0 Probe port change from https to http
-      if (!to?.controller?.startsWith('4.1') && !to?.controller?.startsWith('4.2')) {
+      // 5.0.0 Probe port change from https to http
+      if (!to?.controller?.startsWith('4.1') && !to?.controller?.startsWith('5.0')) {
         await shell.waitPods()
       }
 


### PR DESCRIPTION
- workaround for failing to uninstall metrics
- automatically generate upgrade map