### PR TITLE
Add tsconfig for e2e tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7
   # Limited to rancher-shell by Giuseppe Leo
   - package-ecosystem: "npm"
     directory: "/"
@@ -18,6 +20,8 @@ updates:
       day: "monday"
     allow:
       - dependency-name: "@rancher/shell"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "npm"
     directory: "/tests"
     schedule:
@@ -26,3 +30,5 @@ updates:
       time: "06:00"
       timezone: "Europe/Prague"
     labels: ["dependencies", "area/qa"]
+    cooldown:
+      default-days: 7

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -71,8 +71,10 @@ on:
       - release-2.1 # rancher 2.9
       - release-3.1 # rancher 2.10
     paths:
-      - pkg/kubewarden/**
-      - package.json
+      - 'pkg/kubewarden/**'
+      - 'package.json'
+      - 'tests/**'
+      - '!tests/unit/**'
 
   workflow_run:
     workflows: ["Build and Release Extension Charts"]
@@ -251,6 +253,10 @@ jobs:
       run: |
         yarn install
         yarn playwright install chromium  # --with-deps not supported on opensuse
+
+    - name: Typecheck
+      if: github.event_name == 'pull_request'
+      run: npx tsc -p tests/tsconfig.json --noEmit
 
     - name: Execute tests
       timeout-minutes: 120

--- a/tests/package.json
+++ b/tests/package.json
@@ -14,7 +14,7 @@
     "semver": "^7.7.4"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "scripts": {}
 }

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node", "@playwright/test"],
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules", "./unit"]
+}


### PR DESCRIPTION
- Postpone dependabot by 7 days
- Add tsconfig for e2e tests. Fixed error:
```
Cannot find name 'process'. Do you need to install type definitions for node?
Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
```
- Add typecheck for e2e tests on PRs. Prevents typescript errors:
 ```
npx tsc -p tsconfig.json --noEmit
e2e/10-kubewarden.spec.ts:8:27 - error TS2307: Cannot find module './components/rancher-uis' or its corresponding type declarations.

8 import { RancherUI } from './components/rancher-uis'
```
- Trigger e2e tests on e2e PRs
Currently only PRs to pkg/kubewarden are tested with e2e.
Try to trigger workflow also for e2e changes to find if it's useful.