### PR TITLE
[2.10] Chart version list shows twice

### DIFF
--- a/tests/e2e/rancher/rancher-apps.page.ts
+++ b/tests/e2e/rancher/rancher-apps.page.ts
@@ -187,7 +187,7 @@ export class RancherAppsPage extends BasePage {
         if (chart.version) {
           const versionPane = this.page.getByRole('heading', { name: 'Chart Versions', exact: true }).locator('..')
           const showMore = versionPane.getByText('Show More', { exact: true })
-          const chartVersion = versionPane.getByText(chart.version, { exact: true })
+          const chartVersion = versionPane.getByText(chart.version, { exact: true }).first()
 
           await expect(versionPane).toBeVisible()
           // Expand versions


### PR DESCRIPTION
Tests occasionally fail on version list showing twice. I noticed this only on rancher 2.10 so far.
In this example I want to click on version 0.102.0, but playwright errors because locator resolves to 2 elements:

```
Error: locator.click: Error: strict mode violation: getByRole('heading', { name: 'Chart Versions', exact: true }).locator('..').getByText('0.102.0', { exact: true }) resolved to 2 elements:
    1) <a data-v-d383264a="" class="v-popper--has-tooltip">0.102.0</a> aka getByText('0.102.0').first()
    2) <a data-v-d383264a="" class="v-popper--has-tooltip">0.102.0</a> aka getByText('0.102.0').nth(1)

Call log:
  - waiting for getByRole('heading', { name: 'Chart Versions', exact: true }).locator('..').getByText('0.102.0', { exact: true })
```

https://github.com/user-attachments/assets/0ae62d2d-09d5-42ab-b7a2-634cd26df0b9

