### PR TITLE
Split jaeger installation into 2 steps

### DIFF
--- a/tests/e2e/pages/telemetry.page.ts
+++ b/tests/e2e/pages/telemetry.page.ts
@@ -79,7 +79,15 @@ export class TelemetryPage extends BasePage {
     const app = managedApps[name]
     const appsPage = new RancherAppsPage(this.page)
     await appsPage.addRepository(app.repo)
-    await appsPage.installChart(app, { yamlPatch: app.yaml })
+    if (name == 'jaeger') {
+      // Split into 2 steps because of jaeger race condition during startup when jaeger.create=true
+      // Internal error occurred: failed calling webhook "mjaeger.kb.io": failed to call webhook:
+      // No endpoints available for service "jaeger-operator-webhook-service"
+      await appsPage.installChart(app)
+      await appsPage.updateApp(app.name, { yamlPatch: app.yaml })
+    } else {
+      await appsPage.installChart(app, { yamlPatch: app.yaml })
+    }
   }
 
   async removeManaged(name: ManagedAppList) {


### PR DESCRIPTION
Installation often [fails](https://github.com/rancher/kubewarden-ui/actions/runs/33356063109/job/101033944975?pr=1582#step:12:68) because of race condition.

Jaeger is being created while jaeger-operator startup is still in progress.
This is caused by value `jaeger.create = true` [here](https://github.com/rancher/kubewarden-ui/blob/main/tests/e2e/pages/telemetry.page.ts#L35).

Fixes this issue:
<img width="1045" height="614" alt="Screenshot From 2026-09-07 10-17-22" src="https://github.com/user-attachments/assets/3265ce0a-d683-455f-9bba-7a65cf8bce52" />

