### PR TITLE
Bump OTEL_OPERATOR to 0.97.1

### DIFF
--- a/tests/e2e/pages/telemetry.page.ts
+++ b/tests/e2e/pages/telemetry.page.ts
@@ -24,9 +24,10 @@ export const managedApps = {
     yaml     : (y) => { y.crds.enabled = true }
   },
   openTelemetry: {
+    // https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/UPGRADING.md
     title    : 'opentelemetry-operator', name     : 'opentelemetry-operator', namespace: 'open-telemetry', check    : 'opentelemetry-operator', version  : process.env.OTEL_OPERATOR,
     repo     : { name: 'open-telemetry', url: 'https://open-telemetry.github.io/opentelemetry-helm-charts' },
-    yaml     : (y) => { y.manager.collectorImage.repository = 'otel/opentelemetry-collector-contrib' }
+    yaml     : (y) => { y.manager.collectorImage.repository = 'ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib' }
   },
   jaeger: {
     title    : 'jaeger-operator', name     : 'jaeger-operator', namespace: 'jaeger', check    : 'jaeger-operator',

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -43,7 +43,7 @@ async function globalSetup(config: FullConfig) {
   // PRs: hardcoded default, github variables are not passed to PRs from forks
   // Fleet: latest released OTEL (*) to check for future failures
   // Other workflows: github action variable or hardcoded default
-  process.env.OTEL_OPERATOR ||= '0.93.0'
+  process.env.OTEL_OPERATOR ||= '0.97.1'
 }
 
 export default globalSetup


### PR DESCRIPTION
Switch to ghcr.io for collectorImage

In the [v0.123.1 Collector release](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/UPGRADING.md#0864-to-0870) stopped pushing images to Dockerhub because of new rate limit changes.

