### PR TITLE
Required non-object types are never allowed

### DIFF
--- a/pkg/kubewarden/components/Policies/Create.vue
+++ b/pkg/kubewarden/components/Policies/Create.vue
@@ -329,7 +329,7 @@ export default ({
 
       if (!isEmpty(requiredKeys)) {
         for (const key of requiredKeys.values()) {
-          if (!isEmpty(requiredProp[key])) {
+          if (!isEmpty(requiredProp[key]) || typeof requiredProp[key] === 'boolean' || typeof requiredProp[key] === 'number') {
             match.push(key);
           }
         }


### PR DESCRIPTION
[Objects are considered empty](https://lodash.info/doc/isEmpty) if they have no own enumerable string keyed properties.
With current logic we never satisfy requirements to enable `Finish` button on policy creation page.
This affects all `boolean` and `int` variable types with `required: true` property in questions-ui.yaml.

Depends on https://github.com/rancher/kubewarden-ui/pull/1251 for e2e tests.

```typescript
// Lodash considers boolean/number types always empty:

_.isEmpty(true);
// => true

_.isEmpty(1);
// => true

_.isEmpty([1, 2, 3]);
// => false
```

### Without fix
https://github.com/user-attachments/assets/25d4ee45-27c9-47ae-a5e1-c321977eb6ce

### With fix
https://github.com/user-attachments/assets/7dbdc3b7-adcb-476b-94b9-d9d95be1d39f
