### PR TITLE
Revert "Skip showConfiguration tests" workaround

### DIFF
--- a/tests/e2e/30-policyservers.spec.ts
+++ b/tests/e2e/30-policyservers.spec.ts
@@ -2,7 +2,6 @@ import semver from 'semver'
 import { test, expect } from './rancher/rancher-test'
 import { PolicyServersPage, PolicyServer } from './pages/policyservers.page'
 import { Policy, AdmissionPoliciesPage, ClusterAdmissionPoliciesPage } from './pages/policies.page'
-import { RancherUI } from './components/rancher-ui'
 
 const expect3m = expect.configure({ timeout: 3 * 60_000 })
 
@@ -88,15 +87,12 @@ test('Create with custom values', async({ page, ui, nav }) => {
   const ps = { name: 'test-policyserver', image: 'ghcr.io/kubewarden/policy-server:latest', replicas: 2 }
   await psPage.create(ps, { wait: false })
 
-  // https://github.com/rancher/kubewarden-ui/issues/1310
-  if (RancherUI.isVersion('<2.13')) {
-    await nav.pservers(ps.name)
-    await ui.showConfiguration()
-    await expect(ui.input('Name*')).toHaveValue(ps.name)
-    await expect(ui.input('Image URL')).toHaveValue(ps.image)
-    await expect(ui.input('Replicas*')).toHaveValue(ps.replicas.toString())
-    await ui.hideConfiguration()
-  }
+  await nav.pservers(ps.name)
+  await ui.showConfiguration()
+  await expect(ui.input('Name*')).toHaveValue(ps.name)
+  await expect(ui.input('Image URL')).toHaveValue(ps.image)
+  await expect(ui.input('Replicas*')).toHaveValue(ps.replicas.toString())
+  await ui.hideConfiguration()
 
   await psPage.delete(ps.name)
 })

--- a/tests/e2e/40-policies.spec.ts
+++ b/tests/e2e/40-policies.spec.ts
@@ -47,8 +47,7 @@ async function checkPolicy(p: Policy, polPage: BasePolicyPage, ui: RancherUI) {
     await expect(ui.page.getByText('API Versions')).toBeVisible()
   })
 
-  // Skip: https://github.com/rancher/kubewarden-ui/issues/1310
-  await test.step.skip(`Check config page: ${p.name}`, async() => {
+  await test.step(`Check config page: ${p.name}`, async() => {
     await ui.showConfiguration()
     await expect(polPage.name).toHaveValue(p.name)
     if (p.title === 'Custom Policy') await expect(polPage.module).toHaveValue(module)
@@ -227,15 +226,13 @@ test('Recommended policies', async({ page, ui, nav }) => {
       }
     })
 
-    // https://github.com/rancher/kubewarden-ui/issues/1310
-    if (RancherUI.isVersion('<2.13')) {
-      const capPage = new ClusterAdmissionPoliciesPage(page)
-      await nav.capolicies('no-privileged-pod')
-      await ui.showConfiguration()
-      await capPage.selectTab('Settings')
-      await expect(ui.checkbox('Skip init containers')).toBeChecked()
-      await ui.hideConfiguration()
-    }
+    const capPage = new ClusterAdmissionPoliciesPage(page)
+    await nav.capolicies('no-privileged-pod')
+    await ui.showConfiguration()
+    await capPage.selectTab('Settings')
+    // await expect(ui.codeMirror).toContainText('skip_init_containers: true')
+    await expect(ui.checkbox('Skip init containers')).toBeChecked()
+    await ui.hideConfiguration()
   })
 })
 


### PR DESCRIPTION
This reverts commit ecce608962853a2892340818115b6e694d24d9de.

Issue https://github.com/rancher/dashboard/issues/15658 was fixed, enabling tests again.