### PR TITLE
Disable dependabot for main projct

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,17 +6,18 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directory: "/tests"
     schedule:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 10
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 10
+  # Disabling based on discussion with Giuseppe Leo
+  # - package-ecosystem: "npm"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #     day: "monday"
+  #   open-pull-requests-limit: 10
   - package-ecosystem: "npm"
     directory: "/tests"
     schedule:


### PR DESCRIPTION
Based on conversation with Giuseppe I am disabling dependabot

> All of these libraries defined in Dependabot should be not there and are inherited by @rancher/shell, which means we do not have to do maintenance for each extension, as we will do just there, plus the code will be more reliable
> you can close all the PRs and block dependabot for now