### PR TITLE
Skip image-cve policy in e2e tests

### DIFF
--- a/tests/e2e/90-allpolicies.spec.ts
+++ b/tests/e2e/90-allpolicies.spec.ts
@@ -35,6 +35,7 @@ const policySettingsMap: Partial<Record<policyTitle, PolicySettings>> = {
   'Helm Release Target Namespace'                                 : { settings: generalArray },
   'Helm Release Values From'                                      : { settings: generalArray },
   'Helm Repo URL Should Be in Organisation Domain'                : { settings: generalArray },
+  'image-cve'                                                     : { skip: 'https://github.com/kubewarden/image-cve-policy/issues/82' },
   'Istio Gateway Approved Hosts'                                  : { settings: generalArray },
   'Istio Injected Namespaces'                                     : { settings: generalArray },
   'Kustomization Decryption Provider'                             : { settings: generalArray },

--- a/tests/e2e/pages/policies.page.ts
+++ b/tests/e2e/pages/policies.page.ts
@@ -24,7 +24,7 @@ export const apList = ['Custom Policy',
   'Rbac Prohibit Watch On Secrets', 'Rbac Prohibit Wildcard On Secrets', 'Rbac Prohibit Wildcards on Policy Rule Resources', 'Rbac Prohibit Wildcards on Policy Rule Verbs',
   'Readonly Root Filesystem PSP', 'Resource Quota Setting Is Missing', 'Resource Reconcile Interval Must Be Set Between Lower and Upper Bound', 'Resource Suspend Waiver',
   'Safe Annotations', 'Safe Labels', 'Seccomp PSP', 'Selinux PSP', 'Share PID namespace', 'Sysctl PSP', 'Trusted Repos', 'Unique Ingress host', 'Unique service selector',
-  'User Group PSP', 'Verify Image Signatures', 'Volumes PSP', 'volumeMounts', 'High Risk Service Account', 'Annotations', 'Labels'] as const
+  'User Group PSP', 'Verify Image Signatures', 'Volumes PSP', 'volumeMounts', 'High Risk Service Account', 'Annotations', 'Labels', 'image-cve'] as const
 
 export const capList = [...apList, 'PSA Label Enforcer', 'Istio Injected Namespaces', 'Persistent Volume Access Modes'] as const
 


### PR DESCRIPTION
Policy also requires sbomscanner, we don't have automation for this yet.