### PR TITLE
Add typeLabels to ensure proper menu entries

### DIFF
--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -529,18 +529,6 @@ asyncButton:
     waiting: Installing&hellip;
 
 typeLabel:
-  policies.kubewarden.io.policyserver: |-
-    {count, plural,
-      one { Policy Server }
-      other { Policy Servers }
-    }
-  policies.kubewarden.io.admissionpolicy: |-
-    {count, plural,
-      one { Admission Policy }
-      other { Admission Policies }
-    }
-  policies.kubewarden.io.clusteradmissionpolicy: |-
-    {count, plural,
-      one { Cluster Admission Policy }
-      other { Cluster Admission Policies }
-    }
+  policies.kubewarden.io.policyserver: Policy Servers
+  policies.kubewarden.io.admissionpolicy: Admission Policies
+  policies.kubewarden.io.clusteradmissionpolicy: Cluster Admission Policies

--- a/pkg/kubewarden/l10n/en-us.yaml
+++ b/pkg/kubewarden/l10n/en-us.yaml
@@ -527,3 +527,20 @@ asyncButton:
     action: Install Policy Reporter Chart
     success: Installed
     waiting: Installing&hellip;
+
+typeLabel:
+  policies.kubewarden.io.policyserver: |-
+    {count, plural,
+      one { Policy Server }
+      other { Policy Servers }
+    }
+  policies.kubewarden.io.admissionpolicy: |-
+    {count, plural,
+      one { Admission Policy }
+      other { Admission Policies }
+    }
+  policies.kubewarden.io.clusteradmissionpolicy: |-
+    {count, plural,
+      one { Cluster Admission Policy }
+      other { Cluster Admission Policies }
+    }

--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -98,9 +98,6 @@ test('Install Kubewarden', async({ page, ui, nav }) => {
     await expect(page.getByRole('heading', { name: 'Welcome to Kubewarden' })).toBeVisible()
   }, 'Kubewarden installation not detected')
 
