### PR TITLE
[2.9] Use extension from github instead of prime

### DIFF
--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -10,7 +10,9 @@ import { RancherUI } from './components/rancher-ui'
 import { Common } from './components/common'
 
 // source (yarn dev) | github (add github repo) | prime (just install)
-const ORIGIN = process.env.ORIGIN || (process.env.API ? 'source' : 'github')
+let ORIGIN = process.env.ORIGIN || (process.env.API ? 'source' : 'github')
+// Override prime -> github to fix temporary github runners - issue#1412
+ORIGIN = ORIGIN === 'prime' ? 'github' : ORIGIN
 expect(ORIGIN).toMatch(/^(source|github|prime)$/)
 
 const MODE = process.env.MODE || 'manual'


### PR DESCRIPTION
Backport of https://github.com/rancher/kubewarden-ui/pull/1411