### PR TITLE
Fix test support of imported cluster

### DIFF
--- a/tests/e2e/components/kubectl-shell.ts
+++ b/tests/e2e/components/kubectl-shell.ts
@@ -142,6 +142,11 @@ export class Shell {
     const status = options?.status ?? 0
     const timeout = options?.timeout || 60_000
 
+    // To run on imported cluster we need to set context
+    if (process.env.CLUSTER && cmd.startsWith('kubectl')) {
+      cmd = cmd.replace(/^kubectl/, `kubectl --context=k3d-${process.env.CLUSTER}`)
+    }
+
     let cmdStatus = 0
     let cmdOutput: string
     try {

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -20,10 +20,14 @@ async function globalSetup(config: FullConfig) {
   // Get clusterId from displayName
   const clusterName = process.env.CLUSTER
   if (clusterName) {
-    resp = await requestContext.get(`/v1/provisioning.cattle.io.clusters/fleet-default/${clusterName}`)
+    resp = await requestContext.get('/v1/management.cattle.io.clusters')
     expect(resp.ok()).toBeTruthy()
+
     const reqJson = await resp.json()
-    process.env.CLUSTER_ID = reqJson.status.clusterName
+    const cluster = reqJson.data.find((c: any) => c.spec?.displayName === clusterName)
+    expect(cluster).toBeDefined()
+
+    process.env.CLUSTER_ID = cluster.metadata.name
   }
 
   // Get Rancher version


### PR DESCRIPTION
Fix tests to support running on imported clusters.

Rancher API changed, `/v1/provisioning.cattle.io.clusters/fleet-default/${clusterName}` is not reachable.

Part of [1.33 testing](https://github.com/kubewarden/kubewarden-controller/issues/1153#issuecomment-3056066739)