### PR TITLE
Fix icon URL

### DIFF
--- a/pkg/kubewarden/package.json
+++ b/pkg/kubewarden/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kubewarden",
   "description": "Kubewarden extension for Rancher Manager",
-  "icon": "https://raw.githubusercontent.com/kubewarden/ui/main/pkg/kubewarden/assets/icon-kubewarden.svg",
+  "icon": "https://raw.githubusercontent.com/rancher/kubewarden-ui/main/pkg/kubewarden/assets/icon-kubewarden.svg",
   "version": "4.1.2",
   "private": false,
   "rancher": {


### PR DESCRIPTION
Release job is failing because icon URL is not in allow list.
https://github.com/rancher/ui-plugin-charts/actions/runs/26161755679/job/76955143498#step:4:239