### PR TITLE
fix: Don't leave sparse holes when parsing JSON arrays

### DIFF
--- a/pkg/kubewarden/utils/__tests__/object.spec.ts
+++ b/pkg/kubewarden/utils/__tests__/object.spec.ts
@@ -83,6 +83,33 @@ describe('removeEmptyAttrs', () => {
     expect(cleanedObj).toEqual(null);
   });
 
+  it('should preserve empty-string entries inside arrays (e.g. apiGroups: [""] for core/v1)', () => {
+    const obj = {
+      spec: {
+        rules: [
+          {
+            apiGroups:   [''],
+            apiVersions: ['v1'],
+            resources:   ['pods'],
+            operations:  ['CREATE', 'UPDATE'],
+          },
+          {
+            apiGroups:   ['apps'],
+            apiVersions: ['v1'],
+            resources:   ['deployments'],
+            operations:  ['CREATE'],
+          },
+        ],
+      },
+    };
+    const cleanedObj = removeEmptyAttrs(obj);
+
+    expect(cleanedObj).toEqual(obj);
+    expect(cleanedObj.spec.rules[0].apiGroups).toEqual(['']);
+    // Ensure no sparse holes were introduced (which would JSON-serialize as null)
+    expect(JSON.parse(JSON.stringify(cleanedObj))).toEqual(obj);
+  });
+
   it('should remove only the empty memory object while preserving non-empty cpu object', () => {
     const obj = {
       settings: {

--- a/pkg/kubewarden/utils/object.ts
+++ b/pkg/kubewarden/utils/object.ts
@@ -8,6 +8,12 @@ export function removeEmptyAttrs(obj: any): any {
     // Check for value being empty, null, or an empty array
     if (value === undefined || value === null || value === '' || (Array.isArray(value) && !value.length)) {
       delete obj[key];
+    } else if (Array.isArray(value)) {
+      // Arrays are treated as leaf values. Items inside an array (e.g.
+      // `apiGroups: ['']` meaning the core Kubernetes API group) may be
+      // semantically meaningful even when "empty", and using `delete` on an
+      // array index would produce a sparse hole that serializes to `null`.
+      // Leave non-empty arrays as-is.
     } else if (isObject(value)) {
       // Recursively clean the object
       removeEmptyAttrs(value);


### PR DESCRIPTION
Fixes https://github.com/kubewarden/adm-controller/issues/1779.


When serializing a policy, the policy has the following rules field:

```yaml
spec:
  rules:
    - apiGroups:
        - ''  # this is meaningful
      apiVersions:
        - v1
      resources:
        - pods
      operations:
        - CREATE
        - UPDATE
```

Before this commit, the empty object in `spec.rules[1].apiGroups[0]` was seralized to JSON by deleting it, so it would be `[null]`. This is incorrect, the K8s API expects this empty array element, and it should be serialized to `[""]`.

Add a unit test to prevent regressions.

This is a longstanding bug, but was masked by the Kubewarden Adm Controller because we were using a Defaulter reconciler that always mutated the policy spec, hence it was always parsed with Go `encoding/json`, whose default behavior is to coerce `[null]` into `[""]`. But the controller has changed behavior and this Defaulter reconciler only runs in some cases.