### PR TITLE
Rename install params to match their function

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,11 +8,11 @@ on:
       kubewarden:
         description: Kubewarden UI from
         type: choice
-        default: 'rc'
+        default: 'github'
         options:
         - source # build extension from main branch
-        - rc     # https://rancher.github.io/kubewarden-ui/
-        - released # ui-plugin-charts in released rancher prime
+        - github # https://rancher.github.io/kubewarden-ui/
+        - prime  # ui-plugin-charts in released rancher prime
       rancher:
         description: Rancher version
         type: choice
@@ -44,19 +44,19 @@ on:
         - v1.32
         - v1.33
       mode:
-        description: Installation mode
+        description: Kubewarden install mode
         type: choice
-        default: 'base'
+        default: 'manual'
         options:
-        - base
+        - manual
         - fleet
         - upgrade
       testbase:
-        description: Run base tests
+        description: Run standard e2e tests
         type: boolean
         default: true
       testpolicies:
-        description: Run policy tests
+        description: Run extra policy tests
         type: boolean
         default: false
 
@@ -104,7 +104,7 @@ jobs:
       matrix:
         # Rancher versions for PRs is based on the branch
         rancher:  ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && fromJSON('["p2.8", "p2.9", "p2.10", "p2.11"]') || fromJSON(format('["{0}"]', inputs.rancher_text || inputs.rancher )) }}
-        mode: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && fromJSON('["base", "upgrade", "fleet"]') || fromJSON(format('["{0}"]', inputs.mode || 'base')) }}
+        mode: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && fromJSON('["manual", "upgrade", "fleet"]') || fromJSON(format('["{0}"]', inputs.mode || 'manual')) }}
         exclude:
           # Run all modes on latest prime version (2.11)
           - rancher: ${{ github.event_name == 'schedule' && 'p2.8' }}
@@ -189,9 +189,9 @@ jobs:
             RANCHER="${{ steps.find-rancher.outputs.rancher }}"
             ;;
           schedule)
-            [[ "$RANCHER" == c* ]] && KUBEWARDEN=rc || KUBEWARDEN=released;;
+            [[ "$RANCHER" == c* ]] && KUBEWARDEN=github || KUBEWARDEN=prime;;
           workflow_run)
-            KUBEWARDEN=rc;;
+            KUBEWARDEN=github;;
         esac
 
         # Print matrix

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,13 +2,14 @@
 
 | Trigger            	| Rancher    	| Mode    	| UI Ext 	| K3S  	| Notes                            	| Status 	|
 |--------------------	|------------	|---------	|--------	|------	|----------------------------------	|:------:	|
-| nightly (schedule) 	| 2.7 (p)    	| base    	| prime  	| 1.27 	|                                  	| [![E2E](https://github.com/rancher/kubewarden-ui/actions/workflows/playwright.yml/badge.svg?event=schedule)](https://github.com/rancher/kubewarden-ui/actions/workflows/playwright.yml?query=event%3Aschedule) |
-|                    	| 2.8 (p)    	| base    	| prime  	| 1.28 	|                                  	|  |
-|                    	| 2.9 (p)    	| base    	| prime  	| 1.30 	| install kubewarden from UI       	|  |
-|                    	| 2.9 (p)    	| upgrade 	| prime  	| 1.30 	| upgrade path of kubewarden stack 	|  |
-|                    	| 2.9 (p)    	| fleet   	| prime  	| 1.30 	| install kubewarden by fleet      	|  |
+| nightly (schedule) 	| 2.8 (p)    	| manual   	| prime  	| 1.28 	|                                  	| [![E2E](https://github.com/rancher/kubewarden-ui/actions/workflows/playwright.yml/badge.svg?event=schedule)](https://github.com/rancher/kubewarden-ui/actions/workflows/playwright.yml?query=event%3Aschedule) |
+|                    	| 2.9 (p)    	| manual   	| prime  	| 1.30 	| install kubewarden from UI       	|  |
+|                    	| 2.10 (p)    	| manual   	| prime  	| 1.31 	| install kubewarden from UI       	|  |
+|                    	| 2.11 (p)    	| manual 	| prime  	| 1.32 	| upgrade path of kubewarden stack 	|  |
+|                    	| 2.11 (p)    	| fleet   	| prime  	| 1.32 	| install kubewarden by fleet      	|  |
+|                    	| 2.11 (p)    	| upgrade  	| prime  	| 1.32 	| install kubewarden by fleet      	|  |
 | release (tag)      	| ^          	| ^       	| github 	| ^    	| same matrix as nightly job       	| [![E2E](https://github.com/rancher/kubewarden-ui/actions/workflows/playwright.yml/badge.svg?event=workflow_run)](https://github.com/rancher/kubewarden-ui/actions/workflows/playwright.yml?query=event%3Aworkflow_run) |
-| pull request       	| latest (c) 	| base    	| source 	| 1.30 	|                                  	|  |
+| pull request       	| latest (c) 	| manual   	| source 	| 1.30 	|                                  	|  |
 | manual             	| any        	| any      	| any    	| any  	|                                  	|  |
 
 ## Setup
@@ -49,7 +50,7 @@ ENV variables can be used to change behaviour
 
 ```bash
 # Install UI extension from source, tag or official one
-MODE=[base|upgrade|fleet] ORIGIN=[source|rc|released] pw test --ui -x
+MODE=[manual|upgrade|fleet] ORIGIN=[source|github|prime] pw test --ui -x
 
 # Install old kubewarden and upgrade it before tests
 MODE=upgrade pw test --ui -x

--- a/tests/e2e/40-policies.spec.ts
+++ b/tests/e2e/40-policies.spec.ts
@@ -4,7 +4,7 @@ import { AdmissionPoliciesPage, ClusterAdmissionPoliciesPage, BasePolicyPage, Po
 import { RancherUI } from './components/rancher-ui'
 import { RancherAppsPage } from './rancher/rancher-apps.page'
 
-const MODE = process.env.MODE || 'base'
+const MODE = process.env.MODE || 'manual'
 
 function isAP(polPage: BasePolicyPage) {
   return polPage instanceof AdmissionPoliciesPage


### PR DESCRIPTION
We use env variables to control e2e tests. They were introduced long time ago and are not self-explanatory.

Update values that control how to install ui extension and kubewarden:
```
# UI extension can be loaded locally (source), from github or included in prime
source -> source
rc -> github
released -> prime

# Kubewarden can be installed manually from UI extension, from fleet or old version for upgrade test
base -> manual
fleet -> fleet
upgrade -> upgrade
```

I also changed variable names `origin -> ui_from` and `mode -> kw_mode` to reference what component they affect: ui / kw.

PR does not bring new functionality, it's just code cleanup.