### PR TITLE
Remove kw.(c)ap. prefix from policy names

### DIFF
--- a/pkg/kubewarden/components/PolicyReporter/ResourceTab.vue
+++ b/pkg/kubewarden/components/PolicyReporter/ResourceTab.vue
@@ -104,7 +104,8 @@ function statusColor(row: PolicyReportResult) {
 function formattedDisplayName(displayName: string): string {
   return displayName
     .replace(/^clusterwide-/, '') // Remove 'clusterwide-' prefix
-    .replace(/^namespaced-[^-]+-/, ''); // Remove 'namespaced-<namespace>-' prefix
+    .replace(/^namespaced-[^-]+-/, '') // Remove 'namespaced-<namespace>-' prefix
+    .replace(/^kw\.c?ap\./, ''); // Remove 'kw.cap.' & 'kw.ap.' prefix
 };
 
 onMounted(async() => {

--- a/pkg/kubewarden/modules/__tests__/jaegerTracing.spec.ts
+++ b/pkg/kubewarden/modules/__tests__/jaegerTracing.spec.ts
@@ -11,17 +11,17 @@ function createMockStore() {
 }
 
 describe('jaegerPolicyName', () => {
-  it('returns clusterwide-<name> for a ClusterAdmissionPolicy', () => {
+  it('returns kw.cap.<name> for a ClusterAdmissionPolicy', () => {
     const policy = {
       kind:     'ClusterAdmissionPolicy',
       metadata: { name: 'cap1' }
     };
     const result = jaegerPolicyName(policy);
 
-    expect(result).toBe('clusterwide-cap1');
+    expect(result).toBe('kw.cap.cap1');
   });
 
-  it('returns namespaced-<ns>-<name> for an AdmissionPolicy', () => {
+  it('returns kw.ap.<ns>.<name> for an AdmissionPolicy', () => {
     const policy = {
       kind:     'AdmissionPolicy',
       metadata: {
@@ -31,7 +31,7 @@ describe('jaegerPolicyName', () => {
     };
     const result = jaegerPolicyName(policy);
 
-    expect(result).toBe('namespaced-ns1-ap1');
+    expect(result).toBe('kw.ap.ns1.ap1');
   });
 
   it('returns null if policy kind is unknown', () => {
@@ -133,7 +133,7 @@ describe('jaegerTraces', () => {
               tags:          [
                 {
                   key:   'policy_id',
-                  value: 'clusterwide-cap1'
+                  value: 'kw.cap.cap1'
                 },  // matches 1st policy
                 {
                   key:   'allowed',
@@ -154,7 +154,7 @@ describe('jaegerTraces', () => {
               tags:          [
                 {
                   key:   'policy_id',
-                  value: 'namespaced-ns1-ap1'
+                  value: 'kw.ap.ns1.ap1'
                 }, // matches 2nd policy
                 {
                   key:   'allowed',
@@ -245,7 +245,7 @@ describe('jaegerTraces', () => {
               tags:          [
                 {
                   key:   'policy_id',
-                  value: 'namespaced-ns2-ap2'
+                  value: 'kw.ap.ns2.ap2'
                 },
                 {
                   key:   'allowed',

--- a/pkg/kubewarden/modules/jaegerTracing.ts
+++ b/pkg/kubewarden/modules/jaegerTracing.ts
@@ -54,11 +54,11 @@ export function jaegerPolicyName(policy: any) {
 
   switch (policy?.kind) {
   case 'ClusterAdmissionPolicy':
-    out = `clusterwide-${ policy?.metadata?.name }`;
+    out = `kw.cap.${ policy?.metadata?.name }`;
     break;
 
   case 'AdmissionPolicy':
-    out = `namespaced-${ policy?.metadata?.namespace }-${ policy?.metadata?.name }`;
+    out = `kw.ap.${ policy?.metadata?.namespace }.${ policy?.metadata?.name }`;
     break;
 
   default:

--- a/tests/e2e/50-policyreports.spec.ts
+++ b/tests/e2e/50-policyreports.spec.ts
@@ -56,8 +56,8 @@ test('New resources should be reported', async({ ui, page, nav, shell }) => {
   await expect(reporter.getChip(testNs, 'fail')).toHaveText('1')
 
   await reporter.selectTab('Kubewarden')
-  await expect(reporter.getChip(`clusterwide-${policyLabels}`, 'fail')).toHaveText('1')
-  await expect(reporter.getChip('clusterwide-no-privileged-pod', 'fail')).toHaveText('1')
+  await expect(reporter.getChip(`kw.cap.${policyLabels}`, 'fail')).toHaveText('1')
+  await expect(reporter.getChip('kw.cap.no-privileged-pod', 'fail')).toHaveText('1')
 })
 
 test('Check reports on resources details page', async({ ui, nav }) => {


### PR DESCRIPTION
Fix for https://github.com/rancher/kubewarden-ui/issues/1575