### PR TITLE
Update app installer steps for rancher 2.15

### DIFF
--- a/tests/e2e/rancher/rancher-apps.page.ts
+++ b/tests/e2e/rancher/rancher-apps.page.ts
@@ -48,8 +48,8 @@ export class RancherAppsPage extends BasePage {
 
   constructor(page: Page) {
     super(page)
-    this.step1 = page.getByRole('heading', { name: 'Install: Step 1' })
-    this.step2 = page.getByRole('heading', { name: 'Install: Step 2' })
+    this.step1 = page.getByRole('heading', { name: 'Install: Step 1' }).or(this.page.getByRole('tab', { name: 'Metadata', selected: true })).first()
+    this.step2 = page.getByRole('heading', { name: 'Install: Step 2' }).or(this.page.getByRole('tab', { name: 'Values', selected: true })).first()
     this.stepTitle = page.locator('div.top.choice-banner>.title')
     this.nextBtn = this.ui.button('Next')
     this.installBtn = this.ui.button(/Install|Install this version/)


### PR DESCRIPTION
Steps heading changed to just `<app>: Install`.
I updated locators to use also step tab to match current page.

<img width="1592" height="896" alt="Screenshot From 2026-07-14 16-16-25" src="https://github.com/user-attachments/assets/0d0afe8c-0ca8-4dc1-ac57-7454fef0488d" />

This should fix https://github.com/rancher/kubewarden-ui/actions/runs/29285952675/job/87082370749