### PR TITLE
Fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,8 @@ updates:
     cooldown:
       default-days: 7
     ignore:
+      # malformed version 2.6.3-.beta.1
       - dependency-name: "desktop"
-        versions: ["2.6.3-.beta.1"]
   # Limited to rancher-shell by Giuseppe Leo
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
Dependabot fails to parse rancher/dashboard tags because of malformed version on one of them.

Copilot pushed commit to fix that but it uses malformed tag in version, which is checked for semver...
`The property '#/updates/0/ignore/0/versions' includes invalid version requirements for a github-actions ignore condition
`

This ignores all "desktop" tags, we don't use it.

Original error:

```
2026-08-13T19:54:44.4209918Z updater | 2026/08/13 19:54:44 ERROR <job_1524492486> Error processing rancher/dashboard/.github/workflows/build-extension-charts.yml (ArgumentError)
2026-08-13T19:54:44.4211723Z 2026/08/13 19:54:44 ERROR <job_1524492486> Malformed version number string 2.6.3-.beta.1
...
...
2026-08-13T19:54:52.8848636Z Dependabot encountered '1' error(s) during execution, please check the logs for more details.
2026-08-13T19:54:52.8849390Z +------------------------------------------------------------------------------------------------+
2026-08-13T19:54:52.8850047Z |                                 Dependencies failed to update                                  |
2026-08-13T19:54:52.8850697Z +----------------------------------------------------------------+---------------+---------------+
2026-08-13T19:54:52.8851336Z | Dependency                                                     | Error Type    | Error Details |
2026-08-13T19:54:52.8851971Z +----------------------------------------------------------------+---------------+---------------+
2026-08-13T19:54:52.8852756Z | rancher/dashboard/.github/workflows/build-extension-charts.yml | unknown_error | null          |
```