### PR TITLE
Use systemDefaultRegistry only when modified

### DIFF
--- a/pkg/kubewarden/components/Policies/Create.vue
+++ b/pkg/kubewarden/components/Policies/Create.vue
@@ -482,7 +482,8 @@ export default ({
         let registry = policyAnnotations[KUBEWARDEN_CATALOG_ANNOTATIONS.REGISTRY];
         let policyModule = `${ policyAnnotations[KUBEWARDEN_CATALOG_ANNOTATIONS.REPOSITORY] }:${ policyAnnotations[KUBEWARDEN_CATALOG_ANNOTATIONS.TAG] }`;
 
-        if (this.systemDefaultRegistry?.value) {
+        // Override annotation by rancher system-default-registry if user changed default value (expected in airgap)
+        if (this.systemDefaultRegistry?.value && this.systemDefaultRegistry.value !== this.systemDefaultRegistry.default) {
           registry = this.systemDefaultRegistry.value;
         }
 

--- a/tests/e2e/60-telemetry.spec.ts
+++ b/tests/e2e/60-telemetry.spec.ts
@@ -10,7 +10,7 @@ const cmanRepo: ChartRepo = { name: 'jetstack', url: 'https://charts.jetstack.io
 const cmanChart: Chart = { title: 'cert-manager', name: 'cert-manager', namespace: 'cert-manager', check: 'cert-manager' }
 // OpenTelemetry
 const otelRepo: ChartRepo = { name: 'open-telemetry', url: 'https://open-telemetry.github.io/opentelemetry-helm-charts' }
-const otelChart: Chart = { title: 'opentelemetry-operator', name: 'opentelemetry-operator', namespace: 'open-telemetry', check: 'opentelemetry-operator', version: process.env.OTEL_OPERATOR }
+const otelChart: Chart = { title: 'opentelemetry-operator', name: 'opentelemetry-operator', namespace: 'open-telemetry', check: 'opentelemetry-operator', version: process.env.OTEL_OPERATOR || '0.86.4' }
 // Jaeger Tracing
 const jaegerRepo: ChartRepo = { name: 'jaegertracing', url: 'https://jaegertracing.github.io/helm-charts' }
 const jaegerChart: Chart = { title: 'jaeger-operator', name: 'jaeger-operator', namespace: 'jaeger', check: 'jaeger-operator' }


### PR DESCRIPTION
Rancher API shows value is set https://172.18.0.2.nip.io/v1/management.cattle.io.settings/system-default-registry 
```json
{
  "id": "system-default-registry",
  "type": "management.cattle.io.setting",
  "apiVersion": "management.cattle.io/v3",
  "customized": false,
  "default": "registry.rancher.com",
  "source": "",
  "value": "registry.rancher.com"
}
```

Same resource in yaml value is empty:
```yaml 
~ k get settings.management.cattle.io system-default-registry -o yaml
apiVersion: management.cattle.io/v3
customized: false
default: registry.rancher.com
kind: Setting
source: ""
value: ""
...
```

It seems rancher does some magic, where `system-default-registry` is never empty on prime.

This PR checks if default value was changed and if so uses it.
Not sure if that's ideal solution, but it fixes https://github.com/rancher/kubewarden-ui/issues/1173.