### PR TITLE
Fix fleet tracing test

### DIFF
--- a/tests/e2e/60-telemetry.spec.ts
+++ b/tests/e2e/60-telemetry.spec.ts
@@ -3,7 +3,7 @@ import { Chart, ChartRepo, RancherAppsPage } from './rancher/rancher-apps.page'
 import { PolicyServersPage } from './pages/policyservers.page'
 import { TelemetryPage } from './pages/telemetry.page'
 import { RancherUI } from './components/rancher-ui'
-import { AdmissionPoliciesPage } from './pages/policies.page'
+import { AdmissionPoliciesPage, Policy } from './pages/policies.page'
 
 // Cert-Manager
 const cmanRepo: ChartRepo = { name: 'jetstack', url: 'https://charts.jetstack.io' }
@@ -54,9 +54,10 @@ test.describe('Setup', () => {
     }
   })
 
-  test('Create custom PolicyServer', async({ page }) => {
+  test('Create custom PolicyServer & Policy', async({ page }) => {
+    const policy: Policy = { name: 'no-privileged-custom', title: 'Pod Privileged Policy', mode: 'Monitor', server: 'custom-ps' }
     await new PolicyServersPage(page).create({ name: 'custom-ps' })
-    await new AdmissionPoliciesPage(page).create({ name: 'no-privileged-custom', title: 'Pod Privileged Policy', mode: 'Monitor', server: 'custom-ps' })
+    await new AdmissionPoliciesPage(page).create(policy, { wait: process.env.MODE == 'fleet' })
   })
 })
 

