### PR TITLE
Fix fleet drift error on webhooks

### DIFF
--- a/tests/e2e/10-kubewarden.spec.ts
+++ b/tests/e2e/10-kubewarden.spec.ts
@@ -118,7 +118,7 @@ test('Install Kubewarden by Fleet', { tag: '@kw' }, async({ page }) => {
     branch     : 'main',
     selfHealing: true,
     paths      : ['tests/e2e/fleet/'],
-  }, { timeout: 2 * 60_000 })
+  }, { timeout: 4 * 60_000 })
 })
 
 test('Add Policy Catalog Repository', { tag: '@kw' }, async({ page, ui, nav }) => {

--- a/tests/e2e/fleet/jaeger-operator/fleet.yaml
+++ b/tests/e2e/fleet/jaeger-operator/fleet.yaml
@@ -11,5 +11,23 @@ helm:
     jaeger:
       create: true
 
+diff:
+  comparePatches:
+    - apiVersion: admissionregistration.k8s.io/v1
+      kind: MutatingWebhookConfiguration
+      name: jaeger-operator-mutating-webhook-configuration
+      jsonPointers:
+        - /webhooks/0/clientConfig/caBundle
+        - /webhooks/0/rules
+        - /webhooks/1/clientConfig/caBundle
+        - /webhooks/1/rules
+
+    - apiVersion: admissionregistration.k8s.io/v1
+      kind: ValidatingWebhookConfiguration
+      name: jaeger-operator-validating-webhook-configuration
+      jsonPointers:
+        - /webhooks/0/clientConfig/caBundle
+        - /webhooks/0/rules
+
 labels:
   name: jaeger-operator

--- a/tests/e2e/fleet/kubewarden/controller/fleet.yaml
+++ b/tests/e2e/fleet/kubewarden/controller/fleet.yaml
@@ -30,12 +30,25 @@ helm:
 
 diff:
   comparePatches:
-  - apiVersion: opentelemetry.io/v1alpha1
-    kind: OpenTelemetryCollector
-    name: kubewarden
-    namespace: cattle-kubewarden-system
-    operations:
-    - {"op": "remove", "path": "/spec"}
+    - apiVersion: opentelemetry.io/v1alpha1
+      kind: OpenTelemetryCollector
+      name: kubewarden
+      namespace: cattle-kubewarden-system
+      operations:
+        - {"op": "remove", "path": "/spec"}
+
+    - apiVersion: admissionregistration.k8s.io/v1
+      kind: MutatingWebhookConfiguration
+      name: kubewarden-controller-mutating-webhook-configuration
+      jsonPointers:
+      operations:
+        - {"op": "remove", "path":"/webhooks"}
+
+    - apiVersion: admissionregistration.k8s.io/v1
+      kind: ValidatingWebhookConfiguration
+      name: kubewarden-controller-validating-webhook-configuration
+      operations:
+        - {"op": "remove", "path":"/webhooks"}
 
 labels:
   app: rancher-kubewarden-controller


### PR DESCRIPTION
It seems rancher 2.14 uses newer fleet, which is more strict about how drift is handled.
Rancher 2.13 works fine with kubewarden.

Problem is that fleet fights with controller for webhooks, reports `Modified` resource, and shows error.
Jaeger has the same problem.