### PR TITLE
Fix test for PriorityClassPolicy settings

### DIFF
--- a/tests/e2e/90-allpolicies.spec.ts
+++ b/tests/e2e/90-allpolicies.spec.ts
@@ -58,7 +58,7 @@ const policySettingsMap: Partial<Record<policyTitle, PolicySettings>> = {
   'PVC StorageClass Validator'                                    : { settings: generalArray },
   'Persistent Volume Access Modes'                                : { settings: persistentVolumeAccessModes },
   'Persistent Volume Claim Snapshot'                              : { settings: persistentVolumeClaimSnapshot },
-  'Priority class policy'                                         : { settings: generalArray },
+  'Priority class policy'                                         : { settings: priorityClassPolicy },
   'Probes validator policy'                                       : { skip: 'https://github.com/kubewarden/policy-server/issues/1329' },
   'Resource Quota Setting Is Missing'                             : { settings: resourceQuotaSettingIsMissing },
   'Resource Suspend Waiver'                                       : { settings: generalArray },
@@ -88,6 +88,10 @@ async function setupHighRiskServiceAccount(ui: RancherUI) {
   await fillGroup(ui, 'Resources', ['roles', 'rolebindings'])
   await fillGroup(ui, 'Verbs', ['*'])
   await ui.input('namespace').fill('default')
+}
+
+async function priorityClassPolicy(ui: RancherUI) {
+  await fillGroup(ui, 'Allowed priority classes', ['low-priority'])
 }
 
 async function affinityNodeSelector(ui: RancherUI) {


### PR DESCRIPTION
Test fails because it finds multiple `Add` buttons on the policy.
Policy was changed and has new settings, this PR updates test for it.

<img width="1600" height="900" alt="test-failed-1" src="https://github.com/user-attachments/assets/93ab1abc-8f4a-428a-bcfc-438e35df86e6" />

Failed test: https://github.com/rancher/kubewarden-ui/actions/runs/20317226163/job/58444145813
Qase: https://app.qase.io/run/KUBEWARDEN/dashboard/4206/55031bbbb99342df6c7f65ba57cd908d75eb7780