### PR TITLE
Wait for policy to be active before checks

### DIFF
--- a/tests/e2e/40-policies.spec.ts
+++ b/tests/e2e/40-policies.spec.ts
@@ -140,7 +140,7 @@ for (const PolicyPage of pageTypes) {
     await psPage.create(ps)
 
     // Create and check policy
-    const row = await polPage.create(p)
+    const row = await polPage.create(p, { wait: true })
     await checkPolicy(p, polPage, ui)
     await shell.privpod({ ns: p.namespace })
 


### PR DESCRIPTION
Rancher 2.12.1 tests are failing on switching policy to Protect mode:
https://github.com/rancher/kubewarden-ui/actions/runs/17415911544/job/49444267269

This can be prevented by waiting for policy to be Active after creation.

<img width="1278" height="605" alt="Screenshot From 2025-09-03 10-50-29" src="https://github.com/user-attachments/assets/71feea83-de8a-4c57-9497-576234e1400d" />
