### PR TITLE
Revert "fix: controller upgrade shows twice on 2.12"

### DIFF
--- a/tests/e2e/pages/kubewarden.page.ts
+++ b/tests/e2e/pages/kubewarden.page.ts
@@ -158,9 +158,6 @@ export class KubewardenPage extends BasePage {
     if (!to?.controller?.startsWith('4.1') && !to?.controller?.startsWith('5.0')) {
       await shell.waitPods()
     }
-    // Workaround for controller upgrade showing twice (issue#1275)
-    await this.nav.explorer('Apps', 'Installed Apps')
-    await this.ui.tableRow('rancher-kubewarden-controller').toHaveState('Deployed')
 
     // Defaults upgrade
     await this.nav.kubewarden()


### PR DESCRIPTION
This reverts commit ca72c459d6d65b1ef80e3d5b648a1cbd2ef46073.

https://github.com/rancher/kubewarden-ui/issues/1275 was fixed on rancher side.