### PR TITLE
Add rego policy questions

### DIFF
--- a/tests/e2e/90-allpolicies.spec.ts
+++ b/tests/e2e/90-allpolicies.spec.ts
@@ -15,30 +15,129 @@ type PolicySettings = {
 }
 
 const policySettingsMap: Partial<Record<policyTitle, PolicySettings>> = {
-  'Custom Policy'              : { settings: setupCustomPolicy },
-  'Deprecated API Versions'    : { settings: setupDeprecatedAPIVersions },
-  'Environment Variable Policy': { settings: setupEnvironmentVariablePolicy },
-  'Namespace label propagator' : { settings: setupNamespaceLabelPropagator },
-  'PSA Label Enforcer'         : { settings: setupPSALabelEnforcer },
-  'Selinux PSP'                : { settings: setupSelinuxPSP },
-  'Trusted Repos'              : { settings: setupTrustedRepos },
-  'User Group PSP'             : { settings: setupUserGroupPSP },
-  'Verify Image Signatures'    : { settings: setupVerifyImageSignatures },
-  'Container Resources'        : { settings: setupContainerResources },
-  'PVC StorageClass Validator' : { settings: setupPvcScValidator },
-  'Priority class policy'      : { settings: setupPriorityClassPolicy },
-  'CEL Policy'                 : { skip: 'https://github.com/kubewarden/cel-policy/issues/12' },
-  'volumeMounts'               : { settings: setupVolumeMounts },
+  'Custom Policy'                                                        : { settings: setupCustomPolicy },
+  'Affinity Node Selector'                                               : { settings: affinityNodeSelector },
+  'Bucket Approved Region'                                               : { settings: generalArray },
+  'Bucket Endpoint Domain'                                               : { settings: generalArray },
+  'CEL Policy'                                                           : { skip: 'https://github.com/kubewarden/cel-policy/issues/12' },
+  'Container Resources'                                                  : { settings: setupContainerResources },
+  'Containers Block Specific Image Names'                                : { settings: generalArray },
+  'Deprecated API Versions'                                              : { settings: setupDeprecatedAPIVersions },
+  'Environment Variable Policy'                                          : { settings: generalArray },
+  'GitRepository Ignore Suffixes'                                        : { settings: generalArray },
+  'GitRepository Organization Domains'                                   : { settings: generalArray },
+  'GitRepository Specific Branch'                                        : { settings: gitRepositorySpecificBranch },
+  'GitRepository Untrusted Domains'                                      : { settings: generalArray },
+  'Helm Release Service Account Name'                                    : { settings: generalArray },
+  'Helm Release Storage Namespace'                                       : { settings: generalArray },
+  'Helm Release Target Namespace'                                        : { settings: generalArray },
+  'Helm Release Values From'                                             : { settings: generalArray },
+  'Helm Repo URL Should Be in Organisation Domain'                       : { settings: generalArray },
+  'Istio Gateway Approved Hosts'                                         : { settings: generalArray },
+  'Istio Injected Namespaces'                                            : { settings: generalArray },
+  'Kustomization Decryption Provider'                                    : { settings: generalArray },
+  'Kustomization Excluded Paths'                                         : { settings: generalArray },
+  'Kustomization Images Requirement'                                     : { skip: 'https://github.com/rancher/kubewarden-ui/pull/1250' },
+  'Kustomization Patches'                                                : { skip: 'https://github.com/rancher/kubewarden-ui/pull/1250', settings: kustomizationPatches },
+  'Kustomization Prune'                                                  : { skip: 'https://github.com/rancher/kubewarden-ui/pull/1250', settings: kustomizationPrune },
+  'Kustomization Target Namespace'                                       : { settings: generalArray },
+  'Metadata Missing Label And Value'                                     : { settings: metadataMissingLabelAndValue },
+  'Namespace Resources Limitrange'                                       : { settings: namespaceResourcesLimitrange },
+  'Namespace label propagator'                                           : { settings: generalArray },
+  'Network Allow Egress Traffic From Namespace To Another'               : { settings: networkAllowTrafficFromNamespaceToAnother },
+  'Network Allow Ingress Traffic From Namespace To Another'              : { settings: networkAllowTrafficFromNamespaceToAnother },
+  'Network Block All Ingress Traffic To Namespace From CIDR Block'       : { settings: networkBlockAllIngressTrafficToNamespaceFromCIDRBlock },
+  'OCIRepository Ignore Suffixes'                                        : { settings: generalArray },
+  'OCIRepository Layer Selector'                                         : { settings: ociRepositoryLayerSelector },
+  'OCIRepository Organization Domains'                                   : { settings: generalArray },
+  'OCIRepository Patch Annotation'                                       : { settings: ociRepositoryPatchAnnotation },
+  'PSA Label Enforcer'                                                   : { settings: setupPSALabelEnforcer },
+  'PVC StorageClass Validator'                                           : { settings: generalArray },
+  'Persistent Volume Access Modes'                                       : { settings: persistentVolumeAccessModes },
+  'Persistent Volume Claim Snapshot'                                     : { settings: persistentVolumeClaimSnapshot },
+  'Priority class policy'                                                : { settings: generalArray },
+  'Resource Quota Setting Is Missing'                                    : { settings: resourceQuotaSettingIsMissing },
+  'Resource Suspend Waiver'                                              : { settings: generalArray },
+  'Selinux PSP'                                                          : { settings: setupSelinuxPSP },
+  'Trusted Repos'                                                        : { settings: setupTrustedRepos },
+  'User Group PSP'                                                       : { settings: setupUserGroupPSP },
+  'Verify Image Signatures'                                              : { settings: setupVerifyImageSignatures },
+  'volumeMounts'                                                         : { settings: setupVolumeMounts },
+  'Rbac Prohibit Wildcards on Policy Rule Resources'                     : { skip: 'https://github.com/kubewarden/rego-policies-library/pull/54' },
+  'Rbac Prohibit Wildcards on Policy Rule Verbs'                         : { skip: 'https://github.com/kubewarden/rego-policies-library/pull/54' },
+  'Containers Block Ssh Port'                                            : { skip: 'https://github.com/rancher/kubewarden-ui/pull/1250' },
+  'Container Running As User'                                            : { skip: 'https://github.com/rancher/kubewarden-ui/pull/1250' },
+  'Helm Release Max History'                                             : { skip: 'https://github.com/rancher/kubewarden-ui/pull/1250' },
+  'Helm Release Remediation Retries'                                     : { skip: 'https://github.com/rancher/kubewarden-ui/pull/1250' },
+  'Resource Reconcile Interval Must Be Set Between Lower and Upper Bound': { skip: 'https://github.com/rancher/kubewarden-ui/pull/1250' },
+  'Namespace Pod Quota'                                                  : { skip: 'https://github.com/rancher/kubewarden-ui/pull/1250' },
 }
 
