### PR TITLE
Remove rancher 2.8 test support

### DIFF
--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -60,24 +60,18 @@ test('Install UI extension', async({ page, ui }) => {
   const extensions = new RancherExtensionsPage(page)
   await extensions.goto()
 
-  await test.step('Enable extension support', async() => {
-    if (RancherUI.isVersion('<2.9')) {
-      await extensions.enable({ rancher: conf.ui_from === 'prime', partners: false })
-    }
-    // Wait for default list of extensions
-    if (conf.ui_from === 'prime') {
-      if (RancherUI.isVersion('>=2.9')) {
-        await extensions.addRancherRepos({ rancher: true, partners: false })
-      }
+  if (conf.ui_from === 'prime') {
+    await test.step('Add official repository', async() => {
+      await extensions.addRancherRepos({ rancher: true, partners: false })
       await ui.retry(async() => {
         await extensions.selectTab('All')
         await expect(page.locator('.plugin', { hasText: 'Kubewarden' })).toBeVisible({ timeout: 30_000 })
       }, 'Not showing kubewarden extension')
-    }
-  })
+    })
+  }
 
   if (conf.ui_from === 'github') {
-    await test.step('Add UI charts repository', async() => {
+    await test.step('Add github repository', async() => {
       const apps = new RancherAppsPage(page)
       await expect(page.getByText('No Extensions available', { exact: true })).toBeVisible()
       await page.getByTestId('extensions-page-menu').click()

--- a/tests/e2e/60-telemetry.spec.ts
+++ b/tests/e2e/60-telemetry.spec.ts
@@ -215,9 +215,6 @@ test.describe('Metrics', () => {
       const frame = page.frameLocator('iframe')
 
       for (const metric of metrics) {
-        // Skip some panels until bugfix is backported to Rancher <2.9 (1.6.4 release)
-        if (RancherUI.isVersion('<2.9') && metric.source.match(/Total accepted|rejected/)) continue
-
         // byTestId for Rancher >2.9, byLabel for old versions
         const panel = frame.getByTestId(metric).or(frame.getByLabel(metric))
         // Accepted metrics should be >0, rejected could be 0

--- a/tests/e2e/rancher/rancher-extensions.page.ts
+++ b/tests/e2e/rancher/rancher-extensions.page.ts
@@ -32,23 +32,6 @@ export class RancherExtensionsPage extends BasePage {
     if (options?.partners !== undefined) await partnersRepo.setChecked(options.partners)
   }
 
-  // Extensions need to be enabled before 2.9
-  async enable(options?: { rancher?: boolean, partners?: boolean }) {
-    await expect(this.page.getByRole('heading', { name: 'Extension support is not enabled' })).toBeVisible()
-
-    await this.ui.button('Enable').click()
-    await expect(this.page.getByRole('heading', { name: 'Enable Extension Support?' })).toBeVisible()
-
-    // Select requested repositories
-    await this.selectRepos(options)
-    await this.ui.button('OK').click()
-
-    // Wait for extensions to be visible
-    await this.ui.retry(async() => {
-      await expect(this.tabs).toBeVisible({ timeout: 60_000 })
-    }, 'Extensions enabled but not visible')
-  }
-
   // Repositories need to be added since 2.9
   async addRancherRepos(options?: { rancher?: boolean, partners?: boolean }) {
     await this.dotMenu('Add Rancher Repositories')


### PR DESCRIPTION
Rancher 2.8 is end of life, cleaning up test code that is targeting it.