### PR TITLE
Fix policy index in pagination

### DIFF
--- a/pkg/kubewarden/components/SortableTableWrapper.vue
+++ b/pkg/kubewarden/components/SortableTableWrapper.vue
@@ -39,8 +39,9 @@ const addRowClickListener = () => {
       table.querySelectorAll('tbody tr').forEach((row, index) => {
         const listener = () => {
           const rowsProp = (sortableTable.value?.$props as Props).rows || [];
+          const indexFrom = sortableTable.value?.indexFrom || 1;
 
-          emit('selectRow', rowsProp[index]);
+          emit('selectRow', rowsProp[indexFrom - 1 + index]);
         };
 
         row.addEventListener('click', listener);


### PR DESCRIPTION
Index calculation does not take into account pagination, it always opens policiey from the first page.

Fix for https://github.com/rancher/kubewarden-ui/issues/1249