-async function setupPriorityClassPolicy(ui: RancherUI) {
+async function generalArray(ui: RancherUI) {
   await ui.button('Add').click()
-  await ui.page.getByPlaceholder('e.g. bar').fill('low-priority')
+  await ui.page.getByPlaceholder('e.g. bar').fill('item')
 }
 
-async function setupPvcScValidator(ui: RancherUI) {
-  await ui.button('Add').click()
-  await ui.page.getByPlaceholder('e.g. bar').fill('denyname')
+async function affinityNodeSelector(ui: RancherUI) {
+  await ui.input('Key*').fill('node-role.kubernetes.io/control-plane')
+  await ui.input('Value*').fill('true')
+}
+
+async function metadataMissingLabelAndValue(ui: RancherUI) {
+  await ui.input('Label*').fill('req-label')
+  await ui.input('Value*').fill('req-value')
+}
+
+async function gitRepositorySpecificBranch(ui: RancherUI) {
+  await ui.input('Branch*').fill('main')
+}
+
+async function namespaceResourcesLimitrange(ui: RancherUI) {
+  await ui.input('Resource type*').fill('cpu')
+  await ui.input('Resource setting*').fill('default')
+}
+
+async function networkAllowTrafficFromNamespaceToAnother(ui: RancherUI) {
+  await ui.input('Src namespace*').fill('default')
+  await ui.input('Dst namespace*').fill('kube-system')
+}
+
+async function networkBlockAllIngressTrafficToNamespaceFromCIDRBlock(ui: RancherUI) {
+  await ui.input('Namespace*').fill('default')
+  await ui.input('Cidr*').fill('cidr')
+}
+
+async function ociRepositoryLayerSelector(ui: RancherUI) {
+  await ui.button('Add').first().click()
+  await ui.page.getByRole('textbox').first().fill('registry.my-corp.com')
+  await ui.button('Add').last().click()
+  await ui.page.getByRole('textbox').last().fill('registry.my-corp.com')
+}
+
+async function ociRepositoryPatchAnnotation(ui: RancherUI) {
+  await ui.input('Provider*').fill('provider')
+}
+
+async function persistentVolumeClaimSnapshot(ui: RancherUI) {
+  await ui.input('Snapshot class*').fill('snapshot-class')
+  await ui.input('Pvc name*').fill('pvc-name')
+}
+
+async function resourceQuotaSettingIsMissing(ui: RancherUI) {
+  await ui.input('Resource type*').fill('cpu')
+}
+
+async function kustomizationPatches(ui: RancherUI) {
+  await ui.checkbox('Patches required').check()
+}
+
+async function kustomizationPrune(ui: RancherUI) {
+  await ui.checkbox('Prune').check()
+}
+
+async function persistentVolumeAccessModes(ui: RancherUI) {
+  await ui.input('Name*').fill('pvname')
+  await ui.input('Access mode*').fill('readWriteOnce')
 }
 
 async function setupContainerResources(ui: RancherUI) {
@@ -50,11 +149,6 @@ async function setupContainerResources(ui: RancherUI) {
 async function setupTrustedRepos(ui: RancherUI) {
   await ui.button('Add').first().click()
   await ui.page.getByRole('textbox').last().fill('registry.my-corp.com')
-}
-
-async function setupNamespaceLabelPropagator(ui: RancherUI) {
-  await ui.button('Add').click()
-  await ui.page.getByRole('textbox').last().fill('cost-center')
 }
 
 async function setupPSALabelEnforcer(ui: RancherUI) {
@@ -94,16 +188,9 @@ async function setupVerifyImageSignatures(ui: RancherUI) {
   })
 }
 
-async function setupEnvironmentVariablePolicy(ui: RancherUI) {
-  await ui.selectOption('Criteria*', 'containsAnyOf')
-  await ui.button('Add').click()
-  await ui.page.getByPlaceholder('e.g. bar').fill('reqvar')
-}
-
 async function setupUserGroupPSP(ui: RancherUI) {
-  for (const role of await ui.page.getByRole('combobox').all()) {
-    role.click()
-    await ui.page.getByRole('option', { name: 'RunAsAny', exact: true }).click()
+  for (const rule of await ui.select('Rule').all()) {
+    await ui.selectOption(rule, 'RunAsAny')
   }
 }
 

--- a/tests/e2e/components/rancher-ui.ts
+++ b/tests/e2e/components/rancher-ui.ts
@@ -62,15 +62,22 @@ export class RancherUI {
     return this.radioGroup(label).getByRole('radio', { name })
   }
 
-  // Labeled Select (ComboBox)
-  select(label: string) {
-    return this.page.locator('div.labeled-select').filter({ hasText: label })
-      .getByRole('combobox', { name: 'Search for option' })
+  // (un)Labeled Select (ComboBox)
+  select(label: string|Locator) {
+    const base = (typeof label === 'string')
+      ? this.page.locator('div.labeled-select').filter({ hasText: label })
+      : label.locator('div.unlabeled-select')
+
+    return base.getByRole('combobox', { name: 'Search for option' })
   }
 
   // Select option from (un)labeled Select
   async selectOption(label: string|Locator, option: string | RegExp | number) {
-    const select = (typeof label === 'string') ? this.select(label) : label.getByRole('combobox', { name: 'Search for option' })
+    const select = (typeof label === 'string')
+      ? this.select(label)
+      : (await label.getAttribute('role') === 'combobox')
+          ? label
+          : this.select(label)
     await select.click()
 
     const optionItem = typeof option === 'number'

--- a/tests/e2e/components/rancher-ui.ts
+++ b/tests/e2e/components/rancher-ui.ts
@@ -34,6 +34,7 @@ export class RancherUI {
     return this.page.locator('div.labeled-input')
       .filter({ has: this.page.getByText(label, { exact: true }) })
       .locator('input')
+      .filter({ visible: true })
   }
 
   // Labeled Checkbox

--- a/tests/e2e/pages/policies.page.ts
+++ b/tests/e2e/pages/policies.page.ts
@@ -4,25 +4,27 @@ import { TableRow } from '../components/table-row'
 import { step } from '../rancher/rancher-test'
 import { BasePage } from '../rancher/basepage'
 
-export const apList = ['Custom Policy', 'Allow Privilege Escalation PSP', 'Allowed Fs Groups PSP', 'Allowed Proc Mount Types PSP', 'Apparmor PSP', 'Capabilities PSP', 'CEL Policy',
-  'Container Resources', 'Affinity Node Selector', 'Containers Block Ssh Port', 'Container Block Sysctls', 'Container Block Sysctls CVE-2022-0811', 'Container Running As Root',
-  'Container Running As User', 'Containers Block Specific Image Names', 'Missing Kubernetes App Component Label', 'Missing Kubernetes App Created By Label', 'Missing Kubernetes App Instance Label',
-  'Missing Kubernetes App Label', 'Missing Kubernetes App Managed By Label', 'Missing Kubernetes App Part Of Label', 'Missing Kubernetes App Version Label', 'Metadata Missing Label And Value',
-  'Block Workloads Created Without Specifying Namespace', 'Missing Owner Label', 'Containers Missing Security Context', 'Containers Should Not Run In Namespace', 'Deprecated API Versions',
-  'Disallow Service Loadbalancer', 'Disallow Service Nodeport', 'Do not expose admission controller webhook services', 'Echo', 'Environment Variable Secrets Scanner', 'Environment Variable Policy',
-  'Flexvolume Drivers Psp', 'Bucket Approved Region', 'Bucket Endpoint Domain', 'Bucket Insecure Connections', 'GitRepository Ignore Suffixes', 'GitRepository Organization Domains',
-  'GitRepository Specific Branch', 'GitRepository Untrusted Domains', 'HelmChart Cosign Verification', 'HelmChart Values File Format', 'Helm Release Max History', 'Helm Release Namespace Match',
-  'Helm Release Post Renderer', 'Helm Release Remediation Retries', 'Helm Release Rollback Should Be Disabled', 'Helm Release Service Account Name', 'Helm Release Storage Namespace',
-  'Helm Release Target Namespace', 'Helm Release Values From', 'Helm Repo Type Should Be OCI', 'Helm Repo URL Should Be in Organisation Domain', 'Kustomization Decryption Provider',
-  'Kustomization Image Tag Standards', 'Kustomization Excluded Paths', 'Kustomization Target Namespace', 'Kustomization Var Substitution', 'Kustomization Images Requirement', 'Kustomization Patches',
-  'Kustomization Prune', 'OCIRepository Cosign Verification', 'OCIRepository Ignore Suffixes', 'OCIRepository Layer Selector', 'OCIRepository Not Latest Tag', 'OCIRepository Organization Domains',
-  'OCIRepository Patch Annotation', 'Resource Reconcile Interval Must Be Set Between Lower and Upper Bound', 'Resource Suspend Waiver', 'Host Namespaces PSP', 'Hostpaths PSP', 'Ingress Policy',
-  'Istio Gateway Approved Hosts', 'Namespace label propagator', 'Namespace Resources Limitrange', 'Namespace Pod Quota', 'Resource Quota Setting Is Missing',
-  'Network Allow Egress Traffic From Namespace To Another', 'Network Allow Ingress Traffic From Namespace To Another', 'Network Block All Ingress Traffic To Namespace From CIDR Block',
-  'PVC StorageClass Validator', 'Persistent Volume Claim Snapshot', 'Pod ndots', 'Pod Privileged Policy', 'Pod Runtime', 'Priority class policy', 'Rbac Prohibit List On Secrets',
-  'Rbac Prohibit Watch On Secrets', 'Rbac Prohibit Wildcard On Secrets', 'Rbac Prohibit Wildcards on Policy Rule Resources', 'Rbac Prohibit Wildcards on Policy Rule Verbs', 'Readonly Root Filesystem PSP',
-  'Safe Annotations', 'Safe Labels', 'Seccomp PSP', 'Selinux PSP', 'Share PID namespace', 'Sysctl PSP', 'Trusted Repos', 'Unique Ingress host', 'Unique service selector', 'User Group PSP',
-  'Verify Image Signatures', 'volumeMounts', 'Volumes PSP'] as const
+export const apList = ['Custom Policy',
+  'Affinity Node Selector', 'Allow Privilege Escalation PSP', 'Allowed Fs Groups PSP', 'Allowed Proc Mount Types PSP', 'Apparmor PSP', 'Bucket Approved Region', 'Bucket Endpoint Domain',
+  'Bucket Insecure Connections', 'Capabilities PSP', 'CEL Policy', 'Container Block Sysctls', 'Container Block Sysctls CVE-2022-0811', 'Container Resources', 'Container Running As Root',
+  'Container Running As User', 'Containers Block Ssh Port', 'Containers Block Specific Image Names', 'Containers Missing Security Context', 'Containers Should Not Run In Namespace',
+  'Deprecated API Versions', 'Disallow Service Loadbalancer', 'Disallow Service Nodeport', 'Do not expose admission controller webhook services', 'Echo', 'Environment Variable Policy',
+  'Environment Variable Secrets Scanner', 'Flexvolume Drivers Psp', 'GitRepository Ignore Suffixes', 'GitRepository Organization Domains', 'GitRepository Specific Branch',
+  'GitRepository Untrusted Domains', 'Helm Release Max History', 'Helm Release Namespace Match', 'Helm Release Post Renderer', 'Helm Release Remediation Retries',
+  'Helm Release Rollback Should Be Disabled', 'Helm Release Service Account Name', 'Helm Release Storage Namespace', 'Helm Release Target Namespace', 'Helm Release Values From',
+  'Helm Repo Type Should Be OCI', 'Helm Repo URL Should Be in Organisation Domain', 'HelmChart Cosign Verification', 'HelmChart Values File Format', 'Host Namespaces PSP',
+  'Hostpaths PSP', 'Ingress Policy', 'Istio Gateway Approved Hosts', 'Kustomization Decryption Provider', 'Kustomization Excluded Paths', 'Kustomization Image Tag Standards',
+  'Kustomization Images Requirement', 'Kustomization Patches', 'Kustomization Prune', 'Kustomization Target Namespace', 'Kustomization Var Substitution',
+  'Metadata Missing Label And Value', 'Missing Kubernetes App Component Label', 'Missing Kubernetes App Created By Label', 'Missing Kubernetes App Instance Label',
+  'Missing Kubernetes App Label', 'Missing Kubernetes App Managed By Label', 'Missing Kubernetes App Part Of Label', 'Missing Kubernetes App Version Label',
+  'Missing Owner Label', 'Namespace Pod Quota', 'Namespace Resources Limitrange', 'Namespace label propagator', 'Network Allow Egress Traffic From Namespace To Another',
+  'Network Allow Ingress Traffic From Namespace To Another', 'Network Block All Ingress Traffic To Namespace From CIDR Block', 'OCIRepository Cosign Verification',
+  'OCIRepository Ignore Suffixes', 'OCIRepository Layer Selector', 'OCIRepository Not Latest Tag', 'OCIRepository Organization Domains', 'OCIRepository Patch Annotation',
+  'PVC StorageClass Validator', 'Persistent Volume Claim Snapshot', 'Pod Privileged Policy', 'Pod Runtime', 'Pod ndots', 'Priority class policy', 'Rbac Prohibit List On Secrets',
+  'Rbac Prohibit Watch On Secrets', 'Rbac Prohibit Wildcard On Secrets', 'Rbac Prohibit Wildcards on Policy Rule Resources', 'Rbac Prohibit Wildcards on Policy Rule Verbs',
+  'Readonly Root Filesystem PSP', 'Resource Quota Setting Is Missing', 'Resource Reconcile Interval Must Be Set Between Lower and Upper Bound', 'Resource Suspend Waiver',
+  'Safe Annotations', 'Safe Labels', 'Seccomp PSP', 'Selinux PSP', 'Share PID namespace', 'Sysctl PSP', 'Trusted Repos', 'Unique Ingress host', 'Unique service selector',
+  'User Group PSP', 'Verify Image Signatures', 'Volumes PSP', 'volumeMounts'] as const
 
 export const capList = [...apList, 'PSA Label Enforcer', 'Istio Injected Namespaces', 'Persistent Volume Access Modes'] as const
 

--- a/tests/e2e/rancher/rancher-fleet.page.ts
+++ b/tests/e2e/rancher/rancher-fleet.page.ts
@@ -28,7 +28,7 @@ export class RancherFleetPage extends BasePage {
   }
 
   async selectWorkspace(workspace: string) {
-    await this.ui.selectOption(this.page.locator('.rd-header-right').locator('.unlabeled-select'), workspace)
+    await this.ui.selectOption(this.page.getByTestId('workspace-switcher'), workspace)
   }
 
   @step


### PR DESCRIPTION
[Nightly tests](https://github.com/rancher/kubewarden-ui/actions/runs/16010112805/job/45165823912) are failing because rego policies were added to the list but they need setup for required questions.

- Add setup functions for new rego policies with required questions
- Allow to use find unlabeled select by locator
- Fix multiple `Name` inputs on tabbed pages - ignore hidden tabs
On tabbed pages (general/settings/rules on questions) we have the same inputs, but some tabs are hidden