### PR TITLE
Fix spec.mutating policy value

### DIFF
--- a/pkg/kubewarden/components/Policies/Create.vue
+++ b/pkg/kubewarden/components/Policies/Create.vue
@@ -498,7 +498,7 @@ export default ({
           spec:       {
             module:   policyModule,
             mode:     'monitor', // Default to monitor mode
-            mutating: policyAnnotations[KUBEWARDEN_CATALOG_ANNOTATIONS.MUTATING] === 'true' || false,
+            mutating: policyAnnotations[KUBEWARDEN_CATALOG_ANNOTATIONS.MUTATION] === 'true' || false,
             rules:    this.parseObj(policyAnnotations[KUBEWARDEN_CATALOG_ANNOTATIONS.RULES]) || []
           }
         };


### PR DESCRIPTION
Annotation is named `kubewarden/mutation`, but we use `spec.mutating` on resources.

Mutation/Mutating naming confusion caused UI code to use wrong const.

https://github.com/rancher/kubewarden-ui/blob/8eaf6c46e0b264171db27188031824dc6c7edf6c/pkg/kubewarden/types/kubewarden.ts#L50

Fixes https://github.com/rancher/kubewarden-ui/issues/1340