### PR TITLE
Fix extension installation

### DIFF
--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -76,8 +76,8 @@ test('Install UI extension', async({ page, ui }) => {
     await test.step('Add official repository', async() => {
       await extensions.addRancherRepos({ rancher: true, partners: false })
       await ui.retry(async() => {
-        await extensions.selectTab('All')
-        await expect(page.locator('.plugin', { hasText: 'Kubewarden' })).toBeVisible({ timeout: 30_000 })
+        await extensions.selectTab('Available')
+        await expect(extensions.getByName('kubewarden')).toBeVisible({ timeout: 30_000 })
       }, 'Not showing kubewarden extension')
     })
   }

--- a/tests/e2e/rancher/rancher-extensions.page.ts
+++ b/tests/e2e/rancher/rancher-extensions.page.ts
@@ -49,7 +49,7 @@ export class RancherExtensionsPage extends BasePage {
      * @param name Case insensitive exact match of plugin name
      * @returns plugin Locator
      */
-  getExtension(name: string|RegExp) {
+  getByName(name: string|RegExp) {
     return RancherUI.isVersion('>=2.13')
       ? this.page.locator('.item-card', { has: this.page.getByRole('heading', { name, exact: true }) })
       : this.page.locator('.plugin', { has: this.page.locator('.plugin-name').getByText(name, { exact: true }) })
@@ -66,7 +66,7 @@ export class RancherExtensionsPage extends BasePage {
   async install(name: string, options?: { version?: string }) {
     await this.selectTab('Available')
 
-    const plugin = this.getExtension(name)
+    const plugin = this.getByName(name)
     if (RancherUI.isVersion('>=2.13')) {
       await plugin.getByTestId('item-card-header-action-menu').click()
       await plugin.getByRole('menuitem', { name: 'Install' }).click()


### PR DESCRIPTION
In rancher 2.13.1:
- `All` tab was removed, using `Available` instead
- `.plugin` selector was changed to `.item-card`, using helper method

### Rancher 2.12:
<img width="448" height="160" alt="Screenshot From 2025-12-21 14-16-22" src="https://github.com/user-attachments/assets/665e091a-e59d-4cc2-a1e2-9b676f567bea" />

### Rancher 2.13.1:
<img width="448" height="160" alt="Screenshot From 2025-12-21 14-43-51" src="https://github.com/user-attachments/assets/0fc9d69c-bdef-4fa4-8e9f-8e202e0ecc35" />
