### PR TITLE
Extend timeout for deleting ns with admission policies

### DIFF
--- a/tests/e2e/components/kubectl-shell.ts
+++ b/tests/e2e/components/kubectl-shell.ts
@@ -168,7 +168,7 @@ export class Shell {
   async runBatch(...commands: string[]) {
     await this.open()
     for (const cmd of commands) {
-      await this.run(cmd, { inPlace: true })
+      await this.run(cmd, { inPlace: true, timeout: 2 * 60_000 })
     }
     await this.close()
   }


### PR DESCRIPTION
e2e fails sporadically because namespace deletion takes longer than 60s.
From what I tried it was 43s, 73s, 80s, 46s. Timeout 2m should be enough.
