### PR TITLE
Manually track errors in PolicyServer edit screen

### DIFF
--- a/pkg/kubewarden/components/Dashboard/__tests__/DashboardView.spec.ts
+++ b/pkg/kubewarden/components/Dashboard/__tests__/DashboardView.spec.ts
@@ -1,6 +1,5 @@
 import { mount } from '@vue/test-utils';
 
-import ConsumptionGauge from '@shell/components/ConsumptionGauge';
 import Loading from '@shell/components/Loading';
 import { CATALOG, POD } from '@shell/config/types';
 

--- a/pkg/kubewarden/edit/policies.kubewarden.io.policyserver.vue
+++ b/pkg/kubewarden/edit/policies.kubewarden.io.policyserver.vue
@@ -6,6 +6,7 @@ import CreateEditView from '@shell/mixins/create-edit-view';
 
 import CruResource from '@shell/components/CruResource';
 import Loading from '@shell/components/Loading';
+import { Banner } from '@components/Banner';
 
 import { DEFAULT_POLICY_SERVER } from '@kubewarden/models/policies.kubewarden.io.policyserver';
 import { KUBEWARDEN } from '@kubewarden/types';
@@ -14,6 +15,7 @@ import Values from '@kubewarden/components/PolicyServer/Values';
 
 export default {
   components: {
+    Banner,
     CruResource,
     Loading,
     Values
@@ -45,10 +47,7 @@ export default {
   },
 
   data() {
-    return {
-      errors:           [],
-      chartValues:      this.value,
-    };
+    return { chartValues: this.value };
   },
 
   created() {
@@ -62,12 +61,22 @@ export default {
       return this.realMode === _CREATE;
     },
 
+    hasErrors() {
+      return this.errors?.length && Array.isArray(this.errors);
+    },
+
     validationPassed() {
       return !!this.chartValues?.metadata?.name;
     }
   },
 
   methods: {
+    closeError(index) {
+      const errors = this.errors.filter((_, i) => i !== index);
+
+      this.errors = errors;
+    },
+
     async finish(event) {
       // Clean up the securityContexts "seccompProfile" property if there are no keys set on the object
       const securityContexts = this.chartValues?.spec?.securityContexts;
@@ -103,12 +112,27 @@ export default {
     :errors="errors"
     :validation-passed="validationPassed"
     @finish="finish"
-    @error="e => errors = e"
   >
     <Values
       :value="value"
       :chart-values="chartValues"
       :mode="mode"
     />
+    <div
+      v-if="hasErrors"
+      id="cru-errors"
+      class="cru__errors"
+    >
+      <Banner
+        v-for="(err, i) in errors"
+        :key="i"
+        color="error"
+        :data-testid="`error-banner${ i }`"
+        :closable="true"
+        @close="closeError(i)"
+      >
+        {{ err }}
+      </Banner>
+    </div>
   </CruResource>
 </template>


### PR DESCRIPTION
Fix #1123 

There was an issue with the `errors` property not being populated when a failed attempt to save a PolicyServer resource was returned.

The `save` hook that is utilized from the `CreateEditDelete` mixin is not properly returning an error and instead just logging it to the console. This would cause any error messages to go unnoticed unless the user opened the browser console.

This will handle the errors manually by displaying a banner when an error is populated in the `CreateEditDelete` mixin.


https://github.com/user-attachments/assets/8fc31861-7a55-4600-b7e3-22f277039424

