### PR TITLE
Update tests for slide-in config in rancher 2.12

### DIFF
--- a/tests/e2e/30-policyservers.spec.ts
+++ b/tests/e2e/30-policyservers.spec.ts
@@ -88,10 +88,11 @@ test('Create with custom values', async({ page, ui, nav }) => {
   await psPage.create(ps, { wait: false })
 
   await nav.pservers(ps.name)
-  await ui.button('Config').click()
+  await ui.showConfiguration()
   await expect(ui.input('Name*')).toHaveValue(ps.name)
   await expect(ui.input('Image URL')).toHaveValue(ps.image)
   await expect(ui.input('Replicas*')).toHaveValue(ps.replicas.toString())
+  await ui.hideConfiguration()
 
   await psPage.delete(ps.name)
 })

--- a/tests/e2e/40-policies.spec.ts
+++ b/tests/e2e/40-policies.spec.ts
@@ -48,7 +48,7 @@ async function checkPolicy(p: Policy, polPage: BasePolicyPage, ui: RancherUI) {
   })
 
   await test.step(`Check config page: ${p.name}`, async() => {
-    await ui.button('Config').click()
+    await ui.showConfiguration()
     await expect(polPage.name).toHaveValue(p.name)
     if (p.title === 'Custom Policy') await expect(polPage.module).toHaveValue(module)
     await expect(polPage.mode(mode)).toBeChecked()
@@ -57,6 +57,7 @@ async function checkPolicy(p: Policy, polPage: BasePolicyPage, ui: RancherUI) {
     if (isAP(polPage)) {
       await expect(polPage.namespace).toContainText(namespace)
     }
+    await ui.hideConfiguration()
   })
 
   await test.step(`Check edit config: ${p.name}`, async() => {
@@ -230,9 +231,10 @@ test('Recommended policies', async({ page, ui, nav }) => {
 
     const capPage = new ClusterAdmissionPoliciesPage(page)
     await nav.capolicies('no-privileged-pod')
-    await ui.button('Config').click()
+    await ui.showConfiguration()
     await capPage.selectTab('Settings')
     // await expect(ui.codeMirror).toContainText('skip_init_containers: true')
     await expect(ui.checkbox('Skip init containers')).toBeChecked()
+    await ui.hideConfiguration()
   })
 })

--- a/tests/e2e/components/rancher-ui.ts
+++ b/tests/e2e/components/rancher-ui.ts
@@ -71,6 +71,18 @@ export class RancherUI {
     return base.getByRole('combobox', { name: 'Search for option' })
   }
 
+  // Slide-in drawer or old config
+  async showConfiguration() {
+    const configBtn = RancherUI.isVersion('>=2.12') ? 'Show Configuration' : 'Config'
+    await this.button(configBtn).click()
+  }
+
+  // Handling for second "Close" button on policy readme
+  async hideConfiguration() {
+    if (RancherUI.isVersion('>=2.12'))
+      await this.button(/^Close.*Configuration drawer$/).last().click()
+  }
+
   // Select option from (un)labeled Select
   async selectOption(label: string|Locator, option: string | RegExp | number) {
     const select = (typeof label === 'string')
@@ -161,8 +173,8 @@ export class RancherUI {
   }
 
   /**
-     * Call await ui.retry(async()=> { <code> }, 'Reason')
-     */
+   * Call await ui.retry(async()=> { <code> }, 'Reason')
+   */
   async retry(code: () => Promise<void>, message: string, options?: { reload?: boolean }) {
     const optReload = options?.reload || true
     try {

--- a/tests/e2e/components/rancher-ui.ts
+++ b/tests/e2e/components/rancher-ui.ts
@@ -24,9 +24,8 @@ export class RancherUI {
 
   // Button
   button(name: string|RegExp) {
-    return this.page.getByRole('button', { name, exact: true }).or(
-      this.page.locator('a.btn').filter({ has: this.page.getByText(name, { exact: true }) })
-    )
+    return this.page.getByRole('button', { name, exact: true })
+      .or(this.page.locator('a.btn,button', { has: this.page.getByText(name, { exact: true }) }))
   }
 
   // Labeled Input


### PR DESCRIPTION
Rancher 2.12 has new slide-in configuration that has to be closed.

- adapted tests for new slice-in config
- updated button locator to match also by displayed text
 
https://github.com/user-attachments/assets/bcc59854-de25-4781-9494-c5a92f2fbb02
