### PR TITLE
Fix e2e github repository owner

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -216,7 +216,7 @@ jobs:
     - name: Checkout kubewarden-end-to-end-tests
       uses: actions/checkout@v4
       with:
-        repository: ${{ github.repository_owner }}/kubewarden-end-to-end-tests
+        repository: kubewarden/kubewarden-end-to-end-tests
         ref: main
         path: action-make
 


### PR DESCRIPTION
Kubewarden e2e tests repository is under `kubewarden`, not `rancher`.

Fixes https://github.com/rancher/kubewarden-ui/actions/runs/15544602791/job/43763216032