### PR TITLE
Fix url version parser

### DIFF
--- a/tests/e2e/rancher/rancher-apps.page.ts
+++ b/tests/e2e/rancher/rancher-apps.page.ts
@@ -62,8 +62,11 @@ export class RancherAppsPage extends BasePage {
   }
 
   async swapUrlVersion(version: string) {
-    const url = this.page.url()
-    await this.page.goto(url.replace(/version=[0-9.]+(-rc[0-9]|-beta[0-9])?/, `version=${version}`))
+    const url = new URL(this.page.url())
+    expect(url.searchParams.get('version')).not.toBeNull()
+    url.searchParams.set('version', version)
+
+    await this.page.goto(url.toString())
     await expect(this.stepTitle).toContainText(version)
   }
 


### PR DESCRIPTION
Version parser does not recognize `-alpha` version.

Semver does not define strict format for prerelease suffix (-dev, -patch, rc.1, ...)
I updated parser to use URL object, which should prevent this issue in the future.

Failed nightly [upgrade test](https://github.com/rancher/kubewarden-ui/actions/runs/25698494400/job/75640008009).