### PR TITLE
refactor: Managed telemetry apps with OTEL default 0.92.3

### DIFF
--- a/tests/e2e/fleet/kubewarden/servers/default/fleet.yaml
+++ b/tests/e2e/fleet/kubewarden/servers/default/fleet.yaml
@@ -18,4 +18,4 @@ helm:
 dependsOn:
   - selector:
       matchLabels:
-        app: rancher-kubewarden-controller
+        app: rancher-kubewarden-crds

--- a/tests/e2e/fleet/open-telemetry/fleet.yaml
+++ b/tests/e2e/fleet/open-telemetry/fleet.yaml
@@ -2,11 +2,17 @@ defaultNamespace: opentelemetry
 helm:
   releaseName: opentelemetry
   chart: opentelemetry-operator
-  version: "0.86.4" # *
+  version: "*"
   repo: https://open-telemetry.github.io/opentelemetry-helm-charts
   values:
     manager:
       collectorImage:
         repository: "otel/opentelemetry-collector-contrib"
+
 labels:
   name: opentelemetry
+
+# To disable OTEL Collector deployment
+# targetCustomizations:
+# - clusterSelector: {}
+#   doNotDeploy: true

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -38,6 +38,12 @@ async function globalSetup(config: FullConfig) {
   process.env.RANCHER_PRIME = data.RancherPrime
 
   await requestContext.dispose()
+
+  // OTEL version in GitHub workflows:
+  // PRs: hardcoded default, github variables are not passed to PRs from forks
+  // Fleet: latest released OTEL (*) to check for future failures
+  // Other workflows: github action variable or hardcoded default
+  process.env.OTEL_OPERATOR ||= '0.92.3'
 }
 
 export default globalSetup


### PR DESCRIPTION
Telemetry apps were defined as const on telemetry test.
This PR changes this to `managedApps` handled by telemetry page, which follows POM pattern.

Another change is to unlock OTEL-operator chart in fleet test. This will check for potential issues with latest OTEL release.
Other tests can will use default from version matrix.

OTEL version in GitHub workflows:
 - PRs: hardcoded default, github vars are not passed to PRs from forks
 - Fleet: latest released OTEL to check for future failures
 - Other workflows: github action variable or hardcoded default

Related to https://github.com/kubewarden/kubewarden-end-to-end-tests/issues/110