### PR TITLE
Change banner to have the button under the text

### DIFF
--- a/pkg/kubewarden/components/DefaultsBanner.vue
+++ b/pkg/kubewarden/components/DefaultsBanner.vue
@@ -213,12 +213,10 @@ export default {
   </Banner>
 </template>
 <style scoped>
-/** This is an anti pattern and will break on component changes */
 .kw-banner-content {
   display: flex;
-  flex-direction: row;
-  align-items: center;
-  flex-grow: 1;
-  justify-content: space-between;
+  flex-direction: column;
+  align-items: start;
+  gap: 12px;
 }
 </style>


### PR DESCRIPTION
Fixes #1201

- Added alignment
- Added space between elements
- Replaced primary with secondary button, as it's not CTA (FYI @oboc-sts )

<img width="1914" height="966" alt="Screenshot 2025-11-25 at 10 43 24" src="https://github.com/user-attachments/assets/374a7e07-08a4-42ff-a150-291a3c19dcea" />

