### PR TITLE
Retry tracing log check

### DIFF
--- a/tests/e2e/60-telemetry.spec.ts
+++ b/tests/e2e/60-telemetry.spec.ts
@@ -87,7 +87,7 @@ test.describe('Tracing', () => {
       }
     })
     // Wait until kubewarden controller restarts policyserver
-    await shell.retry(`kubectl logs -l app=kubewarden-policy-server-default -n cattle-kubewarden-system -c otc-container --since-time ${now} | grep -F "Everything is ready."`)
+    await shell.retry(`kubectl logs -l app=kubewarden-policy-server-default -n cattle-kubewarden-system -c otc-container --since-time ${now} 2>/dev/null | grep -F "Everything is ready."`)
   })
 
   test('Check traces are visible', async({ ui, nav, shell }) => {
@@ -100,7 +100,10 @@ test.describe('Tracing', () => {
     await test.step('Check default PS', async() => {
       // Check logs on policy server
       await nav.pservers('default', 'Tracing')
-      await expect(logline).toBeVisible()
+      await ui.retry(async() => {
+        await expect(logline).toBeVisible()
+      }, 'Jaeger might take a moment to process the trace')
+
       // Check logs on (recommended) policy
       await nav.capolicies('no-privileged-pod', 'Tracing')
       await expect(logline).toBeVisible()


### PR DESCRIPTION
We generate log line with `kubectl run pod --image=busybox ... --privileged`.
Right after that we navigate to tracing tab and expect log to be visible.

Sometimes it takes a second for Jaeger to process the line and test fails:
https://github.com/rancher/kubewarden-ui/actions/runs/21225765899/job/61072185372

<img width="1600" height="900" alt="test-failed-1" src="https://github.com/user-attachments/assets/f2f23b68-3c0b-4edb-8468-436a24347c63" />

Issue happens in ~ 20% of tests, I was able to reproduce it locally.
With this fix I rerun it 15 times and it always passed.