### PR TITLE
Update code for playwright 1.54.0

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -270,8 +270,8 @@ jobs:
         [[ "$TESTPOLICIES" != "true" ]] && GFILTER="$EXCLUDE" # Limit number of tested policies
 
         # List tests and execute
-        echo yarn playwright test ${TFILTER:-} ${GFILTER:+-gv "$GFILTER"} -x
-        yarn playwright test ${TFILTER:-} ${GFILTER:+-gv "$GFILTER"} -x | tee qase-report.log
+        echo yarn playwright test ${TFILTER:-} ${GFILTER:+--grep-invert "$GFILTER"} -x
+        yarn playwright test ${TFILTER:-} ${GFILTER:+--grep-invert "$GFILTER"} -x | tee qase-report.log
       env:
         MODE: ${{ matrix.mode }}
         # Override OTEL operator version by github variable


### PR DESCRIPTION
From playwright 1.54.0 [release notes](https://github.com/microsoft/playwright/releases/tag/v1.54.0):
Option -gv has been removed from the npx playwright test command. Use --grep-invert instead