### PR TITLE
Handle number in tab names

### DIFF
--- a/tests/e2e/components/rancher-ui.ts
+++ b/tests/e2e/components/rancher-ui.ts
@@ -49,7 +49,9 @@ export class RancherUI {
 
   // Tab
   tab(name: string|RegExp) {
-    return this.page.getByRole('tab', { name, exact: true }).describe(`Tab: ${name}`)
+    // Modify string parameter to handle (N) suffix (UI >= 4.0.4)
+    if (typeof name === 'string') name = new RegExp(`^${name}( \\(\\d+\\))?$`)
+    return this.page.getByRole('tab', { name }).describe(`Tab: ${name}`)
   }
 
   // Radio group


### PR DESCRIPTION
Tabs in newer version of rancher-shell contain `(N)` for number of resources.
Tests were matching tab name exactly, which does not work anymore.
Related PR with rancher-shell bump: https://github.com/rancher/kubewarden-ui/pull/1376

<img width="746" height="193" alt="Screenshot From 2026-01-13 10-28-35" src="https://github.com/user-attachments/assets/a55fee20-17ce-41c8-aca4-1ec7f33a518d" />