-  // Workaround for issues#938: Both singular & plural resource names in menu
-  await page.reload()
-
   await test.step('Install default policyserver', async() => {
     const psPage = new PolicyServersPage(page)
 

--- a/tests/e2e/20-kubewarden.spec.ts
+++ b/tests/e2e/20-kubewarden.spec.ts
@@ -22,7 +22,7 @@ test('Check initial state', async({ page, ui, nav }) => {
 
   await test.step('Policy Servers Landing Page', async() => {
     await nav.pservers()
-    await expect(page.getByRole('heading', { name: 'PolicyServers' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Policy Servers' })).toBeVisible()
 
     // Default policy server
     const psRow = ui.tableRow('default')
@@ -37,14 +37,14 @@ test('Check initial state', async({ page, ui, nav }) => {
   await test.step('Admission Policies Landing page', async() => {
     await nav.apolicies()
 
-    await expect(page.getByRole('heading', { name: 'AdmissionPolicies' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Admission Policies' })).toBeVisible()
     await expect(page.getByText('There are no rows to show.')).toBeVisible()
   })
 
   await test.step('Cluster Admission Policies Landing page', async() => {
     await nav.capolicies()
 
-    await expect(page.getByRole('heading', { name: 'ClusterAdmissionPolicies' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Cluster Admission Policies' })).toBeVisible()
     await expect(page.locator('.col-policy-status')).toHaveCount(6)
     await expect(page.locator('.col-policy-status').getByText('Active')).toHaveCount(6)
     await expect(page.locator('.col-link-detail').first()).not.toBeEmpty()

--- a/tests/e2e/40-policies.spec.ts
+++ b/tests/e2e/40-policies.spec.ts
@@ -32,8 +32,11 @@ async function checkPolicy(p: Policy, polPage: BasePolicyPage, ui: RancherUI) {
   })
 
   await test.step(`Check details page: ${p.name}`, async() => {
-    // The regex inserts a space between lowercase letter followed by an uppercase letter
-    const polKindTitle = new RegExp(`^\\s+${polPage.kind.replace(/([a-z])([A-Z])/g, '$1 $2')}:\\s+${p.name}`)
+    // The regex inserts spaces and matches both singular and plural
+    const polKindTitle = new RegExp(`^\\s+${polPage.kind
+      .replace(/([a-z])([A-Z])/g, '$1 $2')
+      .replace(/Policy$/, "Polic(y|ies)")
+    }:\\s+${p.name}`)
 
     await row.open()
     await expect(ui.page.getByText(polKindTitle)).toBeVisible()

--- a/tests/e2e/40-policies.spec.ts
+++ b/tests/e2e/40-policies.spec.ts
@@ -32,8 +32,11 @@ async function checkPolicy(p: Policy, polPage: BasePolicyPage, ui: RancherUI) {
   })
 
   await test.step(`Check details page: ${p.name}`, async() => {
+    // The regex inserts a space between lowercase letter followed by an uppercase letter
+    const polKindTitle = new RegExp(`^\\s+${polPage.kind.replace(/([a-z])([A-Z])/g, '$1 $2')}:\\s+${p.name}`)
+
     await row.open()
-    await expect(ui.page.getByText(new RegExp(`^\\s+${polPage.kind}:\\s+${p.name}`))).toBeVisible()
+    await expect(ui.page.getByText(polKindTitle)).toBeVisible()
     await expect(ui.page.getByText('API Versions')).toBeVisible()
   })
 

--- a/tests/e2e/components/navigation.ts
+++ b/tests/e2e/components/navigation.ts
@@ -129,7 +129,7 @@ export class Navigation {
       await this.explorer('Admission Policy Management', 'Policy Servers')
       if (name) {
         await this.ui.tableRow(name).open()
-        await expect(this.page.getByRole('heading', { name: new RegExp(`Policy Server:? ${name}`) })).toBeVisible()
+        await expect(this.page.getByRole('heading', { name: new RegExp(`Policy Servers:? ${name}`) })).toBeVisible()
       }
       if (tab) await this.ui.tab(tab).click()
     }

--- a/tests/e2e/components/navigation.ts
+++ b/tests/e2e/components/navigation.ts
@@ -8,7 +8,7 @@ type ExpItemMap = {
     Workloads: 'CronJobs' | 'DaemonSets' | 'Deployments' | 'Jobs' | 'StatefulSets' | 'Pods'
     Apps: 'Charts' | 'Installed Apps' | 'Repositories' | 'Recent Operations'
     Storage: 'PersistentVolumes' | 'StorageClasses' | 'ConfigMaps' | 'PersistentVolumeClaims' | 'Secrets'
-    'Admission Policy Management': 'PolicyServers' | 'ClusterAdmissionPolicies' | 'AdmissionPolicies' | 'Policy Reporter'
+    'Admission Policy Management': 'Policy Servers' | 'Cluster Admission Policies' | 'Admission Policies' | 'Policy Reporter'
 };
 
 type FleetGroup = '' | 'Advanced'
@@ -126,24 +126,24 @@ export class Navigation {
 
     @step // Policy Servers
     async pservers(name?: string, tab?: 'Policies' | 'Metrics' | 'Tracing' | 'Conditions' | 'Recent Events' | 'Related Resources') {
-      await this.explorer('Admission Policy Management', 'PolicyServers')
+      await this.explorer('Admission Policy Management', 'Policy Servers')
       if (name) {
         await this.ui.tableRow(name).open()
-        await expect(this.page.getByRole('heading', { name: new RegExp(`PolicyServer:? ${name}`) })).toBeVisible()
+        await expect(this.page.getByRole('heading', { name: new RegExp(`Policy Server:? ${name}`) })).toBeVisible()
       }
       if (tab) await this.ui.tab(tab).click()
     }
 
     @step // Cluster Admission Policies
     async capolicies(name?: string, tab?: 'Rules' | 'Tracing' | 'Metrics' | 'Conditions' | 'Recent Events' | 'Related Resources') {
-      await this.explorer('Admission Policy Management', 'ClusterAdmissionPolicies')
+      await this.explorer('Admission Policy Management', 'Cluster Admission Policies')
       if (name) await this.ui.tableRow(name).open()
       if (tab) await this.ui.tab(tab).click()
     }
 
     @step // Admission Policies
     async apolicies(name?: string, tab?: 'Rules' | 'Tracing' | 'Metrics' | 'Conditions' | 'Recent Events') {
-      await this.explorer('Admission Policy Management', 'AdmissionPolicies')
+      await this.explorer('Admission Policy Management', 'Admission Policies')
       if (name) await this.ui.tableRow(name).open()
       if (tab) await this.ui.tab(tab).click()
     }

--- a/tests/e2e/pages/policies.page.ts
+++ b/tests/e2e/pages/policies.page.ts
@@ -8,7 +8,7 @@ export const apList = ['Custom Policy', 'Allow Privilege Escalation PSP', 'Allow
   'Deprecated API Versions', 'Disallow Service Loadbalancer', 'Disallow Service Nodeport', 'Echo', 'Environment Variable Secrets Scanner', 'Environment Variable Policy', 'Flexvolume Drivers Psp',
   'Host Namespaces PSP', 'Hostpaths PSP', 'Ingress Policy', 'Namespace label propagator', 'Pod Privileged Policy', 'Pod Runtime', 'Readonly Root Filesystem PSP', 'Share PID namespace',
   'Safe Annotations', 'Safe Labels', 'Seccomp PSP', 'Selinux PSP', 'Sysctl PSP', 'Trusted Repos', 'User Group PSP', 'Verify Image Signatures', 'volumeMounts', 'Volumes PSP', 'Unique Ingress host',
-  'Unique service selector', 'PVC StorageClass Validator', 'CEL Policy', 'Pod ndots'] as const
+  'Unique service selector', 'PVC StorageClass Validator', 'CEL Policy', 'Pod ndots', 'Do not expose admission controller webhook services'] as const
 
 export const capList = [...apList, 'PSA Label Enforcer'] as const
 


### PR DESCRIPTION
Fix #938 

This will add the `typeLabel` translations for each Kubewarden type which will ensure that the menu entries are consistent.

![menu-items](https://github.com/user-attachments/assets/c9884457-6bf4-494a-b2cf-8276693f210e)
