### PR TITLE
Fix fleet repository paths

### DIFF
--- a/tests/e2e/fleet/kubewarden/controller/fleet.yaml
+++ b/tests/e2e/fleet/kubewarden/controller/fleet.yaml
@@ -27,8 +27,6 @@ helm:
             endpoint: "jaeger-operator-jaeger-collector.jaeger.svc.cluster.local:4317"
             tls:
               insecure: true
-    auditScanner:
-      policyReporter: true
 
 diff:
   comparePatches:

--- a/tests/e2e/rancher/rancher-fleet.page.ts
+++ b/tests/e2e/rancher/rancher-fleet.page.ts
@@ -150,6 +150,8 @@ export class RancherFleetPage extends BasePage {
         if (repo.paths) {
           for (const path of repo.paths) {
             await this.ui.button(/Add Path/).click()
+            // Input is cleared short after creation
+            await this.page.waitForTimeout(200)
             await this.page.getByPlaceholder('e.g. /directory/in/your/repo').fill(path)
           }
           // Wait for generated fields


### PR DESCRIPTION
Nightly test fails with error: `Error while running post render on files: invalid character '}' looking for beginning of object key string`.

After closer debug root cause is that fleet clears `path` input after it's created. This results in:
 - path input is created
 - test fill value of the input
 - path input is cleared
 - test creates fleet repo without root path

Fleet [nightly test fail](https://github.com/rancher/kubewarden-ui/actions/runs/24423424757/job/71402271723):
<img width="1600" height="900" alt="test-failed-1" src="https://github.com/user-attachments/assets/cc91f575-97bf-471a-8ab2-a3f4b1f06cb2" />
