### PR TITLE
Update tests for new Policy Server

### DIFF
--- a/tests/e2e/20-dashboard.spec.ts
+++ b/tests/e2e/20-dashboard.spec.ts
@@ -86,7 +86,7 @@ test('Check landing pages', async({ page, ui, nav }) => {
   })
 })
 
-test('Stats reflect resource changes', async({ page, nav }) => {
+test('Stats reflect resource changes', async({ page, nav, ui }) => {
   const kwPage = new KubewardenPage(page)
   const psPage = new PolicyServersPage(page)
   const apPage = new AdmissionPoliciesPage(page)
@@ -123,6 +123,11 @@ test('Stats reflect resource changes', async({ page, nav }) => {
 
   await test.step('Stats after deleting resources ', async() => {
     await psPage.delete(ps.name)
+    await nav.apolicies()
+    await ui.tableRow(policy.name).delete()
+    await nav.capolicies()
+    await ui.tableRow(policy.name).delete()
+
     await nav.kubewarden()
     await expect(kwPage.getStats('Namespaced Policies')).toHaveText('No policies available.')
     await expect(kwPage.getStats('Cluster Policies')).toHaveText('0 protect+6 monitor')

--- a/tests/e2e/30-policyservers.spec.ts
+++ b/tests/e2e/30-policyservers.spec.ts
@@ -64,11 +64,9 @@ test('Policy Servers', async({ page, ui, nav }) => {
   await test.step('Delete policy server', async() => {
     await psRow.delete()
     await apPage.goto()
-    await expect(page.locator('table.sortable-table')).toBeVisible()
-    await expect(apRow.row).not.toBeVisible()
+    await ui.tableRow(policy.name).delete()
     await capPage.goto()
-    await expect(page.locator('table.sortable-table')).toBeVisible()
-    await expect(capRow.row).not.toBeVisible()
+    await ui.tableRow(policy.name).delete()
   })
 })
 

--- a/tests/e2e/40-policies.spec.ts
+++ b/tests/e2e/40-policies.spec.ts
@@ -152,11 +152,11 @@ for (const PolicyPage of pageTypes) {
     await shell.waitPolicyState(p, polPage.kind)
     await shell.privpod({ ns: p.namespace, status: 1 })
 
-    // Delete custom PS & NS, policy is deleted too
+    // Delete custom PS, Policy state changes to Scheduled
     await psPage.delete(ps.name)
     await polPage.goto()
-    await expect(page.getByRole('columnheader', { name: 'Status' })).toBeVisible()
-    await expect(row.row).not.toBeVisible()
+    await row.toHaveState('Scheduled')
+    await row.delete()
     if (isAP(polPage)) await shell.run(`kubectl delete ns ${p.namespace}`)
   })
 }


### PR DESCRIPTION
Since Kubewarden 1.36 policy server does not delete it's policies when it's removed.
Policies switch to `Scheduled` state instead.