### PR TITLE
Handle no installed apps showing after upgrade

### DIFF
--- a/tests/e2e/pages/kubewarden.page.ts
+++ b/tests/e2e/pages/kubewarden.page.ts
@@ -168,6 +168,8 @@ export class KubewardenPage extends BasePage {
     }
     await apps.updateApp('rancher-kubewarden-defaults', { navigate: false })
 
+    // UI shows no installed apps if navigation is too fast
+    await this.page.waitForTimeout(3000)
     // Check resources are online
     await this.nav.explorer('Apps', 'Installed Apps')
     for (const chart of ['controller', 'crds', 'defaults'] as const) {


### PR DESCRIPTION
Should fix upgrade e2e test
https://github.com/rancher/kubewarden-ui/actions/runs/21151400921/job/60828007833

We wait for `Success` message from rancher shell and then click `Installed Apps`.
Navigation to `Installed Apps` while page is loading/redirecting causes Installed Apps to show empty table.

https://github.com/user-attachments/assets/236d9963-5881-4d14-b599-dc0bb26358fb

