### PR TITLE
Error on uncompatible kubewarden charts

### DIFF
--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -28,6 +28,9 @@ test.beforeAll(async() => {
 
   if (conf.kw_mode === 'upgrade') {
     conf.upMap = (await Common.fetchVersionMap()).splice(-3)
+    if (conf.upMap.length === 0) {
+      throw new Error('No compatible version was found, check rancher-version annotations')
+    }
   }
 })
 


### PR DESCRIPTION
We exclude rancher incompatible versions based on [this annotation](https://github.com/rancher/kubewarden-ui/blob/main/tests/e2e/components/common.ts#L27).

On the test side it finds no previous version on rancher 2.13 that it can install, which was tricky to debug.
Add this check to make error more obvious.