### PR TITLE
Extend controller installation timeout

### DIFF
--- a/tests/e2e/pages/kubewarden.page.ts
+++ b/tests/e2e/pages/kubewarden.page.ts
@@ -135,7 +135,7 @@ export class KubewardenPage extends BasePage {
       // Start installation
       await apps.installBtn.click()
       await apps.waitHelmSuccess('rancher-kubewarden-crds', { keepLog: true })
-      await apps.waitHelmSuccess('rancher-kubewarden-controller')
+      await apps.waitHelmSuccess('rancher-kubewarden-controller', { timeout: 4 * 60_000 })
     }
 
     @step

--- a/tests/e2e/rancher/rancher-apps.page.ts
+++ b/tests/e2e/rancher/rancher-apps.page.ts
@@ -124,7 +124,7 @@ export class RancherAppsPage extends BasePage {
      * SUCCESS: helm [install|upgrade] [--generate-name=true|name]  /home/shell/helm/opentelemetry-operator-0.38.0.tgz
      */
     async waitHelmSuccess(text: string, options?: { timeout?: number, keepLog?: boolean }) {
-      const timeout = options?.timeout || 60_000
+      const timeout = options?.timeout || 2 * 60_000
       const keepLog = options?.keepLog || false
 
       // Can't match ^..$ because output is sometimes mixed up


### PR DESCRIPTION
Current timeout just at the limit we need to pull additional kubectl.
PR updates timeout to match what we have in main.

Failed test: https://github.com/rancher/kubewarden-ui/actions/runs/15743588993/job/44438464313#step:13:44