### PR TITLE
feat: Support helmOp fleet bundles in tests

### DIFF
--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -126,24 +126,18 @@ test('Install Kubewarden', async({ page, ui, nav }) => {
   })
 })
 
-test('Install Kubewarden by Fleet', async({ page, ui }) => {
+test('Install Kubewarden by Fleet', async({ page }) => {
   test.skip(conf.kw_mode !== 'fleet')
   test.slow()
 
   const fleetPage = new RancherFleetPage(page)
-  const repoRow = await fleetPage.addRepository({
-    name       : 'therepo',
+  await fleetPage.addGitRepo({
+    name       : 'kubewarden',
     url        : 'https://github.com/rancher/kubewarden-ui.git',
     branch     : 'main',
     selfHealing: true,
     paths      : ['tests/e2e/fleet/'],
-    workspace  : 'fleet-local'
-  })
-
-  await ui.retry(async() => {
-    await fleetPage.selectWorkspace('fleet-local')
-    await expect(repoRow.column('Clusters Ready')).toHaveText('1/1', { timeout: 7 * 60_000 })
-  }, 'Installed but not refreshed?')
+  }, { timeout: 2 * 60_000 })
 })
 
 test('Add Policy Catalog Repository', async({ page, ui, nav }) => {

--- a/tests/e2e/components/navigation.ts
+++ b/tests/e2e/components/navigation.ts
@@ -78,9 +78,9 @@ export class Navigation {
   }
 
   @step
-  async fleet<T extends FleetGroup>(groupName: T, childName?: FleetItemMap[T]) {
-    if (this.isblank()) await this.mainNav('Continuous Delivery')
-    await this.sideNavHandler(groupName, childName)
+  async fleet<T extends FleetGroup>(groupName?: T, childName?: FleetItemMap[T]) {
+    await this.mainNav('Continuous Delivery')
+    if (groupName !== undefined) await this.sideNavHandler(groupName, childName)
   }
 
   @step


### PR DESCRIPTION
Rancher 2.12 brings support for helmOp fleet bundle, which shares part of the setup with gitRepos bundle.

This PR adds test support for adding helmOp bundle.