### PR TITLE
Add match conditions test

### DIFF
--- a/tests/e2e/components/rancher-ui.ts
+++ b/tests/e2e/components/rancher-ui.ts
@@ -121,8 +121,10 @@ export class RancherUI {
    *   await editYaml((y) => { y.policyServer.telemetry.enabled = false })
    * Yaml nodes are created automatically
    *   await editYaml({ 'policyServer.telemetry.enabled': false })
-   * String patch
+   * String patch (contains ':')
    *   await editYaml('{"policyServer": {"telemetry": { "enabled": false }}}')
+   * String value
+   *   await editYaml('any value will be pasted as string')
    */
   @step
   async editYaml(patch: YAMLPatch) {
@@ -148,7 +150,10 @@ export class RancherUI {
     // Paste edited yaml
     await this.codeMirror.click()
     await this.page.keyboard.press('Control+A')
-    await this.page.keyboard.insertText(jsyaml.dump(cmYaml))
+    // If patch is a string but not JSON, insert it as-is
+    await this.page.keyboard.insertText(
+      typeof patch === 'string' && !patch.trim().startsWith('{') && !patch.includes(':') ? patch : jsyaml.dump(cmYaml)
+    )
   }
 
   @step

--- a/tests/e2e/pages/policies.page.ts
+++ b/tests/e2e/pages/policies.page.ts
@@ -41,6 +41,7 @@ export interface Policy {
   namespace?      : string // AdmissionPolicy specific
   ignoreRancherNS?: boolean // ClusterAdmissionAdmissionPolicy specific
   settings?(ui: RancherUI): Promise<void>
+  matchConditions?: string
   yamlPatch?      : YAMLPatch
 }
 
@@ -99,7 +100,7 @@ export abstract class BasePolicyPage extends BasePage {
     return this.auditGroup.getByRole('radio', { name: state })
   }
 
-  async selectTab(name: 'General' | 'Rules' | 'Settings' | 'Namespace Selector' | 'Context Aware Resources') {
+  async selectTab(name: 'General' | 'Rules' | 'Settings' | 'Namespace Selector' | 'Match Conditions' | 'Context Aware Resources') {
     await this.ui.tab(name).click()
     await expect(this.page.locator('.tab-header').getByRole('heading', { name })).toBeVisible()
   }
@@ -164,6 +165,12 @@ export abstract class BasePolicyPage extends BasePage {
       await p.settings(this.ui)
       // Wait for generated fields
       await this.page.waitForTimeout(200)
+    }
+    if (p.matchConditions) {
+      await this.selectTab('Match Conditions')
+      await this.ui.button('Add Match Condition').click()
+      await this.ui.input('Name*').fill('con1')
+      await this.ui.editYaml(p.matchConditions)
     }
     if (p.yamlPatch) {
       await this.ui.openView('Edit YAML')


### PR DESCRIPTION
Add test for policy with custom `matchConditions`.

Test will create a Cluster Admission Policy that is limited to specific namespace (equivalent of Admission Policy) using matchCondition. Then it will check that only selected namespace is affected by this policy.

<img width="1165" height="657" alt="Screenshot From 2025-09-08 14-38-47" src="https://github.com/user-attachments/assets/3070b740-363a-4def-9ab3-abb9b6f21492" />
