### PR TITLE
Wait for extensions page to load after navigation

### DIFF
--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -79,7 +79,6 @@ test('Install UI extension', async({ page, ui }) => {
   if (conf.ui_from === 'github') {
     await test.step('Add UI charts repository', async() => {
       const apps = new RancherAppsPage(page)
-      await expect(page.getByText('No Extensions available', { exact: true })).toBeVisible()
       await page.getByTestId('extensions-page-menu').click()
       await page.getByText('Manage Repositories', { exact: true }).click()
       await apps.addRepository({ name: 'kubewarden-extension-github', url: 'https://rancher.github.io/kubewarden-ui/' })

--- a/tests/e2e/rancher/rancher-extensions.page.ts
+++ b/tests/e2e/rancher/rancher-extensions.page.ts
@@ -10,8 +10,9 @@ export class RancherExtensionsPage extends BasePage {
   }
 
   async goto(): Promise<void> {
-    // await this.nav.mainNav('Extensions')
-    await this.page.goto('dashboard/c/local/uiplugins')
+    await this.nav.mainNav('Extensions')
+    await expect(this.page.getByRole('heading', { name: 'Extensions', exact: true })).toBeVisible()
+    await expect(this.page.getByText('Loading…', { exact: true })).not.toBeVisible()
   }
 
   async selectTab(name: 'Installed' | 'Available' | 'Updates' | 'All') {


### PR DESCRIPTION
Extension page still displays `Loading...` but tests already click on menu to add extension repository.
Meanwhile page loads and click is ignored.

Failed test: https://github.com/rancher/kubewarden-ui/actions/runs/16892095906/job/47854114179

https://github.com/user-attachments/assets/5b977418-71fb-4f60-8f93-cd35a41f5028

