### PR TITLE
Rename kubewarden extension to SSAC on prime

### DIFF
--- a/tests/e2e/10-kubewarden.spec.ts
+++ b/tests/e2e/10-kubewarden.spec.ts
@@ -53,7 +53,7 @@ test('Install UI extension', { tag: '@kw' }, async({ page, ui }) => {
       await extensions.addRancherRepos({ rancher: true, partners: false })
       await ui.retry(async() => {
         await extensions.selectTab('Available')
-        await expect(extensions.getByName('kubewarden')).toBeVisible({ timeout: 30_000 })
+        await expect(extensions.getByName('SUSE Security Admission Controller')).toBeVisible({ timeout: 30_000 })
       }, 'Not showing kubewarden extension')
     })
   }
@@ -72,7 +72,7 @@ test('Install UI extension', { tag: '@kw' }, async({ page, ui }) => {
     if (conf.ui_from === 'source') {
       await extensions.developerLoad(conf.src_url)
     } else {
-      await extensions.install('kubewarden', { version: process.env.UIVERSION?.replace(/^kubewarden-/, '') })
+      await extensions.install(/kubewarden|SUSE Security Admission Controller/, { version: process.env.UIVERSION?.replace(/^kubewarden-/, '') })
     }
   })
 })

--- a/tests/e2e/pages/kubewarden.page.ts
+++ b/tests/e2e/pages/kubewarden.page.ts
@@ -159,7 +159,8 @@ export class KubewardenPage extends BasePage {
     // Rancher Application Values
     await expect(this.ui.checkbox('Enable Background Audit check ')).toBeChecked()
     const schedule = this.ui.input('Schedule')
-    await expect(schedule).toHaveValue('0 * * * *')
+    // Value was fixed in Kubewarden 1.36.0, previous versions (current -3) have old value
+    await expect(schedule).toHaveValue(process.env.MODE == 'upgrade' ? '*/60 * * * *' : '0 * * * *')
     await schedule.fill('*/1 * * * *')
     await this.ui.checkbox('Enable Policy Reporter').check()
 

--- a/tests/e2e/rancher/rancher-extensions.page.ts
+++ b/tests/e2e/rancher/rancher-extensions.page.ts
@@ -63,7 +63,7 @@ export class RancherExtensionsPage extends BasePage {
      * @param name Exact name of the extension
      * @param version exact version to be installed. Defaults to pre-selected one (latest)
      */
-  async install(name: string, options?: { version?: string }) {
+  async install(name: string|RegExp, options?: { version?: string }) {
     await this.selectTab('Available')
 
     const plugin = this.getByName(name)


### PR DESCRIPTION
- Rename kubewarden extension to SSAC on prime
This change was done in https://github.com/rancher/ui-plugin-charts/blob/58b214e8cb5d1b47aca5928bb56d087c01e63858/patches/kubewarden/files/README.md

- Fix upgrade test
Upgrade test installs old kubewarden. Check for default schedule value fails because it was fixed in later releases.