### PR TITLE
Update locator for rancher shell window

### DIFF
--- a/tests/e2e/components/kubectl-shell.ts
+++ b/tests/e2e/components/kubectl-shell.ts
@@ -17,7 +17,7 @@ export class Shell {
 
   constructor(protected readonly page: Page) {
     // Window manager owns kubectl tab
-    this.win = this.page.locator('div#windowmanager')
+    this.win = this.page.locator('div#windowmanager').or(this.page.locator('div#horizontal-window-manager'))
     // Connected message
     this.connected = this.win.locator('.status').getByText('Connected', { exact: true })
     // Visible terminal screen

--- a/tests/e2e/rancher/rancher-apps.page.ts
+++ b/tests/e2e/rancher/rancher-apps.page.ts
@@ -137,7 +137,7 @@ export class RancherAppsPage extends BasePage {
     await expect(passedMsg).toBeVisible({ timeout })
     // Close the window
     if (keepLog === false) {
-      const win = this.page.locator('#windowmanager')
+      const win = this.page.locator('#windowmanager').or(this.page.locator('div#horizontal-window-manager'))
       await win.locator('div.tab.active').locator('i.closer').click()
     }
   }


### PR DESCRIPTION
Rancher 2.13 changed locator from `windowmanager` to `horizontal-window-manager`.
I am keeping both for backwards compatibility.