### PR TITLE
Handle no installed apps showing after navigation

### DIFF
--- a/tests/e2e/pages/kubewarden.page.ts
+++ b/tests/e2e/pages/kubewarden.page.ts
@@ -168,8 +168,6 @@ export class KubewardenPage extends BasePage {
     }
     await apps.updateApp('rancher-kubewarden-defaults', { navigate: false })
 
-    // UI shows no installed apps if navigation is too fast
-    await this.page.waitForTimeout(3000)
     // Check resources are online
     await this.nav.explorer('Apps', 'Installed Apps')
     for (const chart of ['controller', 'crds', 'defaults'] as const) {

--- a/tests/e2e/rancher/rancher-apps.page.ts
+++ b/tests/e2e/rancher/rancher-apps.page.ts
@@ -266,6 +266,9 @@ export class RancherAppsPage extends BasePage {
 
     await this.updateBtn.click()
     await this.waitHelmSuccess(name, { timeout: options?.timeout })
+
+    // List of installed apps is empty if we navigate right after update
+    await this.page.waitForTimeout(3000)
   }
 
   @step


### PR DESCRIPTION
I fixed `no installed apps` problem for upgrade test in https://github.com/rancher/kubewarden-ui/pull/1400.
We have the same occasional failure when uninstalling metrics.

The issue happens between `updateApp` and `nav.explorer('Apps', 'Installed Apps')` calls.
With this change test will always wait 3s after updating app.

In recording you can see app list briefly showed at 5s timestamp, then disappeared again.

https://github.com/user-attachments/assets/444f8d39-7855-44eb-b511-9441897ee4c5

Recording from: https://github.com/rancher/kubewarden-ui/actions/runs/22043072192/job/63729338739