### PR TITLE
feat: Add AP table headers; add namespace

### DIFF
--- a/pkg/kubewarden/config/kubewarden.ts
+++ b/pkg/kubewarden/config/kubewarden.ts
@@ -2,7 +2,7 @@ import { rootKubewardenRoute } from '@kubewarden/utils/custom-routing';
 import {
   KUBEWARDEN, KUBEWARDEN_DASHBOARD, POLICY_REPORTER_PRODUCT, KUBEWARDEN_PRODUCT_NAME, OPEN_REPORTS
 } from '@kubewarden/types';
-import { POLICY_SERVER_HEADERS, POLICY_HEADERS } from './table-headers';
+import { POLICY_SERVER_HEADERS, POLICY_HEADERS, ADMISSION_POLICY_HEADERS } from './table-headers';
 
 export function init($extension: any, store: any) {
   const {
@@ -63,6 +63,6 @@ export function init($extension: any, store: any) {
   weightType(ADMISSION_POLICY, 96, true);
 
   headers(POLICY_SERVER, POLICY_SERVER_HEADERS);
-  headers(ADMISSION_POLICY, POLICY_HEADERS);
+  headers(ADMISSION_POLICY, ADMISSION_POLICY_HEADERS);
   headers(CLUSTER_ADMISSION_POLICY, POLICY_HEADERS);
 }

--- a/pkg/kubewarden/config/table-headers.ts
+++ b/pkg/kubewarden/config/table-headers.ts
@@ -1,4 +1,4 @@
-import { NAME as NAME_HEADER } from '@shell/config/table-headers';
+import { NAME as NAME_HEADER, NAMESPACE as NAMESPACE_HEADER } from '@shell/config/table-headers';
 
 import { createKubewardenRoute } from '@kubewarden/utils/custom-routing';
 import { KUBEWARDEN, PolicyServer } from '@kubewarden/types';
@@ -132,6 +132,34 @@ export const POLICY_SERVER_HEADERS = [
 export const POLICY_HEADERS = [
   ADMISSION_POLICY_STATE,
   NAME_HEADER,
+  ADMISSION_POLICY_MODE,
+  {
+    name:   'capPolicyServer',
+    label:  'Policy Server',
+    value:  'spec.policyServer',
+    sort:   'spec.policyServer:desc',
+    search: true
+  },
+  ADMISSION_POLICY_RESOURCES,
+  ADMISSION_POLICY_OPERATIONS,
+  ADMISSION_POLICY_SOURCE,
+  {
+    name:      'age',
+    labelKey:  'tableHeaders.age',
+    value:     'creationTimestamp',
+    getValue:  (row: any) => row.creationTimestamp,
+    sort:      'creationTimestamp:desc',
+    search:    false,
+    formatter: 'LiveDate',
+    width:     100,
+    align:     'left'
+  }
+];
+
+export const ADMISSION_POLICY_HEADERS = [
+  ADMISSION_POLICY_STATE,
+  NAME_HEADER,
+  NAMESPACE_HEADER,
   ADMISSION_POLICY_MODE,
   {
     name:   'capPolicyServer',


### PR DESCRIPTION
Fixes: https://github.com/rancher/kubewarden-ui/issues/1386

## Technical notes 

As an outcome of this diversion, a separate table header has been created

<img width="1724" height="964" alt="Screenshot 2026-04-27 at 15 52 52" src="https://github.com/user-attachments/assets/375ab501-869a-49a8-bc0e-928777e9ab89" />
