### PR TITLE
Fix OTEL Operator service port

### DIFF
--- a/pkg/kubewarden/components/MetricsTab.vue
+++ b/pkg/kubewarden/components/MetricsTab.vue
@@ -263,7 +263,7 @@ export default {
           const ports = svc?.spec?.ports;
 
           if (ports.length) {
-            return ports.find((p) => p.port === 8080);
+            return ports.find((p) => p.port === 8443 || p.port === 8080);
           }
         });
       }

--- a/pkg/kubewarden/components/TraceTable.vue
+++ b/pkg/kubewarden/components/TraceTable.vue
@@ -201,7 +201,7 @@ export default {
           const ports = svc?.spec?.ports;
 
           if (ports.length) {
-            return ports.find((p) => p.port === 8080);
+            return ports.find((p) => p.port === 8443 || p.port === 8080);
           }
         });
       }

--- a/pkg/kubewarden/components/__tests__/MetricsTab.spec.ts
+++ b/pkg/kubewarden/components/__tests__/MetricsTab.spec.ts
@@ -60,7 +60,7 @@ const clusterAllMock = jest.fn((resourceType) => {
         name:   'service-1',
         labels: { [KUBERNETES.MANAGED_NAME]: 'opentelemetry-operator' }
       },
-      spec: { ports: [{ port: 8080 }] }
+      spec: { ports: [{ port: 8443 }] }
     }];
   default:
     return [];

--- a/pkg/kubewarden/components/__tests__/TraceTable.spec.ts
+++ b/pkg/kubewarden/components/__tests__/TraceTable.spec.ts
@@ -41,7 +41,7 @@ const clusterAllMock = (resourceType: string) => {
             [KUBERNETES.MANAGED_NAME]: 'opentelemetry-operator'
           }
         },
-        spec: { ports: [{ port: 8080 }] }
+        spec: { ports: [{ port: 8443 }] }
       }
     ];
   default:

--- a/tests/e2e/fleet/open-telemetry/fleet.yaml
+++ b/tests/e2e/fleet/open-telemetry/fleet.yaml
@@ -2,7 +2,7 @@ defaultNamespace: opentelemetry
 helm:
   releaseName: opentelemetry
   chart: opentelemetry-operator
-  version: "*"
+  version: "*"   # 0.114.1
   repo: https://open-telemetry.github.io/opentelemetry-helm-charts
   values:
     manager:

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -43,7 +43,7 @@ async function globalSetup(config: FullConfig) {
   // PRs: hardcoded default, github variables are not passed to PRs from forks
   // Fleet: latest released OTEL (*) to check for future failures
   // Other workflows: github action variable or hardcoded default
-  process.env.OTEL_OPERATOR ||= '0.109.0'
+  process.env.OTEL_OPERATOR ||= '0.114.1'
 }
 
 export default globalSetup


### PR DESCRIPTION
OTEL Operator service moved from port 8080 to 8443. Details in OTEL [upgrade guidelines](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/UPGRADING.md).

Kubewarden UI uses port 8080 to detect if OTEL is running before it displays Metrics/Traces tab content.

```
# OTEL Operator < v1.110.0
kubewarden (fleet) Ξ k get svc -n opentelemetry
NAME                                           TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)             AGE
opentelemetry-opentelemetry-operator           ClusterIP   10.43.98.56   <none>        8443/TCP,8080/TCP   26m
opentelemetry-opentelemetry-operator-webhook   ClusterIP   10.43.132.1   <none>        443/TCP             26m
kubewarden (fleet) Ξ k get svc -n opentelemetry

# OTEL Operator >= v1.110.0
NAME                                           TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
opentelemetry-opentelemetry-operator           ClusterIP   10.43.45.244    <none>        8443/TCP   2m7s
opentelemetry-opentelemetry-operator-webhook   ClusterIP   10.43.223.215   <none>        443/TCP    2m7s
```

This PR should fix UI being stack on this screen:

<img width="1600" height="900" alt="test-failed-1" src="https://github.com/user-attachments/assets/7eab7e0d-a789-4116-9e91-2033380f552f" />

Also bumping default OTEL version in tests to current 0.114.1.