### PR TITLE
Switch e2e to rancher 2.14 prime

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -109,7 +109,7 @@ jobs:
       fail-fast: false
       matrix:
         # Rancher versions for PRs is based on the branch
-        rancher:  ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && fromJSON('["p2.10", "p2.11", "p2.12", "p2.13", "c2.14"]') || fromJSON(format('["{0}"]', inputs.rancher_text || inputs.rancher )) }}
+        rancher:  ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && fromJSON('["p2.10", "p2.11", "p2.12", "p2.13", "p2.14"]') || fromJSON(format('["{0}"]', inputs.rancher_text || inputs.rancher )) }}
         mode: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_run') && fromJSON('["manual", "upgrade", "fleet"]') || fromJSON(format('["{0}"]', inputs.mode || 'manual')) }}
         exclude:
           # Run all modes on latest prime version (exclude others)
@@ -125,20 +125,21 @@ jobs:
             mode: upgrade
           - rancher: ${{ github.event_name == 'schedule' && 'p2.12' }}
             mode: fleet
-          - rancher: ${{ github.event_name == 'schedule' && 'c2.14' }}
+          - rancher: ${{ github.event_name == 'schedule' && 'p2.13' }}
             mode: upgrade
-          - rancher: ${{ github.event_name == 'schedule' && 'c2.14' }}
+          - rancher: ${{ github.event_name == 'schedule' && 'p2.13' }}
             mode: fleet
           # Exclude unrelated Rancher versions from release jobs # head_branch = tag (kubewarden-2.1.0-rc.1)
           # UI 3.1 -> Rancher 2.10
           - rancher: ${{ startsWith(github.event.workflow_run.head_branch, 'kubewarden-3.') && 'p2.11' }}
           - rancher: ${{ startsWith(github.event.workflow_run.head_branch, 'kubewarden-3.') && 'p2.12' }}
           - rancher: ${{ startsWith(github.event.workflow_run.head_branch, 'kubewarden-3.') && 'p2.13' }}
-          - rancher: ${{ startsWith(github.event.workflow_run.head_branch, 'kubewarden-3.') && 'c2.14' }}
+          - rancher: ${{ startsWith(github.event.workflow_run.head_branch, 'kubewarden-3.') && 'p2.14' }}
           # UI 4.0 -> Rancher 2.11+
           - rancher: ${{ startsWith(github.event.workflow_run.head_branch, 'kubewarden-4.') && 'p2.10' }}
           - rancher: ${{ startsWith(github.event.workflow_run.head_branch, 'kubewarden-4.') && 'p2.11' }}
           - rancher: ${{ startsWith(github.event.workflow_run.head_branch, 'kubewarden-4.') && 'p2.12' }}
+          - rancher: ${{ startsWith(github.event.workflow_run.head_branch, 'kubewarden-4.') && 'p2.13' }}
 
 
     # Run schedule workflows only on original repo, not forks


### PR DESCRIPTION
Rancher 2.14 released prime version.

- switch from 2.14 community to prime
- use 2.14 as default for main test suite