### PR TITLE
Describe locator helpers

### DIFF
--- a/tests/e2e/components/rancher-ui.ts
+++ b/tests/e2e/components/rancher-ui.ts
@@ -27,6 +27,7 @@ export class RancherUI {
     return this.page.getByRole('button', { name, exact: true })
       .or(this.page.locator('a.btn,button', { has: this.page.getByText(name, { exact: true }) }))
       .filter({ visible: true })
+      .describe(`Button: ${name}`)
   }
 
   // Labeled Input
@@ -35,6 +36,7 @@ export class RancherUI {
       .filter({ has: this.page.getByText(label, { exact: true }) })
       .locator('input')
       .filter({ visible: true })
+      .describe(`Input: ${label}`)
   }
 
   // Labeled Checkbox
@@ -42,11 +44,12 @@ export class RancherUI {
     return this.page.locator('label.checkbox-container')
       .filter({ hasText: label })
       .locator('span.checkbox-custom')
+      .describe(`Checkbox: ${label}`)
   }
 
   // Tab
   tab(name: string|RegExp) {
-    return this.page.getByRole('tab', { name, exact: true })
+    return this.page.getByRole('tab', { name, exact: true }).describe(`Tab: ${name}`)
   }
 
   // Radio group
@@ -56,11 +59,12 @@ export class RancherUI {
     return this.page.locator('.radio-group')
       .filter({ has: this.page.getByRole('heading', { name: groupLabel }) })
       .locator('xpath=./following-sibling::div')
+      .describe(`Radio group: ${label}`)
   }
 
   // Radio input (span)
   radio(label: string, name: string): Locator {
-    return this.radioGroup(label).getByRole('radio', { name })
+    return this.radioGroup(label).getByRole('radio', { name }).describe(`Radio: ${name} in ${label}`)
   }
 
   // (un)Labeled Select (ComboBox)
@@ -69,7 +73,7 @@ export class RancherUI {
       ? this.page.locator('div.labeled-select').filter({ hasText: label })
       : label.locator('div.unlabeled-select')
 
-    return base.getByRole('combobox', { name: 'Search for option' })
+    return base.getByRole('combobox', { name: 'Search for option' }).describe(`Select: ${label}`)
   }
 
   // Slide-in drawer or old config

--- a/tests/e2e/components/table-row.ts
+++ b/tests/e2e/components/table-row.ts
@@ -62,7 +62,7 @@ export class TableRow {
       }
     }
 
-    this.row = rows
+    this.row = rows.describe(`TableRow: ${this}`)
     this.name = this.column('Name')
     this.status = this.column('Status', 'State')
   }
@@ -78,7 +78,7 @@ export class TableRow {
   column(index: number): Locator
   column(name: string, ...altNames: string[]): Locator
   column(...args: (number|string)[]): Locator {
-    return this.row.locator(this.getByColumn(...args))
+    return this.row.locator(this.getByColumn(...args)).describe(`TableRow: ${this}, Column: ${args.join('|')}`)
   }
 
   /**
@@ -106,7 +106,7 @@ export class TableRow {
 
   @step
   async action(name: string) {
-    await this.row.getByTestId(/^sortable-table-\d+-action-button$/).click()
+    await this.row.getByTestId(/^sortable-table-\d+-action-button$/).describe(`TableRow: ${this}, Action: ${name}`).click()
     // Rancher 2.11+ uses both menuitem & listitem
     await this.ui.page.getByRole('listitem').or(this.ui.page.getByRole('menuitem'))
       .getByText(name, { exact: true }).click()
@@ -123,6 +123,6 @@ export class TableRow {
   }
 
   async open() {
-    await this.name.getByRole('link').click()
+    await this.name.getByRole('link').describe(`TableRow: ${this}`).click()
   }
 }


### PR DESCRIPTION
Playwright locators are displayed as string in UI mode and logs. Some locators (especially table rows) are complex and hard to read. This change adds description to most used locators.

Before:
<img width="821" height="191" alt="Screenshot From 2025-11-25 21-59-43" src="https://github.com/user-attachments/assets/1232bd54-d27c-49cb-b13f-092bab2b286c" />

After:
<img width="821" height="191" alt="Screenshot From 2025-11-25 21-54-09" src="https://github.com/user-attachments/assets/2c711173-f01d-4b6c-81cf-fa66ad6fedae" />
