### PR TITLE
[2.9] Revert "Use extension from github instead of prime"

### DIFF
--- a/tests/e2e/00-installation.spec.ts
+++ b/tests/e2e/00-installation.spec.ts
@@ -10,9 +10,7 @@ import { RancherUI } from './components/rancher-ui'
 import { Common } from './components/common'
 
 // source (yarn dev) | github (add github repo) | prime (just install)
-let ORIGIN = process.env.ORIGIN || (process.env.API ? 'source' : 'github')
-// Override prime -> github to fix temporary github runners - issue#1412
-ORIGIN = ORIGIN === 'prime' ? 'github' : ORIGIN
+const ORIGIN = process.env.ORIGIN || (process.env.API ? 'source' : 'github')
 expect(ORIGIN).toMatch(/^(source|github|prime)$/)
 
 const MODE = process.env.MODE || 'manual'


### PR DESCRIPTION
This reverts commit 24df23dfb81e89e02da2219f4fb03c118201e616.