### PR TITLE
Update locator for rancher app cards

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -39,7 +39,8 @@ This should be clean rancher if you want to run all the tests.
 docker run -d --restart=unless-stopped -p 80:80 -p 443:443 --privileged -e CATTLE_BOOTSTRAP_PASSWORD=sa rancher/rancher:latest
 
 # Run tests
-export RANCHER_URL=https://127.0.0.1.nip.io/
+# Tests can detect Rancher URL automatically if not set
+# export RANCHER_URL=https://127.0.0.1.nip.io/
 pw test --ui -x
 ```
 

--- a/tests/e2e/rancher/rancher-apps.page.ts
+++ b/tests/e2e/rancher/rancher-apps.page.ts
@@ -178,11 +178,15 @@ export class RancherAppsPage extends BasePage {
 
   @step
   async installChart(chart: Chart, options?: { questions?: () => Promise<void>, yamlPatch?: YAMLPatch, timeout?: number, navigate?: boolean }) {
+    // Apps grid was redesigned in Rancher 2.12
+    const card = this.page.locator('.grid > .item').or(this.page.locator('.app-chart-cards > .item-card'))
+      .filter({ has: this.page.getByRole('heading', { name: chart.title, exact: true }) })
+
     // Select chart by title
     if (options?.navigate !== false) {
       await this.nav.explorer('Apps', 'Charts')
       await expect(this.page.getByRole('heading', { name: 'Charts', exact: true })).toBeVisible()
-      await this.page.locator('.grid > .item').getByRole('heading', { name: chart.title, exact: true }).click()
+      await card.click()
 
       if (chart.version) {
         const versionPane = this.page.getByRole('heading', { name: 'Chart Versions', exact: true }).locator('..')


### PR DESCRIPTION
Rancher app cards changed visual and locators in rancher 2.12.
This will support both old and new locators.