### PR TITLE
Revert "Use extension from github instead of prime"

### DIFF
--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -29,9 +29,6 @@ test.beforeAll(async({ request }) => {
     .then(() => 'source' as const)
     .catch(() => RancherUI.isPrime ? 'prime' : 'github')
 
-  // Override prime -> github to fix temporary github runners - issue#1412
-  conf.ui_from = conf.ui_from === 'prime' ? 'github' : conf.ui_from
-
   // Default to manual mode, unless fleet or upgrade is requested
   conf.kw_mode ||= 'manual'
 


### PR DESCRIPTION
This reverts commit 32abcfe9ac96d6703c7ff77adbe258a25624bee3.

Related to https://github.com/rancher/kubewarden-ui/issues/1412

Tested on fork: https://github.com/kravciak/kubewarden-ui/actions/runs/21926869506/job/63321481546