### PR TITLE
Add Namespace to PolicyServer mapper policy

### DIFF
--- a/tests/e2e/pages/policies.page.ts
+++ b/tests/e2e/pages/policies.page.ts
@@ -9,7 +9,7 @@ export const apList = ['Custom Policy', 'Allow Privilege Escalation PSP', 'Allow
   'Host Namespaces PSP', 'Hostpaths PSP', 'Ingress Policy', 'Namespace label propagator', 'Pod Privileged Policy', 'Pod Runtime', 'Readonly Root Filesystem PSP', 'Share PID namespace',
   'Safe Annotations', 'Safe Labels', 'Seccomp PSP', 'Selinux PSP', 'Sysctl PSP', 'Trusted Repos', 'User Group PSP', 'Verify Image Signatures', 'volumeMounts', 'Volumes PSP', 'Unique Ingress host',
   'Unique service selector', 'PVC StorageClass Validator', 'CEL Policy', 'Pod ndots', 'Do not expose admission controller webhook services', 'Priority class policy', 'High Risk Service Account',
-  'Labels', 'Annotations', 'image-cve', 'Probes validator policy', 'Rancher Project quotas namespace validator', 'Kyverno DSL policy'] as const
+  'Labels', 'Annotations', 'image-cve', 'Probes validator policy', 'Rancher Project quotas namespace validator', 'Kyverno DSL policy', 'Namespace to PolicyServer mapper'] as const
 
 export const capList = [...apList, 'PSA Label Enforcer', 'Rancher Project propagate labels'] as const
 

--- a/tests/e2e/rancher/rancher-apps.page.ts
+++ b/tests/e2e/rancher/rancher-apps.page.ts
@@ -62,8 +62,11 @@ export class RancherAppsPage extends BasePage {
     }
 
     async swapUrlVersion(version: string) {
-      const url = this.page.url()
-      await this.page.goto(url.replace(/version=[0-9.]+(-rc[0-9]|-beta[0-9])?/, `version=${version}`))
+      const url = new URL(this.page.url())
+      expect(url.searchParams.get('version')).not.toBeNull()
+      url.searchParams.set('version', version)
+
+      await this.page.goto(url.toString())
       await expect(this.stepTitle).toContainText(version)
     }
 


### PR DESCRIPTION
Fix failing nightly job by adding `Namespace to PolicyServer mapper` to the list.
Rancher 2.10 (release 3.1 branch) has hardcoded list of policies, but it's EOM in ~1 month, it's not worth to backport more robust solution.

Failed test [link](https://github.com/rancher/kubewarden-ui/actions/runs/25763344074/job/75669831259).