--- a/tests/e2e/components/kubectl-shell.ts
+++ b/tests/e2e/components/kubectl-shell.ts
@@ -195,7 +195,7 @@ export class Shell {
 
   @step
   async waitPods(options?: { ns?: string, filter?: string, timeout?: number }) {
-    const ns = options?.ns || '-n cattle-kubewarden-system'
+    const ns = options?.ns ? `-n ${options.ns}` : '-n cattle-kubewarden-system'
 
     const filter = options?.filter || ''
     await this.retry(`kubectl get pods --no-headers ${ns} ${filter} 2>&1 | sed -E '/([0-9]+)[/]\\1\\s+Running|Completed/d' | wc -l | grep -qx 0`, options)

--- a/tests/e2e/pages/policies.page.ts
+++ b/tests/e2e/pages/policies.page.ts
@@ -4,13 +4,27 @@ import { TableRow } from '../components/table-row'
 import { step } from '../rancher/rancher-test'
 import { BasePage } from '../rancher/basepage'
 
-export const apList = ['Custom Policy', 'Allow Privilege Escalation PSP', 'Allowed Fs Groups PSP', 'Allowed Proc Mount Types PSP', 'Apparmor PSP', 'Capabilities PSP', 'Container Resources',
-  'Deprecated API Versions', 'Disallow Service Loadbalancer', 'Disallow Service Nodeport', 'Echo', 'Environment Variable Secrets Scanner', 'Environment Variable Policy', 'Flexvolume Drivers Psp',
-  'Host Namespaces PSP', 'Hostpaths PSP', 'Ingress Policy', 'Namespace label propagator', 'Pod Privileged Policy', 'Pod Runtime', 'Readonly Root Filesystem PSP', 'Share PID namespace',
-  'Safe Annotations', 'Safe Labels', 'Seccomp PSP', 'Selinux PSP', 'Sysctl PSP', 'Trusted Repos', 'User Group PSP', 'Verify Image Signatures', 'volumeMounts', 'Volumes PSP', 'Unique Ingress host',
-  'Unique service selector', 'PVC StorageClass Validator', 'CEL Policy', 'Pod ndots', 'Do not expose admission controller webhook services', 'Priority class policy'] as const
+export const apList = ['Custom Policy', 'Allow Privilege Escalation PSP', 'Allowed Fs Groups PSP', 'Allowed Proc Mount Types PSP', 'Apparmor PSP', 'Capabilities PSP', 'CEL Policy',
+  'Container Resources', 'Affinity Node Selector', 'Containers Block Ssh Port', 'Container Block Sysctls', 'Container Block Sysctls CVE-2022-0811', 'Container Running As Root',
+  'Container Running As User', 'Containers Block Specific Image Names', 'Missing Kubernetes App Component Label', 'Missing Kubernetes App Created By Label', 'Missing Kubernetes App Instance Label',
+  'Missing Kubernetes App Label', 'Missing Kubernetes App Managed By Label', 'Missing Kubernetes App Part Of Label', 'Missing Kubernetes App Version Label', 'Metadata Missing Label And Value',
+  'Block Workloads Created Without Specifying Namespace', 'Missing Owner Label', 'Containers Missing Security Context', 'Containers Should Not Run In Namespace', 'Deprecated API Versions',
+  'Disallow Service Loadbalancer', 'Disallow Service Nodeport', 'Do not expose admission controller webhook services', 'Echo', 'Environment Variable Secrets Scanner', 'Environment Variable Policy',
+  'Flexvolume Drivers Psp', 'Bucket Approved Region', 'Bucket Endpoint Domain', 'Bucket Insecure Connections', 'GitRepository Ignore Suffixes', 'GitRepository Organization Domains',
+  'GitRepository Specific Branch', 'GitRepository Untrusted Domains', 'HelmChart Cosign Verification', 'HelmChart Values File Format', 'Helm Release Max History', 'Helm Release Namespace Match',
+  'Helm Release Post Renderer', 'Helm Release Remediation Retries', 'Helm Release Rollback Should Be Disabled', 'Helm Release Service Account Name', 'Helm Release Storage Namespace',
+  'Helm Release Target Namespace', 'Helm Release Values From', 'Helm Repo Type Should Be OCI', 'Helm Repo URL Should Be in Organisation Domain', 'Kustomization Decryption Provider',
+  'Kustomization Image Tag Standards', 'Kustomization Excluded Paths', 'Kustomization Target Namespace', 'Kustomization Var Substitution', 'Kustomization Images Requirement', 'Kustomization Patches',
+  'Kustomization Prune', 'OCIRepository Cosign Verification', 'OCIRepository Ignore Suffixes', 'OCIRepository Layer Selector', 'OCIRepository Not Latest Tag', 'OCIRepository Organization Domains',
+  'OCIRepository Patch Annotation', 'Resource Reconcile Interval Must Be Set Between Lower and Upper Bound', 'Resource Suspend Waiver', 'Host Namespaces PSP', 'Hostpaths PSP', 'Ingress Policy',
+  'Istio Gateway Approved Hosts', 'Namespace label propagator', 'Namespace Resources Limitrange', 'Namespace Pod Quota', 'Resource Quota Setting Is Missing',
+  'Network Allow Egress Traffic From Namespace To Another', 'Network Allow Ingress Traffic From Namespace To Another', 'Network Block All Ingress Traffic To Namespace From CIDR Block',
+  'PVC StorageClass Validator', 'Persistent Volume Claim Snapshot', 'Pod ndots', 'Pod Privileged Policy', 'Pod Runtime', 'Priority class policy', 'Rbac Prohibit List On Secrets',
+  'Rbac Prohibit Watch On Secrets', 'Rbac Prohibit Wildcard On Secrets', 'Rbac Prohibit Wildcards on Policy Rule Resources', 'Rbac Prohibit Wildcards on Policy Rule Verbs', 'Readonly Root Filesystem PSP',
+  'Safe Annotations', 'Safe Labels', 'Seccomp PSP', 'Selinux PSP', 'Share PID namespace', 'Sysctl PSP', 'Trusted Repos', 'Unique Ingress host', 'Unique service selector', 'User Group PSP',
+  'Verify Image Signatures', 'volumeMounts', 'Volumes PSP'] as const
 
-export const capList = [...apList, 'PSA Label Enforcer'] as const
+export const capList = [...apList, 'PSA Label Enforcer', 'Istio Injected Namespaces', 'Persistent Volume Access Modes'] as const
 
 export type policyTitle = typeof capList[number]
 export type PolicyKind = 'AdmissionPolicy' | 'ClusterAdmissionPolicy'


### PR DESCRIPTION
Fleet traces are logged because pod generates them before policy is active.
This does not happen on non-fleet tests because they deploy jaeger as part of test, which slow things down.

Failing test: https://github.com/rancher/kubewarden-ui/actions/runs/15887149245/job/44827495860

I also updated policy list to include also new rego policies.