### PR TITLE
[2.9] Override otel operator version from env

### DIFF
--- a/tests/e2e/60-telemetry.spec.ts
+++ b/tests/e2e/60-telemetry.spec.ts
@@ -5,7 +5,7 @@ import { RancherUI } from './components/rancher-ui'
 
 // OpenTelemetry
 const otelRepo: ChartRepo = { name: 'open-telemetry', url: 'https://open-telemetry.github.io/opentelemetry-helm-charts' }
-const otelChart: Chart = { title: 'opentelemetry-operator', name: 'opentelemetry-operator', namespace: 'open-telemetry', check: 'opentelemetry-operator' }
+const otelChart: Chart = { title: 'opentelemetry-operator', name: 'opentelemetry-operator', namespace: 'open-telemetry', check: 'opentelemetry-operator', version: process.env.OTEL_OPERATOR }
 // Jaeger Tracing
 const jaegerRepo: ChartRepo = { name: 'jaegertracing', url: 'https://jaegertracing.github.io/helm-charts' }
 const jaegerChart: Chart = { title: 'jaeger-operator', name: 'jaeger-operator', namespace: 'jaeger', check: 'jaeger-operator' }


### PR DESCRIPTION
## Description

We use latest stable OTEL Operator version, but it's occasionally broken.
Allowing to override OTEL version from env removes the need to commit & revert every time it breaks.

Currently all our tests are failing because of https://github.com/open-telemetry/opentelemetry-helm-charts/issues/1648.
I will create `OTEL_OPERATOR` env variable in github action setup to pin version.