### PR TITLE
Override otel operator version from env

### DIFF
--- a/tests/e2e/60-telemetry.spec.ts
+++ b/tests/e2e/60-telemetry.spec.ts
@@ -10,7 +10,7 @@ const cmanRepo: ChartRepo = { name: 'jetstack', url: 'https://charts.jetstack.io
 const cmanChart: Chart = { title: 'cert-manager', name: 'cert-manager', namespace: 'cert-manager', check: 'cert-manager' }
 // OpenTelemetry
 const otelRepo: ChartRepo = { name: 'open-telemetry', url: 'https://open-telemetry.github.io/opentelemetry-helm-charts' }
-const otelChart: Chart = { title: 'opentelemetry-operator', name: 'opentelemetry-operator', namespace: 'open-telemetry', check: 'opentelemetry-operator' }
+const otelChart: Chart = { title: 'opentelemetry-operator', name: 'opentelemetry-operator', namespace: 'open-telemetry', check: 'opentelemetry-operator', version: process.env.OTEL_OPERATOR }
 // Jaeger Tracing
 const jaegerRepo: ChartRepo = { name: 'jaegertracing', url: 'https://jaegertracing.github.io/helm-charts' }
 const jaegerChart: Chart = { title: 'jaeger-operator', name: 'jaeger-operator', namespace: 'jaeger', check: 'jaeger-operator' }

--- a/tests/e2e/fleet/open-telemetry/fleet.yaml
+++ b/tests/e2e/fleet/open-telemetry/fleet.yaml
@@ -2,7 +2,7 @@ defaultNamespace: opentelemetry
 helm:
   releaseName: opentelemetry
   chart: opentelemetry-operator
-  version: "*" # 0.68.1
+  version: "0.86.4" # *
   repo: https://open-telemetry.github.io/opentelemetry-helm-charts
   values:
     manager:


### PR DESCRIPTION
## Description

We use latest stable OTEL Operator version, but it's occasionally broken.
Allowing to override OTEL version from env removes the need to commit & revert every time it breaks.

Currently all our tests are failing because of https://github.com/open-telemetry/opentelemetry-helm-charts/issues/1648.
I will create `OTEL_OPERATOR` env variable in github action setup to pin version.