### PR TITLE
Detect RANCHER_URL if not set

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -255,7 +255,6 @@ jobs:
             [ $i -ne 20 ] && sleep 30 || { echo "Godot: pods not running"; exit 1; }
         done
 
-        echo "RANCHER_FQDN=$RANCHER_FQDN" | tee -a $GITHUB_ENV
 
     # ==================================================================================================
     # Setup playwright ENV and run tests
@@ -301,7 +300,6 @@ jobs:
         yarn playwright test ${TFILTER:-} ${GFILTER:+-gv "$GFILTER"} -x | tee qase-report.log
       env:
         MODE: ${{ matrix.mode }}
-        RANCHER_URL: https://${{ env.RANCHER_FQDN }}
         # Override OTEL operator version by github variable
         OTEL_OPERATOR: ${{ vars.OTEL_OPERATOR }}
         # Check that installed extension version matches release tag

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test'
+import { execSync } from 'child_process'
 
 /**
  * Read environment variables from file.
@@ -41,7 +42,8 @@ export default defineConfig({
 
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    baseURL          : process.env.RANCHER_URL, /* Base URL to use in actions like `await page.goto('/')`. */
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL          : process.env.RANCHER_URL || 'https://' + JSON.parse(execSync('helm get values -n cattle-system rancher -o json', { encoding: 'utf-8' })).hostname.trimEnd(),
     actionTimeout    : 60_000, /* Maximum time each action such as `click()` can take. */
     navigationTimeout: 60_000, /* Timeout for navigation actions like page.goto() */
     // launchOptions    : { slowMo: 200 }, /* Slows down Playwright operations by the specified amount of milliseconds. */


### PR DESCRIPTION
Currently tests require export `RANCHER_URL=https://<RANCHER_FQDN>`.
This value can be automatically guessed from helm chart if unset.