### PR TITLE
Trigger SBOMScanner on AdmissionController images & fixes

### DIFF
--- a/tests/e2e/10-kubewarden.spec.ts
+++ b/tests/e2e/10-kubewarden.spec.ts
@@ -6,47 +6,26 @@ import { RancherAppsPage } from './rancher/rancher-apps.page'
 import { RancherFleetPage } from './rancher/rancher-fleet.page'
 import { RancherUI } from './components/rancher-ui'
 import { Common } from './components/common'
+import { conf } from '../env-config'
 import semver from 'semver'
 
-const conf = {
-  src_url: 'http://127.0.0.1:4500/kubewarden-0.0.1/kubewarden-0.0.1.umd.min.js',
-  // Install UI extension from: source (yarn dev), github (github tag), prime (official)
-  ui_from: (process.env.ORIGIN || undefined) as 'source'|'github'|'prime'|undefined,
-  // Install Kubewarden from: github (community), gitlab (mr), prime (official)
-  kw_from: (process.env.KW || undefined) as 'github'|'gitlab'|'prime'|undefined,
-  // How to install Kubewarden: manual (from UI extension), fleet, upgrade (previous version)
-  kw_mode: (process.env.MODE || undefined) as 'manual'|'fleet'|'upgrade'|undefined,
-  // Fetch Kubewarden versions from github for upgrade test
-  upMap  : [] as AppVersion[]
-}
-
-if (conf.ui_from) expect(conf.ui_from).toMatch(/^(source|github|prime)$/)
-if (conf.kw_mode) expect(conf.kw_mode).toMatch(/^(manual|fleet|upgrade)$/)
-if (conf.kw_from) expect(conf.kw_from).toMatch(/^(github|gitlab|prime)$/)
-if (conf.kw_from !== 'github') {
-  expect(process.env.APPCO_USERNAME).toBeTruthy()
-  expect(process.env.APPCO_PASSWORD).toBeTruthy()
-}
+// Fetch Kubewarden versions from github for upgrade test
+let upMap = [] as AppVersion[]
 
 // Configure defaults after env is loaded
 test.beforeAll(async({ request }) => {
   // Use local build (yarn serve), prime (if available) or github
   const fallback = RancherUI.isPrime ? 'prime' : 'github'
-  conf.ui_from ||= await request.head(conf.src_url)
+  conf.ui_from ||= await request.head(conf.source.kubewarden)
     .then(r => r.ok() ? 'source' as const : fallback)
     .catch(() => fallback)
 
-  // Default to manual mode, unless fleet or upgrade is requested
-  conf.kw_mode ||= 'manual'
-  // Default to installation from GitLab (MR)
-  conf.kw_from ||= 'prime'
-
   if (conf.kw_mode === 'upgrade') {
-    conf.upMap = (await Common.fetchVersionMap()).splice(-3)
+    upMap = (await Common.fetchVersionMap()).splice(-3)
       // Limit because of https://github.com/kubewarden/policy-server/issues/1300
       .filter(v => semver.gte(v.app.replace(/^v/, ''), '1.29.0'))
 
-    if (conf.upMap.length === 0) {
+    if (upMap.length === 0) {
       throw new Error('No compatible version was found, check rancher-version annotations')
     }
   }
@@ -78,7 +57,7 @@ test('Install UI extension', { tag: '@kw' }, async({ page, ui }) => {
   await test.step('Install or developer load extension', async() => {
     await extensions.goto()
     if (conf.ui_from === 'source') {
-      await extensions.developerLoad(conf.src_url)
+      await extensions.developerLoad(conf.source.kubewarden)
     } else {
       await extensions.install(/kubewarden|SUSE Security Admission Controller/, { version: process.env.UIVERSION?.replace(/^kubewarden-/, '') })
     }
@@ -90,7 +69,7 @@ test('Install Kubewarden', { tag: '@kw' }, async({ page, ui, nav }) => {
 
   const kwPage = new KubewardenPage(page)
   if (conf.kw_from == 'github') {
-    await kwPage.installGithub({ version: conf.kw_mode === 'upgrade' ? conf.upMap[0].controller : undefined })
+    await kwPage.installGithub({ version: conf.kw_mode === 'upgrade' ? upMap[0].controller : undefined })
   } else if (conf.kw_from == 'gitlab') {
     await kwPage.installGitlab()
   } else {
@@ -146,16 +125,16 @@ test('Upgrade Kubewarden', async({ page, nav }) => {
   // Check we installed old versions
   await nav.explorer('Apps', 'Installed Apps')
   for (const chart of ['controller', 'crds', 'defaults'] as const) {
-    await apps.checkChart(`rancher-kubewarden-${chart}`, conf.upMap[0][chart])
+    await apps.checkChart(`rancher-kubewarden-${chart}`, upMap[0][chart])
   }
 
   // Keep track of last upgraded version
-  let last: AppVersion = conf.upMap[conf.upMap.length - 1]
+  let last: AppVersion = upMap[upMap.length - 1]
 
   await test.step('Upgrade predefined versions', async() => {
-    for (let i = 0; i < conf.upMap.length - 1; i++) {
+    for (let i = 0; i < upMap.length - 1; i++) {
       await nav.kubewarden()
-      await kwPage.upgrade({ from: conf.upMap[i], to: conf.upMap[i + 1] })
+      await kwPage.upgrade({ from: upMap[i], to: upMap[i + 1] })
     }
   })
 

--- a/tests/e2e/30-policyservers.spec.ts
+++ b/tests/e2e/30-policyservers.spec.ts
@@ -1,4 +1,5 @@
 import semver from 'semver'
+import { conf } from '../env-config'
 import { test, expect } from './rancher/rancher-test'
 import { PolicyServersPage, PolicyServer } from './pages/policyservers.page'
 import { Policy, AdmissionPoliciesPage, ClusterAdmissionPoliciesPage } from './pages/policies.page'

--- a/tests/e2e/30-policyservers.spec.ts
+++ b/tests/e2e/30-policyservers.spec.ts
@@ -1,5 +1,3 @@
-import semver from 'semver'
-import { conf } from '../env-config'
 import { test, expect } from './rancher/rancher-test'
 import { PolicyServersPage, PolicyServer } from './pages/policyservers.page'
 import { Policy, AdmissionPoliciesPage, ClusterAdmissionPoliciesPage } from './pages/policies.page'
@@ -39,12 +37,9 @@ test('Policy Servers', async({ page, ui, nav }) => {
     expect(cImg).toEqual(dImg)
     expect(cImg).toContain('policy-server')
 
-    // Validate semver
-    expect(semver.valid(cVer)).not.toBeNull()
-    expect(semver.valid(dVer)).not.toBeNull()
-
-    // Validate version is equal to default
-    expect(semver.eq(cVer, dVer)).toBeTruthy()
+    // Validate Tags
+    expect(cVer).toBeTruthy()
+    expect(cVer).toEqual(dVer)
   })
 
   await test.step('Check Details page', async() => {

--- a/tests/e2e/40-policies.spec.ts
+++ b/tests/e2e/40-policies.spec.ts
@@ -3,8 +3,7 @@ import { PolicyServer, PolicyServersPage } from './pages/policyservers.page'
 import { AdmissionPoliciesPage, ClusterAdmissionPoliciesPage, BasePolicyPage, Policy } from './pages/policies.page'
 import { RancherUI } from './components/rancher-ui'
 import { RancherAppsPage } from './rancher/rancher-apps.page'
-
-const MODE = process.env.MODE || 'manual'
+import { conf } from '../env-config'
 
 function isAP(polPage: BasePolicyPage) {
   return polPage instanceof AdmissionPoliciesPage
@@ -211,7 +210,7 @@ test('Check Unofficial policies', async({ page, nav, ui }) => {
 })
 
 test('Recommended policies', async({ page, ui, nav }) => {
-  test.skip(MODE === 'fleet', 'https://github.com/rancher/kubewarden-ui/pull/703')
+  test.skip(conf.kw_mode === 'fleet', 'https://github.com/rancher/kubewarden-ui/pull/703')
 
   await test.step('Edit Recommended policy settings', async() => {
     await nav.capolicies()

--- a/tests/e2e/60-telemetry.spec.ts
+++ b/tests/e2e/60-telemetry.spec.ts
@@ -4,13 +4,14 @@ import { PolicyServersPage } from './pages/policyservers.page'
 import { managedApps, TelemetryPage } from './pages/telemetry.page'
 import { RancherUI } from './components/rancher-ui'
 import { AdmissionPoliciesPage, Policy } from './pages/policies.page'
+import { conf } from '../env-config'
 
 /**
  * Expect timeout has to be increased after telemetry installation on local cluster
  */
 test.describe('Setup', () => {
   test('Install OpenTelemetry', async({ page, nav }) => {
-    test.skip(process.env.MODE === 'fleet')
+    test.skip(conf.kw_mode === 'fleet')
 
     const telPage = new TelemetryPage(page)
 
@@ -37,7 +38,7 @@ test.describe('Setup', () => {
   test('Create custom PolicyServer & Policy', async({ page }) => {
     const policy: Policy = { name: 'no-privileged-custom', title: 'Pod Privileged Policy', mode: 'Monitor', server: 'custom-ps' }
     await new PolicyServersPage(page).create({ name: 'custom-ps' })
-    await new AdmissionPoliciesPage(page).create(policy, { wait: process.env.MODE == 'fleet' })
+    await new AdmissionPoliciesPage(page).create(policy, { wait: conf.kw_mode == 'fleet' })
   })
 })
 
@@ -52,7 +53,7 @@ test.describe('Tracing', () => {
   })
 
   test('Install Jaeger', async({ nav, ui }) => {
-    test.skip(process.env.MODE === 'fleet')
+    test.skip(conf.kw_mode === 'fleet')
 
     // Jaeger is not installed
     await telPage.toBeIncomplete('jaeger')
@@ -72,7 +73,7 @@ test.describe('Tracing', () => {
   })
 
   test('Configure tracing', async({ shell }) => {
-    test.skip(process.env.MODE === 'fleet')
+    test.skip(conf.kw_mode === 'fleet')
 
     await telPage.toBeIncomplete('config')
     await telPage.configBtn.click()
@@ -125,7 +126,7 @@ test.describe('Tracing', () => {
   })
 
   test('Uninstall tracing', async({ nav, shell }) => {
-    test.skip(process.env.MODE === 'fleet')
+    test.skip(conf.kw_mode === 'fleet')
 
     // Clean up
     await appsPage.updateApp('rancher-admission-controller', {
@@ -151,7 +152,7 @@ test.describe('Tracing', () => {
 })
 
 test.describe('Metrics', () => {
-  test.skip(process.env.MODE === 'fleet')
+  test.skip(conf.kw_mode === 'fleet')
 
   let appsPage: RancherAppsPage
   let telPage: TelemetryPage
@@ -278,7 +279,7 @@ test.describe('Teardown', () => {
   })
 
   test('Uninstall OpenTelemetry', async({ page, nav }) => {
-    test.skip(process.env.MODE === 'fleet')
+    test.skip(conf.kw_mode === 'fleet')
 
     const telPage = new TelemetryPage(page)
     await telPage.removeManaged('openTelemetry')

--- a/tests/e2e/80-sbomscanner.spec.ts
+++ b/tests/e2e/80-sbomscanner.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from './rancher/rancher-test'
 import { RancherExtensionsPage } from './rancher/rancher-extensions.page'
 import { RancherAppsPage } from './rancher/rancher-apps.page'
 import { RancherUI } from './components/rancher-ui'
-import { Registry, SbomScannerPage, VexHub } from './sbomscanner/sbomscanner.page'
+import { Registry, SbomScannerPage, authSecret } from './sbomscanner/sbomscanner.page'
 import { ClusterAdmissionPoliciesPage, Policy } from './pages/policies.page'
 import { Deployment, RancherWorkloadsPage } from './rancher/rancher-workloads.page'
 import { PolicyReporterPage } from './pages/policyreporter.page'
@@ -12,12 +12,12 @@ import { conf } from '../env-config'
 test.beforeAll(async({ request }) => {
   // Use local build (yarn serve), prime (if available) or github
   const fallback = RancherUI.isPrime ? 'github' : 'github'
-  conf.ui_from ||= await request.head(conf.src_url)
+  conf.ui_from ||= await request.head(conf.source.sbomscanner)
     .then(r => r.ok() ? 'source' as const : fallback)
     .catch(() => fallback)
 })
 
-test('Install UI extension', { tag: '@sbom' }, async({ page, ui }) => {
+test('Install UI extension', { tag: '@scan' }, async({ page, ui }) => {
   const extensions = new RancherExtensionsPage(page)
   await extensions.goto()
 
@@ -43,17 +43,54 @@ test('Install UI extension', { tag: '@sbom' }, async({ page, ui }) => {
   await test.step('Install or developer load extension', async() => {
     await extensions.goto()
     if (conf.ui_from === 'source') {
-      await extensions.developerLoad(conf.src_url)
+      await extensions.developerLoad(conf.source.sbomscanner)
     } else {
       await extensions.install('SBOMScanner', { version: process.env.UIVERSION?.replace(/^sbomscanner-ui-ext-/, '') })
     }
   })
 })
 
-test('Install SBOMScanner', { tag: '@sbom' }, async({ page }) => {
+test('Install SBOMScanner', { tag: '@scan' }, async({ page, nav, ui }) => {
+  // Disable partners repo for cnpg chart - issue#716
+  await nav.explorer('Apps', 'Repositories')
+  const partners = ui.tableRow('Partners')
+  await partners.action('Disable')
+  await partners.toHaveState('Disabled')
+
   const sbomPage = new SbomScannerPage(page)
   await sbomPage.install()
-  await sbomPage.goto()
+
+  await nav.explorer('Apps', 'Repositories')
+  await partners.action('Enable')
+  await partners.toHaveState('Active')
+})
+
+test('Scan Admission Controller', { tag: '@scan' }, async({ page, ui, nav }) => {
+  // Configure Workload Scan
+  await nav.sbomScanner('Workloads Scan')
+  const sbomPage = new SbomScannerPage(page)
+  await sbomPage.setWorkloadScan({
+    enabled   : true,
+    skipTLS   : conf.kw_from === 'gitlab' || undefined,
+    authSecret: conf.kw_from === 'prime' ? authSecret.name : undefined,
+    nsFilter  : { 'kubernetes.io/metadata.name': 'cattle-kubewarden-system' },
+    osFilter  : { linux: 'amd64' }
+  })
+
+  // Wait for Workload Scan
+  await nav.sbomScanner('Registries Configuration')
+  await ui.tableRow({ Repositories: /kubewarden-controller/ }).toHaveState('Completed', 2 * 60_000)
+
+  // Check Images
+  await nav.sbomScanner('Images')
+  for (const image of ['controller', 'audit-scanner', 'policy-server']) {
+    const row = ui.tableRow({ 'Image reference': new RegExp(`kubewarden-${image}`) })
+    await expect(row.column('Affecting CVEs')).toHaveText('00000', { timeout: 5_000 }).catch(async(error) => {
+      await row.open('Image reference')
+      await ui.tableRow({ 'CVE ID': /.*/ }).waitFor()
+      throw error
+    })
+  }
 })
 
 test.describe('Image CVE policy', () => {
@@ -113,10 +150,8 @@ subjects:
   test('Create WorkloadScan', async({ page }) => {
     const sbomPage = new SbomScannerPage(page)
     await sbomPage.setWorkloadScan({
-      enabled: true,
-      rules   : [
-        { key: 'kubernetes.io/metadata.name', value: 'cattle-kubewarden-system' },
-      ]
+      enabled : true,
+      nsFilter: { 'kubernetes.io/metadata.name': 'cattle-kubewarden-system' },
     })
   })
 
@@ -134,7 +169,7 @@ subjects:
   })
 
   test('Check compliance report', async({ page, ui, nav }) => {
-    await nav.sbomScanner('Registries configuration')
+    await nav.sbomScanner('Registries Configuration')
     await ui.tableRow({ Repositories: 'nginx/nginx-unprivileged' }).toHaveState('Finished')
 
     const reporter = new PolicyReporterPage(page)
@@ -166,13 +201,9 @@ subjects:
   })
 })
 
-test('Add Rancher VEX hub', async({ page }) => {
-  const hub: VexHub = {
-    name: 'rancher-vexhub',
-    uri : 'https://github.com/rancher/vexhub'
-  }
-  const sbomPage = new SbomScannerPage(page)
-  await sbomPage.addVexHub(hub)
+test('Check Rancher VEX Hub', async({ nav, ui }) => {
+  await nav.sbomScanner('VEX Management')
+  await ui.tableRow('rancher').toHaveState('Enabled')
 })
 
 test('Trigger registry scan', async({ page }) => {

--- a/tests/e2e/80-sbomscanner.spec.ts
+++ b/tests/e2e/80-sbomscanner.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from './rancher/rancher-test'
 import { RancherExtensionsPage } from './rancher/rancher-extensions.page'
 import { RancherAppsPage } from './rancher/rancher-apps.page'
 import { RancherUI } from './components/rancher-ui'
-import { Registry, SbomScannerPage, authSecret } from './sbomscanner/sbomscanner.page'
+import { Registry, SbomScannerPage, secretName } from './sbomscanner/sbomscanner.page'
 import { ClusterAdmissionPoliciesPage, Policy } from './pages/policies.page'
 import { Deployment, RancherWorkloadsPage } from './rancher/rancher-workloads.page'
 import { PolicyReporterPage } from './pages/policyreporter.page'
@@ -72,7 +72,7 @@ test('Scan Admission Controller', { tag: '@scan' }, async({ page, ui, nav }) => 
   await sbomPage.setWorkloadScan({
     enabled   : true,
     skipTLS   : conf.kw_from === 'gitlab' || undefined,
-    authSecret: conf.kw_from === 'prime' ? authSecret.name : undefined,
+    authSecret: conf.kw_from === 'prime' ? secretName : undefined,
     nsFilter  : { 'kubernetes.io/metadata.name': 'cattle-kubewarden-system' },
     osFilter  : { linux: 'amd64' }
   })

--- a/tests/e2e/80-sbomscanner.spec.ts
+++ b/tests/e2e/80-sbomscanner.spec.ts
@@ -1,27 +1,12 @@
 import { test, expect } from './rancher/rancher-test'
 import { RancherExtensionsPage } from './rancher/rancher-extensions.page'
-import { AppVersion } from './pages/kubewarden.page'
 import { RancherAppsPage } from './rancher/rancher-apps.page'
 import { RancherUI } from './components/rancher-ui'
-import { Common } from './components/common'
-import semver from 'semver'
 import { Registry, SbomScannerPage, VexHub } from './sbomscanner/sbomscanner.page'
 import { ClusterAdmissionPoliciesPage, Policy } from './pages/policies.page'
 import { Deployment, RancherWorkloadsPage } from './rancher/rancher-workloads.page'
 import { PolicyReporterPage } from './pages/policyreporter.page'
-
-const conf = {
-  src_url: 'http://127.0.0.1:4500/sbomscanner-ui-ext-0.0.1/sbomscanner-ui-ext-0.0.1.umd.min.js',
-  // Install UI extension from: source (yarn dev), github (github tag), prime (official)
-  ui_from: (process.env.ORIGIN || undefined) as 'source'|'github'|'prime'|undefined,
-  // How to install Kubewarden: manual (from UI extension), fleet, upgrade (previous version)
-  kw_mode: (process.env.MODE || undefined) as 'manual'|'fleet'|'upgrade'|undefined,
-  // Fetch Kubewarden versions from github for upgrade test
-  upMap  : [] as AppVersion[]
-}
-
-if (conf.ui_from) expect(conf.ui_from).toMatch(/^(source|github|prime)$/)
-if (conf.kw_mode) expect(conf.kw_mode).toMatch(/^(manual|fleet|upgrade)$/)
+import { conf } from '../env-config'
 
 // Configure defaults after env is loaded
 test.beforeAll(async({ request }) => {
@@ -30,19 +15,6 @@ test.beforeAll(async({ request }) => {
   conf.ui_from ||= await request.head(conf.src_url)
     .then(r => r.ok() ? 'source' as const : fallback)
     .catch(() => fallback)
-
-  // Default to manual mode, unless fleet or upgrade is requested
-  conf.kw_mode ||= 'manual'
-
-  if (conf.kw_mode === 'upgrade') {
-    conf.upMap = (await Common.fetchVersionMap()).splice(-3)
-      // Limit because of https://github.com/kubewarden/policy-server/issues/1300
-      .filter(v => semver.gte(v.app.replace(/^v/, ''), '1.29.0'))
-
-    if (conf.upMap.length === 0) {
-      throw new Error('No compatible version was found, check rancher-version annotations')
-    }
-  }
 })
 
 test('Install UI extension', { tag: '@sbom' }, async({ page, ui }) => {

--- a/tests/e2e/components/common.ts
+++ b/tests/e2e/components/common.ts
@@ -5,6 +5,12 @@ import { AppVersion } from '../pages/kubewarden.page'
 import { RancherUI } from './rancher-ui'
 import { execFileSync } from 'child_process'
 
+interface GitLabRefs {
+  chart: string
+  reg  : string
+  tag  : string
+}
+
 /**
  * Common helper functions and constants
  */
@@ -46,33 +52,41 @@ export class Common {
     ).reverse()
   }
 
-  /**
-   *
-   * @param name Filter MR title by product name
-   * @returns MR chart, registry and tag for the currently open MR
-   */
-  static async fetchAppCoMr() {
-    const title = 'SUSE Security Admission Controller'
-    const chartsRepo = 'oci://registry.suse.de/devel/jasmine/charts/charts/suse-security-admission-controller'
-    const rpmsRepo = 'registry.suse.de/devel/jasmine/containers'
-    return { mrChart: chartsRepo, mrReg: rpmsRepo, undefined }
+  // KW = github / gitlab / prime / mr56:21
+  static findGitLabRefs(): GitLabRefs {
+    // Search only once
+    if (process.env.GL_CHART && process.env.GL_REG && process.env.GL_TAG) {
+      return { chart: process.env.GL_CHART, reg: process.env.GL_REG, tag: process.env.GL_TAG }
+    }
 
-    const firstMr = (repo: string) => JSON.parse(
+    // Defaults without MR
+    const def = {
+      chart: 'oci://registry.suse.de/devel/jasmine/charts/charts/suse-security-admission-controller',
+      reg  : 'registry.suse.de/devel/jasmine/containers',
+      tag  : '1'
+    }
+
+    // Runners without glab for now
+    if (process.env.CI) return def
+
+    const title = 'SUSE Security Admission Controller'
+    const findMr = (repo: string) => JSON.parse(
       execFileSync('glab', ['mr', 'list', '-R', repo, '--search', title, '-F', 'json'], { encoding: 'utf-8' })
     )[0]
 
-    const chartMr = firstMr(chartsRepo)
-    const mrc = chartMr?.iid
-    const mri = firstMr(rpmsRepo)?.iid
+    // Chart
+    // const chartMr = firstMr('https://gitlab.suse.de/orchid/suse-products-recipes/suse-security/charts')
+    const mrc = findMr('https://gitlab.suse.de/orchid/suse-products-recipes/suse-security/charts')?.iid
+    const chart = mrc ? `oci://registry.suse.de/devel/jasmine/charts/suse-security/mr-${mrc}/charts/suse-security-admission-controller` : def.chart
 
-    const mrChart = mrc
-      ? `oci://registry.suse.de/devel/jasmine/charts/suse-security/mr-${mrc}/charts/suse-security-admission-controller`
-      : 'oci://registry.suse.de/devel/jasmine/charts/charts/suse-security-admission-controller'
-    const mrReg = mri
-      ? `registry.suse.de/devel/jasmine/containers/suse-security/mr-${mri}`
-      : 'registry.suse.de/devel/jasmine/containers'
-    const mrTag = chartMr?.title.match(/\d+\.\d+\.\d+/)[0]
+    // Image Registry
+    const mri = findMr('https://gitlab.suse.de/orchid/suse-products-recipes/suse-security/rpms-containers')?.iid
+    const reg = mri ? `registry.suse.de/devel/jasmine/containers/suse-security/mr-${mri}` : def.reg
+    // Tag might not exist without MR (1 = 1.37.2 = 1.37.2-12.6)
+    // const tag = chartMr?.title.match(/\d+\.\d+\.\d+/)[0] || defTag
+    // TODO: Check '1' exists on MR
+    const tag = def.tag
 
-    return { mrChart, mrReg, mrTag }
+    return { chart, reg, tag }
   }
 }

--- a/tests/e2e/components/navigation.ts
+++ b/tests/e2e/components/navigation.ts
@@ -4,19 +4,19 @@ import { RancherUI } from './rancher-ui'
 import { RancherCommonPage } from '../rancher/rancher-common.page'
 
 // Explorer navigation
-type ENav = 'Cluster' | 'Workloads' | 'Apps' | 'Storage' | 'Admission Policy Management' | 'SBOMScanner'
+type ENav = 'Cluster' | 'Workloads' | 'Apps' | 'Storage' | 'Admission Policy Management' | 'Vulnerability Scanner'
 type ENavMap = {
   'Cluster'                    : 'Projects/Namespaces' | 'Nodes' | 'Cluster and Project Members' | 'Events'
   'Workloads'                  : 'CronJobs' | 'DaemonSets' | 'Deployments' | 'Jobs' | 'StatefulSets' | 'Pods'
   'Apps'                       : 'Charts' | 'Installed Apps' | 'Repositories' | 'Recent Operations'
   'Storage'                    : 'PersistentVolumes' | 'StorageClasses' | 'ConfigMaps' | 'PersistentVolumeClaims' | 'Secrets'
   'Admission Policy Management': 'Policy Servers' | 'Cluster Admission Policies' | 'Admission Policies' | 'Policy Reporter'
-  'SBOMScanner'                : 'Images' | 'Advanced'
+  'Vulnerability Scanner'      : 'Images' | 'Advanced'
 }
 // Expandable items in ENavMap that have a third navigation level
 type ENavSubMap = {
-  SBOMScanner: {
-    Advanced: 'Workloads Scan' | 'VEX Management' | 'Registries configuration'
+  'Vulnerability Scanner': {
+    Advanced: 'Workloads Scan' | 'VEX Management' | 'Registries Configuration'
   }
 }
 // Returns valid sub-items for a given group and child
@@ -188,15 +188,15 @@ export class Navigation {
   // SBOMScanner specific helpers
 
   @step
-  async sbomScanner(childName?: ENavMap['SBOMScanner'] | ENavChild<'SBOMScanner', ENavMap['SBOMScanner']>) {
+  async sbomScanner(childName?: ENavMap['Vulnerability Scanner'] | ENavChild<'Vulnerability Scanner', ENavMap['Vulnerability Scanner']>) {
     // Shortcut to Advanced sub-items
-    if (childName === 'VEX Management' || childName === 'Workloads Scan' || childName === 'Registries configuration') {
-      await this.explorer('SBOMScanner', 'Advanced', childName)
+    if (childName === 'VEX Management' || childName === 'Workloads Scan' || childName === 'Registries Configuration') {
+      await this.explorer('Vulnerability Scanner', 'Advanced', childName)
     } else {
-      await this.explorer('SBOMScanner', childName)
+      await this.explorer('Vulnerability Scanner', childName)
     }
 
-    const heading = childName || /^(Dashboard|Install SBOMScanner)/
+    const heading = childName || /^(Dashboard|Install SUSE Security Vulnerability Scanner)/
     const element = this.page.locator('h1.page-title').or(this.page.locator('div.title'))
     await expect(element.getByText(heading)).toBeVisible()
   }

--- a/tests/e2e/components/table-row.ts
+++ b/tests/e2e/components/table-row.ts
@@ -5,7 +5,6 @@ import { RancherCommonPage } from '../rancher/rancher-common.page'
 
 export class TableRow {
   readonly row   : Locator
-  readonly name  : Locator
   readonly status: Locator
   readonly strval: string = ''
 
@@ -64,7 +63,6 @@ export class TableRow {
     }
 
     this.row = rows.describe(`TableRow: ${this}`)
-    this.name = this.column('Name')
     this.status = this.column('Status', 'State')
   }
 
@@ -127,7 +125,7 @@ export class TableRow {
     }
   }
 
-  async open() {
-    await this.name.getByRole('link').describe(`TableRow: ${this}`).click()
+  async open(col: string = 'Name') {
+    await this.column(col).getByRole('link').describe(`TableRow: ${this}`).click()
   }
 }

--- a/tests/e2e/pages/kubewarden.page.ts
+++ b/tests/e2e/pages/kubewarden.page.ts
@@ -216,10 +216,10 @@ export class KubewardenPage extends BasePage {
 
   @step
   async installGitlab() {
-    const { mrChart, mrReg, mrTag } = await Common.fetchAppCoMr()
-    test.info().annotations.push({ type: 'INFO', description: `AppCo Chart: ${mrChart}` })
-    test.info().annotations.push({ type: 'INFO', description: `AppCo Registry: ${mrReg}` })
-    test.info().annotations.push({ type: 'INFO', description: `AppCo Tag: ${mrTag}` })
+    const gl = Common.findGitLabRefs()
+    test.info().annotations.push({ type: 'INFO', description: `Chart: ${gl.chart}` })
+    test.info().annotations.push({ type: 'INFO', description: `Reg: ${gl.reg}` })
+    test.info().annotations.push({ type: 'INFO', description: `Tag: ${gl.tag}` })
 
     // Generated pull secret would use wrong domain based on repository url
     const pullSecret: Secret = {
@@ -232,9 +232,10 @@ export class KubewardenPage extends BasePage {
     }
 
     // Repo has fake auth so app-installer would set global.imagePullSecret
+    // Some redirects are based on repo name, it has to match official one
     const repo: Repo = {
-      name      : 'admission-controller-gitlab',
-      url       : mrChart,
+      name      : 'admission-controller-charts',
+      url       : gl.chart,
       skipTLS   : true,
       authSecret: { username: 'fake', password: 'pass' },
     }
@@ -263,13 +264,21 @@ export class KubewardenPage extends BasePage {
       check          : 'suse-security-admission-controller',
       imagePullSecret: { existing: new RegExp(pullSecret.name) }
     }, { navigate : false, yamlPatch: (y) => {
-      // For images that are not part of MR (policy-reporter, ..)
+      // For images that are not part of MR (policy-reporter, policy-reporter-ui)
       // Value is set automatically if Repo has auth & has appco annotation
       // y.global.imagePullSecrets[0] = '...'
       // Point to ephemeral MR registry
-      if (mrReg) y.image.registry = mrReg
-      if (mrReg) y.policyServer.image.registry = mrReg
-      if (mrReg) y.auditScanner.image.registry = mrReg
+      if (gl.reg) {
+        y.image.registry = gl.reg
+        y.policyServer.image.registry = gl.reg
+        y.auditScanner.image.registry = gl.reg
+      }
+      // Override image tag
+      if (gl.tag) {
+        y.image.tag = gl.tag
+        y.policyServer.image.tag = gl.tag
+        y.auditScanner.image.tag = gl.tag
+      }
       // Customize installation
       y.recommendedPolicies.enabled = true
       y.auditScanner.policyReporter = true

--- a/tests/e2e/pages/kubewarden.page.ts
+++ b/tests/e2e/pages/kubewarden.page.ts
@@ -4,8 +4,8 @@ import { BasePage } from '../rancher/basepage'
 import { Shell } from '../components/kubectl-shell'
 import { step } from '../rancher/rancher-test'
 import { Common } from '../components/common'
-import { RancherStoragePage, Secret } from '../rancher/rancher-storage.page'
-import { conf } from '../../env-config'
+import { RancherStoragePage } from '../rancher/rancher-storage.page'
+import { RancherUI } from '../components/rancher-ui'
 
 type Pane = 'Policy Servers' | 'Namespaced Policies' | 'Cluster Policies'
 // type PaneFilter = 'Policies' | 'Reports' | string | RegExp
@@ -16,6 +16,9 @@ export interface AppVersion {
   crds?      : string
   defaults?  : string
 }
+
+// Generated Pull secret has the same name as auth
+export const secretName = 'appco-auth-kubewarden'
 
 export class KubewardenPage extends BasePage {
   readonly currentApp  : Locator
@@ -181,21 +184,15 @@ export class KubewardenPage extends BasePage {
 
   @step
   async installAppco() {
-    const authSecret : Secret = {
-      type     : 'HTTP Basic Auth',
-      namespace: 'cattle-system',
-      name     : 'appco-auth-clusterrepo',
-      username : process.env.APPCO_USERNAME || '',
-      password : process.env.APPCO_PASSWORD || ''
-    }
+    const secPage = new RancherStoragePage(this.page)
+    const sec = secPage.createAppcoAuth(secretName)
 
-    // Use Kubewarden installer
-    await this.nav.kubewarden()
+    // Welcome screen
+    await this.goto()
     await this.ui.button('Install SUSE Security Admission Controller').click()
 
     // AppCo Registry Auth
-    new RancherStoragePage(this.page).createSecretInShell(authSecret)
-    await this.ui.selectOption('Authentication', new RegExp(`^${authSecret.name}`))
+    await this.ui.selectOption('Authentication', new RegExp(`^${sec.name}`))
     await this.ui.button('Continue').click()
 
     // Add Repository & start installation
@@ -208,6 +205,8 @@ export class KubewardenPage extends BasePage {
       check: 'suse-security-admission-controller',
       // imagePullSecret: Generated from registry auth by rancher app installer
     }, { navigate : false, yamlPatch: (y) => {
+      // Chart secret UI is not available in Rancher < 2.14
+      if (RancherUI.isVersion('<2.14')) y.global.imagePullSecrets[0] = sec.name
       y.recommendedPolicies.enabled = true
       y.auditScanner.policyReporter = true
       y.auditScanner.cronJob.schedule = '*/1 * * * *'
@@ -221,16 +220,6 @@ export class KubewardenPage extends BasePage {
     test.info().annotations.push({ type: 'INFO', description: `Reg: ${gl.reg}` })
     test.info().annotations.push({ type: 'INFO', description: `Tag: ${gl.tag}` })
 
-    // Generated pull secret would use wrong domain based on repository url
-    const pullSecret: Secret = {
-      type     : 'Registry',
-      namespace: 'cattle-kubewarden-system',
-      name     : 'appco-auth-image-pull',
-      domain   : 'dp.apps.rancher.io',
-      username : conf.auth.appco_user || '',
-      password : conf.auth.appco_pass || ''
-    }
-
     // Repo has fake auth so app-installer would set global.imagePullSecret
     // Some redirects are based on repo name, it has to match official one
     const repo: Repo = {
@@ -240,8 +229,9 @@ export class KubewardenPage extends BasePage {
       authSecret: { username: 'fake', password: 'pass' },
     }
 
+    // Generated pull secret would use wrong domain based on repository url
     const secPage = new RancherStoragePage(this.page)
-    await secPage.createSecretInShell(pullSecret)
+    const pullSec = secPage.createAppcoPull(secretName, 'cattle-kubewarden-system')
 
     // Add & annotate repository
     const appsPage = new RancherAppsPage(this.page)
@@ -262,11 +252,15 @@ export class KubewardenPage extends BasePage {
     await appsPage.installChart({
       title          : 'suse-security-admission-controller',
       check          : 'suse-security-admission-controller',
-      imagePullSecret: { existing: new RegExp(pullSecret.name) }
+      imagePullSecret: RancherUI.isVersion('>=2.14') ? { existing: new RegExp(`^${pullSec.name}`) } : undefined
     }, { navigate : false, yamlPatch: (y) => {
       // For images that are not part of MR (policy-reporter, policy-reporter-ui)
       // Value is set automatically if Repo has auth & has appco annotation
-      // y.global.imagePullSecrets[0] = '...'
+      if (RancherUI.isVersion('<2.14')) y.global.imagePullSecrets[0] = pullSec.name
+      y.recommendedPolicies.enabled = true
+      y.auditScanner.policyReporter = true
+      y.auditScanner.cronJob.schedule = '*/1 * * * *'
+
       // Point to ephemeral MR registry
       if (gl.reg) {
         y.image.registry = gl.reg
@@ -279,10 +273,6 @@ export class KubewardenPage extends BasePage {
         y.policyServer.image.tag = gl.tag
         y.auditScanner.image.tag = gl.tag
       }
-      // Customize installation
-      y.recommendedPolicies.enabled = true
-      y.auditScanner.policyReporter = true
-      y.auditScanner.cronJob.schedule = '*/1 * * * *'
     } })
   }
 

--- a/tests/e2e/pages/kubewarden.page.ts
+++ b/tests/e2e/pages/kubewarden.page.ts
@@ -5,6 +5,7 @@ import { Shell } from '../components/kubectl-shell'
 import { step } from '../rancher/rancher-test'
 import { Common } from '../components/common'
 import { RancherStoragePage, Secret } from '../rancher/rancher-storage.page'
+import { conf } from '../../env-config'
 
 type Pane = 'Policy Servers' | 'Namespaced Policies' | 'Cluster Policies'
 // type PaneFilter = 'Policies' | 'Reports' | string | RegExp
@@ -226,8 +227,8 @@ export class KubewardenPage extends BasePage {
       namespace: 'cattle-kubewarden-system',
       name     : 'appco-auth-image-pull',
       domain   : 'dp.apps.rancher.io',
-      username : process.env.APPCO_USERNAME || '',
-      password : process.env.APPCO_PASSWORD || ''
+      username : conf.auth.appco_user || '',
+      password : conf.auth.appco_pass || ''
     }
 
     // Repo has fake auth so app-installer would set global.imagePullSecret

--- a/tests/e2e/pages/policyservers.page.ts
+++ b/tests/e2e/pages/policyservers.page.ts
@@ -3,6 +3,7 @@ import { expect } from '@playwright/test'
 import { TableRow } from '../components/table-row'
 import { step } from '../rancher/rancher-test'
 import { BasePage } from '../rancher/basepage'
+import { conf } from '../../env-config'
 
 export interface PolicyServer {
   name     : string
@@ -41,6 +42,13 @@ export class PolicyServersPage extends BasePage {
     await this.setName(ps.name)
     if (ps.replicas !== undefined) await this.setReplicas(ps.replicas)
     if (ps.image !== undefined) await this.setImage(ps.image)
+    else if (conf.kw_from === 'gitlab') {
+      // dp.apps.rancher.io/containers/kubewarden-policy-server:1.37.2-12.6 (official)
+      // registry.suse.de/devel/jasmine/containers/containers/kubewarden-policy-server:1 (GitLab)
+      // ? (MR)
+      await this.setImage(`${conf.gitlab.reg}/containers/kubewarden-policy-server:${conf.gitlab.tag}`)
+    }
+
     if (ps.settings) {
       await ps.settings()
       await this.ui.openView('Edit YAML')

--- a/tests/e2e/rancher/rancher-extensions.page.ts
+++ b/tests/e2e/rancher/rancher-extensions.page.ts
@@ -22,7 +22,7 @@ export class RancherExtensionsPage extends BasePage {
 
   async dotMenu(name: 'Manage Repositories' | 'Add Rancher Repositories' | 'Manage Extension Catalogs' | 'Developer Load') {
     await this.page.getByTestId('extensions-page-menu').click()
-    await this.page.getByText(name).click()
+    await this.page.getByRole('menuitem', { name }).click()
   }
 
   // Handle extension repositories dialog

--- a/tests/e2e/rancher/rancher-storage.page.ts
+++ b/tests/e2e/rancher/rancher-storage.page.ts
@@ -1,6 +1,7 @@
 import { step } from './rancher-test'
 import { BasePage } from './basepage'
 import { Shell } from '../components/kubectl-shell'
+import { conf } from '../../env-config'
 
 export interface Secret {
   type      : 'Registry' | 'HTTP Basic Auth'
@@ -16,8 +17,8 @@ export class RancherStoragePage extends BasePage {
     await this.nav.explorer('Storage', 'Secrets')
   }
 
-  // Create secrets in nodejs shell to not log creadentials
-  createSecretInShell(secret: Secret) {
+  // Create secrets in nodejs shell to not log credentials
+  createSecretInShell(secret: Secret): Secret {
     const shell = new Shell(this.page)
     shell.runExec(`kubectl get ns ${secret.namespace} || kubectl create ns ${secret.namespace}`)
 
@@ -37,6 +38,7 @@ export class RancherStoragePage extends BasePage {
       default:
         throw new Error(`Unsupported secret type: ${secret.type}`)
     }
+    return secret
   }
 
   @step
@@ -65,5 +67,26 @@ export class RancherStoragePage extends BasePage {
   async deleteSecret(name: string) {
     await this.nav.explorer('Storage', 'Secrets')
     await this.ui.tableRow(name).delete()
+  }
+
+  createAppcoAuth(name: string): Secret {
+    return this.createSecretInShell({
+      type     : 'HTTP Basic Auth',
+      name     : name,
+      namespace: 'cattle-system',
+      username : conf.auth.appco_user || '',
+      password : conf.auth.appco_pass || ''
+    })
+  }
+
+  createAppcoPull(name: string, namespace: string): Secret {
+    return this.createSecretInShell({
+      type     : 'Registry',
+      name     : name,
+      namespace: namespace,
+      domain   : 'dp.apps.rancher.io',
+      username : conf.auth.appco_user || '',
+      password : conf.auth.appco_pass || ''
+    })
   }
 }

--- a/tests/e2e/sbomscanner/sbomscanner.page.ts
+++ b/tests/e2e/sbomscanner/sbomscanner.page.ts
@@ -2,6 +2,9 @@ import { expect } from '@playwright/test'
 import { RancherAppsPage } from '../rancher/rancher-apps.page'
 import { BasePage } from '../rancher/basepage'
 import { step } from '../rancher/rancher-test'
+import { RancherStoragePage, Secret } from '../rancher/rancher-storage.page'
+import { conf } from '../../env-config'
+import { RancherUI } from '../components/rancher-ui'
 
 export interface Registry {
   name         : string
@@ -18,8 +21,19 @@ export interface VexHub {
 }
 
 export interface WorkloadScanConfig {
-  enabled?: boolean
-  rules?  : { key: string, value: string }[]
+  enabled?   : boolean
+  authSecret?: string|RegExp
+  skipTLS?   : boolean // OCI specific
+  nsFilter?  : Record<string, string>
+  osFilter?  : Record<string, string>
+}
+
+export const authSecret: Secret = {
+  type     : 'HTTP Basic Auth',
+  namespace: 'cattle-system',
+  name     : 'appco-auth-sbomscanner',
+  username : conf.auth.appco_user || '',
+  password : conf.auth.appco_pass || ''
 }
 
 export class SbomScannerPage extends BasePage {
@@ -32,61 +46,66 @@ export class SbomScannerPage extends BasePage {
     const appsPage = new RancherAppsPage(this.page)
     // Requirements Dialog
     const welcomeStep = this.page.getByText('Get a comprehensive view of your container image vulnerabilities and focus on risks that truly matter.')
-    const addCNPGRepoStep = this.page.getByRole('heading', { name: 'Add the CNPG Helm repository', exact: true })
-    const addSBOMRepoStep = this.page.getByRole('heading', { name: 'Add the SBOMScanner Helm repository', exact: true })
+    const configAuthStep = this.page.getByRole('heading', { name: /^Configure global authentication/ })
+    const addReposStep = this.page.getByRole('heading', { name: 'Add required Helm repositories', exact: true })
     const installCNPGStep = this.page.getByRole('heading', { name: 'Installation for CloudNativePG', exact: true })
-    const installSBOMStep = this.page.getByRole('heading', { name: 'Installation for SBOMScanner', exact: true })
+    const installSBOMStep = this.page.getByRole('heading', { name: 'Installation for SUSE Security Vulnerability Scanner', exact: true })
 
     await this.goto()
+    new RancherStoragePage(this.page).createSecretInShell(authSecret)
 
-    // We need to skip some steps if kubewarden is already installed
+    // Welcome screen is skipped if kubewarden is already installed
     await this.page.waitForTimeout(2000) // Ignore briefly visible welcome step
-    await expect(welcomeStep.or(addCNPGRepoStep)).toBeVisible()
-    const freshInstall = (await welcomeStep.isVisible())
-
-    // Welcome screen
-    if (freshInstall) {
-      // await expect(welcomeStep).toBeVisible()
+    await expect(welcomeStep.or(configAuthStep)).toBeVisible()
+    if (await welcomeStep.isVisible()) {
       await this.ui.button('Start installation').click()
     }
 
-    // Add CNPG repository
-    await expect(addCNPGRepoStep).toBeVisible()
-    await this.ui.button('Add CNPG repository').click()
+    // AppCo Registry Auth
+    await expect(configAuthStep).toBeVisible()
+    await this.ui.selectOption('Authentication', new RegExp(`^${authSecret.name}`))
+    await this.ui.button('Continue').click()
 
-    // Add SBOMScanner repository
-    if (freshInstall) {
-      await expect(addSBOMRepoStep).toBeVisible()
-      await this.ui.button('Add SBOMScanner repository').click()
-    }
+    // Add repositories
+    await expect(addReposStep).toBeVisible()
+    await this.ui.button('Add all repositories').click()
 
     // Install CloudNativePG
     await expect(installCNPGStep).toBeVisible()
     await this.ui.button('Install CloudNativePG').click()
     await appsPage.installChart(
-      { title: 'cloudnative-pg', name: 'cnpg', check: 'cloudnative-pg' }, // namespace: 'cnpg-system'
+      { title: 'cloudnative-pg', check: 'cloudnative-pg' },
       { navigate: false })
 
     // Install SBOMScanner
     await this.goto()
     await expect(installSBOMStep).toBeVisible()
-    await this.ui.button('Install SBOMScanner').click()
+    await this.ui.button('Install SUSE Security Vulnerability Scanner').click()
     await appsPage.installChart(
-      { title: 'SBOMScanner', check: 'rancher-sbomscanner', version: options?.version },
+      { title: 'SBOMScanner', check: 'suse-security-vulnerability-scanner', version: options?.version },
       { navigate : false,
-        questions: async() => {
-          await this.ui.input('Controller Replicas').fill('1')
-          await this.ui.tab('Worker').click()
-          await this.ui.input('Worker Replicas').fill('1')
-          await this.ui.tab('Storage').click()
-          await this.ui.input('Storage Replicas').fill('1')
-          await this.ui.input('CNPG Instances').fill('1')
-        } })
+        yamlPatch: (y) => {
+          // Value is not set automatically in Rancher < 2.14
+          if (RancherUI.isVersion('<2.14')) y.global.imagePullSecrets[0] = authSecret.name
+          y.controller.replicas = 1
+          y.worker.replicas = 1
+          y.storage.replicas = 1
+          y.storage.postgres.cnpg.instances = 1
+        }
+        // questions: async() => {
+        //   await this.ui.input('Controller Replicas').fill('1')
+        //   await this.ui.tab('Worker').click()
+        //   await this.ui.input('Worker Replicas').fill('1')
+        //   await this.ui.tab('Storage').click()
+        //   await this.ui.input('Storage Replicas').fill('1')
+        //   await this.ui.input('CNPG Instances').fill('1')
+        // }
+      })
   }
 
   @step
   async addRegistry(reg: Registry) {
-    await this.nav.sbomScanner('Registries configuration')
+    await this.nav.sbomScanner('Registries Configuration')
     await this.ui.button('Create').click()
 
     await this.ui.input('Registry*').fill(reg.name)
@@ -104,7 +123,7 @@ export class SbomScannerPage extends BasePage {
 
   @step
   async deleteRegistry(reg: string) {
-    await this.nav.sbomScanner('Registries configuration')
+    await this.nav.sbomScanner('Registries Configuration')
     await this.ui.tableRow({ Registry: reg }).delete()
   }
 
@@ -136,21 +155,41 @@ export class SbomScannerPage extends BasePage {
 
   @step
   async setWorkloadScan(config: WorkloadScanConfig) {
-    const rules = config?.rules ?? []
     await this.nav.sbomScanner('Workloads Scan')
-    if (config?.enabled !== undefined) {
+
+    if (config.enabled !== undefined) {
       await this.ui.checkbox('Enabled').setChecked(config.enabled)
     }
-    await expect(this.ui.checkbox('Enabled')).toBeChecked() // Default is enabled, so the form is visible
-
-    for (let i = 0; i < rules.length; i++) {
-      await this.ui.button('Add Rule').click()
-      await this.page.locator('div.namespace-selector-row').getByTestId(`input-match-expression-key-control-${i}`).fill(rules[i].key)
-      await this.page.locator('div.namespace-selector-row').getByTestId(`input-match-expression-values-control-${i}`).fill(rules[i].value)
+    if (config.authSecret) {
+      await this.ui.selectOption('Authentication', config.authSecret)
     }
-    await this.ui.button('Add Platform').click()
+    if (config.skipTLS !== undefined) {
+      await this.ui.checkbox('Allow insecure connections').setChecked(config.skipTLS)
+    }
+
+    if (config.nsFilter) {
+      const line = this.page.locator('div.match-expression-row').last()
+      for (const [key, value] of Object.entries(config.nsFilter)) {
+        await this.ui.button('Add Rule').click()
+        await line.getByTestId(/^input-match-expression-key-control-/).fill(key)
+        await line.getByTestId(/^input-match-expression-values-control-/).fill(value)
+      }
+    }
+
+    if (config.osFilter) {
+      const line = this.page.locator('div.row-platforms').last()
+      for (const [os, arch] of Object.entries(config.osFilter)) {
+        await this.ui.button('Add Platform').click()
+        await this.ui.selectOption(line.locator('div.labeled-select').nth(0), os)
+        await this.ui.selectOption(line.locator('div.labeled-select').nth(1), arch)
+      }
+    }
+
     await this.page.waitForTimeout(300)
-    await this.ui.button('Create').click()
-    await expect(this.page.getByRole('heading', { name: /^Workloads Scan.*Active$/ })).toBeVisible()
+    await this.ui.button(/Create|Save/).click()
+
+    if (config.enabled !== undefined) {
+      await expect(this.page.locator('span.badge-state')).toHaveText(config.enabled ? 'Active' : 'Disabled')
+    }
   }
 }

--- a/tests/e2e/sbomscanner/sbomscanner.page.ts
+++ b/tests/e2e/sbomscanner/sbomscanner.page.ts
@@ -2,8 +2,7 @@ import { expect } from '@playwright/test'
 import { RancherAppsPage } from '../rancher/rancher-apps.page'
 import { BasePage } from '../rancher/basepage'
 import { step } from '../rancher/rancher-test'
-import { RancherStoragePage, Secret } from '../rancher/rancher-storage.page'
-import { conf } from '../../env-config'
+import { RancherStoragePage } from '../rancher/rancher-storage.page'
 import { RancherUI } from '../components/rancher-ui'
 
 export interface Registry {
@@ -28,13 +27,8 @@ export interface WorkloadScanConfig {
   osFilter?  : Record<string, string>
 }
 
-export const authSecret: Secret = {
-  type     : 'HTTP Basic Auth',
-  namespace: 'cattle-system',
-  name     : 'appco-auth-sbomscanner',
-  username : conf.auth.appco_user || '',
-  password : conf.auth.appco_pass || ''
-}
+// Generated Pull secret has the same name as auth
+export const secretName = 'appco-auth-sbomscanner'
 
 export class SbomScannerPage extends BasePage {
   async goto(): Promise<void> {
@@ -44,6 +38,7 @@ export class SbomScannerPage extends BasePage {
   @step
   async install(options?: { version?: string }) {
     const appsPage = new RancherAppsPage(this.page)
+
     // Requirements Dialog
     const welcomeStep = this.page.getByText('Get a comprehensive view of your container image vulnerabilities and focus on risks that truly matter.')
     const configAuthStep = this.page.getByRole('heading', { name: /^Configure global authentication/ })
@@ -52,7 +47,7 @@ export class SbomScannerPage extends BasePage {
     const installSBOMStep = this.page.getByRole('heading', { name: 'Installation for SUSE Security Vulnerability Scanner', exact: true })
 
     await this.goto()
-    new RancherStoragePage(this.page).createSecretInShell(authSecret)
+    const sec = new RancherStoragePage(this.page).createAppcoAuth(secretName)
 
     // Welcome screen is skipped if kubewarden is already installed
     await this.page.waitForTimeout(2000) // Ignore briefly visible welcome step
@@ -63,7 +58,7 @@ export class SbomScannerPage extends BasePage {
 
     // AppCo Registry Auth
     await expect(configAuthStep).toBeVisible()
-    await this.ui.selectOption('Authentication', new RegExp(`^${authSecret.name}`))
+    await this.ui.selectOption('Authentication', new RegExp(`^${sec.name}`))
     await this.ui.button('Continue').click()
 
     // Add repositories
@@ -75,7 +70,11 @@ export class SbomScannerPage extends BasePage {
     await this.ui.button('Install CloudNativePG').click()
     await appsPage.installChart(
       { title: 'cloudnative-pg', check: 'cloudnative-pg' },
-      { navigate: false })
+      { navigate : false,
+        yamlPatch: (RancherUI.isVersion('<2.14'))
+          ? (y) => { y.global.imagePullSecrets[0] = sec.name }
+          : undefined
+      })
 
     // Install SBOMScanner
     await this.goto()
@@ -85,8 +84,8 @@ export class SbomScannerPage extends BasePage {
       { title: 'SBOMScanner', check: 'suse-security-vulnerability-scanner', version: options?.version },
       { navigate : false,
         yamlPatch: (y) => {
-          // Value is not set automatically in Rancher < 2.14
-          if (RancherUI.isVersion('<2.14')) y.global.imagePullSecrets[0] = authSecret.name
+          // Chart secret UI is not available in Rancher < 2.14
+          if (RancherUI.isVersion('<2.14')) y.global.imagePullSecrets[0] = sec.name
           y.controller.replicas = 1
           y.worker.replicas = 1
           y.storage.replicas = 1

--- a/tests/env-config.ts
+++ b/tests/env-config.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert'
+
+export const conf = {
+  // Install UI extension from: source (yarn dev), github (github tag), prime (official)
+  ui_from: (process.env.ORIGIN || process.env.UI || undefined) as 'source'|'github'|'prime'|undefined,
+  // Install Kubewarden from: github (community), gitlab (mr), prime (official)
+  kw_from: (process.env.KW || undefined) as 'github'|'gitlab'|'prime'|undefined,
+  // How to install Kubewarden: manual (from UI extension), fleet, upgrade (previous version)
+  kw_mode: (process.env.MODE || undefined) as 'manual'|'fleet'|'upgrade'|undefined,
+
+  // Extra config if kw_from=gitlab
+  gitlab: {
+    chart: process.env.GL_CHART,
+    reg  : process.env.GL_REG,
+    tag  : process.env.GL_TAG,
+  },
+  // Extra config if ui_from=source
+  source: {
+    // VERSION=0.0.1 yarn build-pkg kubewarden
+    kubewarden : 'http://127.0.0.1:4500/kubewarden-0.0.1/kubewarden-0.0.1.umd.min.js',
+    // VERSION=0.0.1 yarn build-pkg vulnerability-scanner
+    sbomscanner: 'http://127.0.0.1:4501/vulnerability-scanner-0.0.1/vulnerability-scanner-0.0.1.umd.min.js',
+  },
+
+  // Credentials
+  auth: {
+    appco_user: process.env.APPCO_USERNAME,
+    appco_pass: process.env.APPCO_PASSWORD
+  }
+}
+
+// Defaults
+conf.kw_mode ||= 'manual'
+conf.kw_from ||= 'prime'
+
+// Check values
+if (conf.ui_from) assert(/^(source|github|prime)$/.test(conf.ui_from))
+if (conf.kw_mode) assert(/^(manual|fleet|upgrade)$/.test(conf.kw_mode))
+if (conf.kw_from) assert(/^(github|gitlab|prime)$/.test(conf.kw_from))
+
+if (conf.kw_from !== 'github') {
+  assert(conf.auth.appco_user)
+  assert(conf.auth.appco_pass)
+}

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,5 +1,6 @@
 import type { APIResponse, FullConfig } from '@playwright/test'
 import { expect, request } from '@playwright/test'
+import { Common } from './e2e/components/common'
 
 async function globalSetup(config: FullConfig) {
   let resp: APIResponse
@@ -36,6 +37,15 @@ async function globalSetup(config: FullConfig) {
   const data = await resp.json()
   process.env.RANCHER_VERSION = data.Version
   process.env.RANCHER_PRIME = data.RancherPrime
+
+  // Check for artifact access
+  if (process.env.KW === 'gitlab') {
+    await requestContext.head('https://registry.suse.de')
+    const { chart, reg, tag } = Common.findGitLabRefs()
+    process.env.GL_CHART = chart
+    process.env.GL_REG = reg
+    process.env.GL_TAG = tag
+  }
 
   await requestContext.dispose()
 


### PR DESCRIPTION
- Fix issues when installing from gitlab (`KW=gitlab`)
  - new policy servers point to appco images
  - image tags without PR might not exist in registry (chart points to 1.37.2-12.6, but registry has 1.37.2-12.7)
  - code cleanup

- Fix [nightly jobs](https://github.com/rancher/kubewarden-ui/actions/runs/32666404953) for Rancher < 2.14
Rancher versions < 2.14 don't have UI elements for automatic passing of imagePullSecret from helm chart.
I added workaround for older versions to add secret to yaml instead of relying on UI.

- Update env handling
Created env-config file where env is parsed so we don't duplicate this logic in test files

- Allow to run vulnerability scan on admission controller images
We occasionally release images with fresh CVEs, this automation should prevent it
Trigger installation & scan by `pw test -x --ui --grep '@kw|@scan'`
Also sitched vulnerability scanner installation to AppCo