### PR TITLE
Fix policy readme styling

### DIFF
--- a/pkg/kubewarden/components/Policies/PolicyReadmePanel.vue
+++ b/pkg/kubewarden/components/Policies/PolicyReadmePanel.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue';
+import { computed, ref } from 'vue';
 import { useStore } from 'vuex';
 
 import ChartReadme from '@shell/components/ChartReadme';
 
-import { PolicyDetail, KUBEWARDEN_POLICY_ANNOTATIONS, LEGACY_POLICY_ANNOTATIONS } from '@kubewarden/types';
+import { KUBEWARDEN_POLICY_ANNOTATIONS, LEGACY_POLICY_ANNOTATIONS, PolicyDetail } from '@kubewarden/types';
 
 const props = defineProps<{ policyChartDetails: PolicyDetail }>();
 
@@ -130,7 +130,7 @@ defineExpose({
     transition: right .5s ease;
 
     &__header {
-      text-transform: capitalize;
+      text-transform: inherit;
     }
 
     .policy-info-content {


### PR DESCRIPTION
Fix #1157 

There was a class adding the `text-transform: capitalize` to every word in the readme when it should have only been targeting the actual header. As the header is already capitalized it is unnecessary, so this will update the class to ensure it inherits it's property from the parent.