### PR TITLE
[2.10] Skip image-cve policy in e2e tests

### DIFF
--- a/tests/e2e/90-allpolicies.spec.ts
+++ b/tests/e2e/90-allpolicies.spec.ts
@@ -31,6 +31,7 @@ const policySettingsMap: Partial<Record<policyTitle, PolicySettings>> = {
   'Priority class policy'      : { settings: setupPriorityClassPolicy },
   'CEL Policy'                 : { skip: 'https://github.com/kubewarden/cel-policy/issues/12' },
   'High Risk Service Account'  : { settings: setupHighRiskServiceAccount },
+  'image-cve'                  : { skip: 'https://github.com/kubewarden/image-cve-policy/issues/82' },
   volumeMounts                 : { settings: setupVolumeMounts },
 }
 

--- a/tests/e2e/pages/policies.page.ts
+++ b/tests/e2e/pages/policies.page.ts
@@ -9,7 +9,7 @@ export const apList = ['Custom Policy', 'Allow Privilege Escalation PSP', 'Allow
   'Host Namespaces PSP', 'Hostpaths PSP', 'Ingress Policy', 'Namespace label propagator', 'Pod Privileged Policy', 'Pod Runtime', 'Readonly Root Filesystem PSP', 'Share PID namespace',
   'Safe Annotations', 'Safe Labels', 'Seccomp PSP', 'Selinux PSP', 'Sysctl PSP', 'Trusted Repos', 'User Group PSP', 'Verify Image Signatures', 'volumeMounts', 'Volumes PSP', 'Unique Ingress host',
   'Unique service selector', 'PVC StorageClass Validator', 'CEL Policy', 'Pod ndots', 'Do not expose admission controller webhook services', 'Priority class policy', 'High Risk Service Account',
-  'Labels', 'Annotations'] as const
+  'Labels', 'Annotations', 'image-cve'] as const
 
 export const capList = [...apList, 'PSA Label Enforcer'] as const
 


### PR DESCRIPTION
Policy also requires sbomscanner, we don't have automation for this yet.

Fixes e2e test: https://github.com/rancher/kubewarden-ui/actions/runs/19214410787/job/54964301939