### PR TITLE
Revert "Use github action from e2e tests"

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -213,10 +213,16 @@ jobs:
     - name: Install k3d
       run: TAG=${{ env.K3D_VERSION }} sudo --preserve-env=TAG k3d-install
 
-    - name: Install Rancher
-      uses: kubewarden/kubewarden-end-to-end-tests@main
+    - name: Checkout kubewarden-end-to-end-tests
+      uses: actions/checkout@v5
       with:
-        make: rancher
+        repository: kubewarden/kubewarden-end-to-end-tests
+        ref: main
+        path: action-make
+
+    - name: Install Rancher
+      working-directory: action-make
+      run: make rancher
       env:
         RANCHER: ${{ env.RANCHER }}
         K3S: ${{ env.K3S_VERSION }}


### PR DESCRIPTION
This reverts commit d281cfbc697ca94cad1e5d0fb096f5cc0667f0ac.

I am reverting because of [this issue](https://github.com/rancher/security-team/issues/1416#issuecomment-3195150490).
We need working tests for the rc1, this issue might not be fixed in time.