### PR TITLE
Bump OTEL operator to 0.93.0

### DIFF
--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -43,7 +43,7 @@ async function globalSetup(config: FullConfig) {
   // PRs: hardcoded default, github variables are not passed to PRs from forks
   // Fleet: latest released OTEL (*) to check for future failures
   // Other workflows: github action variable or hardcoded default
-  process.env.OTEL_OPERATOR ||= '0.92.3'
+  process.env.OTEL_OPERATOR ||= '0.93.0'
 }
 
 export default globalSetup


### PR DESCRIPTION
## Description

I updated github variable for nightly jobs to 0.93.0 and tests passed fine.
Changing default for PR tests.